### PR TITLE
Turning on autoplay requires confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ unreleased
 ==========
 
 -
+  Autopilot now requires confirmation
+-
   The sidebar now displays whether a monster is carrying an item
 -
   Fixed incorrect percentage health change info in sidebar

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2486,7 +2486,9 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             exploreKey(controlKey);
             break;
         case AUTOPLAY_KEY:
-            autoPlayLevel(controlKey);
+            if (confirm("Turn on autopilot?", false)) {
+                autoPlayLevel(controlKey);
+            }
             break;
         case MESSAGE_ARCHIVE_KEY:
             displayMessageArchive();


### PR DESCRIPTION

![confirm_autoplay](https://user-images.githubusercontent.com/3458348/69985110-83159800-1532-11ea-9d1c-0d6d6759f27b.png)


An occasional cause of death in later levels is turning on autoplay (capital A) accidently and then being unable to turn it off before your rogue suicides