### PR TITLE
Fix an issue whereby too much user input during playback can pause the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ unreleased
 -
   The message to see your inventory on death is now printed in a brighter colour
 -
+  Excessive input during playback no longer causes pauses in playback
+-
   Turning on autopilot now requires confirmation
 -
   The "blue" player-to-monster combat information is now displayed in ally

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2290,7 +2290,7 @@ boolean pauseBrogue(short milliseconds) {
 
 void nextBrogueEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance, boolean realInputEvenInPlayback) {
     rogueEvent recordingInput;
-    boolean repeatAgain;
+    boolean repeatAgain, interaction;
     short pauseDuration;
 
     returnEvent->eventType = EVENT_ERROR;
@@ -2305,8 +2305,8 @@ void nextBrogueEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsD
                 if (pauseDuration && pauseBrogue(pauseDuration)) {
                     // if the player did something during playback
                     nextBrogueEvent(&recordingInput, false, false, true);
-                    executePlaybackInput(&recordingInput);
-                    repeatAgain = !rogue.playbackPaused;
+                    interaction = executePlaybackInput(&recordingInput);
+                    repeatAgain = !rogue.playbackPaused && interaction;
                 }
             }
         } while ((repeatAgain || rogue.playbackOOS) && !rogue.gameHasEnded);

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -737,7 +737,7 @@ void pausePlayback() {
 }
 
 // Used to interact with playback -- e.g. changing speed, pausing.
-void executePlaybackInput(rogueEvent *recordingInput) {
+boolean executePlaybackInput(rogueEvent *recordingInput) {
     signed long key;
     short newDelay, frameCount, x, y, previousDeepestLevel;
     unsigned long destinationFrame;
@@ -746,7 +746,7 @@ void executePlaybackInput(rogueEvent *recordingInput) {
     char path[BROGUE_FILENAME_MAX];
 
     if (!rogue.playbackMode) {
-        return;
+        return false;
     }
 
     if (recordingInput->eventType == KEYSTROKE) {
@@ -762,7 +762,7 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                 }
                 rogue.playbackDelayPerTurn = newDelay;
                 rogue.playbackDelayThisTurn = rogue.playbackDelayPerTurn;
-                break;
+                return true;
             case DOWN_ARROW:
             case DOWN_KEY:
                 newDelay = min(3000, max(rogue.playbackDelayPerTurn * 1.5, rogue.playbackDelayPerTurn + 1));
@@ -771,14 +771,14 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                 }
                 rogue.playbackDelayPerTurn = newDelay;
                 rogue.playbackDelayThisTurn = rogue.playbackDelayPerTurn;
-                break;
+                return true;
             case ACKNOWLEDGE_KEY:
                 if (rogue.playbackOOS && rogue.playbackPaused) {
                     flashTemporaryAlert(" Out of sync ", 2000);
                 } else {
                     rogue.playbackPaused = !rogue.playbackPaused;
                 }
-                break;
+                return true;
             case TAB_KEY:
                 rogue.playbackOmniscience = !rogue.playbackOmniscience;
                 displayLevel();
@@ -788,7 +788,7 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                 } else {
                     messageWithColor("Omniscience disabled.", &teal, false);
                 }
-                break;
+                return true;
             case DESCEND_KEY:
                 pauseState = rogue.playbackPaused;
                 previousDeepestLevel = rogue.deepestLevel;
@@ -814,12 +814,12 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                     }
                 }
                 rogue.playbackPaused = pauseState;
-                break;
+                return true;
             case INVENTORY_KEY:
                 rogue.playbackMode = false;
                 displayInventory(ALL_ITEMS, 0, 0, true, false);
                 rogue.playbackMode = true;
-                break;
+                return true;
             case RIGHT_KEY:
             case RIGHT_ARROW:
             case LEFT_KEY:
@@ -876,20 +876,20 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                         refreshSideBar(-1, -1, false);
                     }
                 }
-                break;
+                return true;
             case HELP_KEY:
                 printPlaybackHelpScreen();
-                break;
+                return true;
             case DISCOVERIES_KEY:
                 rogue.playbackMode = false;
                 printDiscoveriesScreen();
                 rogue.playbackMode = true;
-                break;
+                return true;
             case MESSAGE_ARCHIVE_KEY:
                 rogue.playbackMode = false;
                 displayMessageArchive();
                 rogue.playbackMode = true;
-                break;
+                return true;
             case VIEW_RECORDING_KEY:
                 confirmMessages();
                 rogue.playbackMode = false;
@@ -903,7 +903,7 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                     }
                 }
                 rogue.playbackMode = true;
-                break;
+                return true;
             case LOAD_SAVED_GAME_KEY:
                 confirmMessages();
                 rogue.playbackMode = false;
@@ -917,7 +917,7 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                     }
                 }
                 rogue.playbackMode = true;
-                break;
+                return true;
             case NEW_GAME_KEY:
                 rogue.playbackMode = false;
                 if (confirm("Close recording and begin a new game?", true)) {
@@ -925,13 +925,13 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                     rogue.gameHasEnded = true;
                 }
                 rogue.playbackMode = true;
-                break;
+                return true;
             case QUIT_KEY:
                 //freeEverything();
                 rogue.gameHasEnded = true;
                 rogue.playbackOOS = false;
                 rogue.creaturesWillFlashThisTurn = false;
-                break;
+                return true;
             case TRUE_COLORS_KEY:
                 rogue.trueColorMode = !rogue.trueColorMode;
                 displayLevel();
@@ -943,7 +943,7 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                     messageWithColor(KEYBOARD_LABELS ? "Color effects enabled. Press '\\' again to disable." : "Color effects enabled.",
                                      &teal, false);
                 }
-                break;
+                return true;
             case AGGRO_DISPLAY_KEY:
                 rogue.displayAggroRangeMode = !rogue.displayAggroRangeMode;
                 displayLevel();
@@ -955,20 +955,21 @@ void executePlaybackInput(rogueEvent *recordingInput) {
                     messageWithColor(KEYBOARD_LABELS ? "Stealth range hidden. Press ']' again to display." : "Stealth range hidden.",
                                      &teal, false);
                 }
-                break;
+                return true;
             case SEED_KEY:
                 //rogue.playbackMode = false;
                 //DEBUG {displayGrid(safetyMap); displayMoreSign(); displayLevel();}
                 //rogue.playbackMode = true;
                 printSeed();
-                break;
+                return true;
             default:
                 if (key >= '0' && key <= '9'
                     || key >= NUMPAD_0 && key <= NUMPAD_9) {
 
                     promptToAdvanceToLocation(key);
+                    return true;
                 }
-                break;
+                return false;
         }
     } else if (recordingInput->eventType == MOUSE_UP) {
         x = recordingInput->param1;
@@ -978,12 +979,15 @@ void executePlaybackInput(rogueEvent *recordingInput) {
             rogue.playbackMode = false;
             displayMessageArchive();
             rogue.playbackMode = true;
+            return true;
         }
     } else if (recordingInput->eventType == RIGHT_MOUSE_UP) {
         rogue.playbackMode = false;
         displayInventory(ALL_ITEMS, 0, 0, true, false);
         rogue.playbackMode = true;
+        return true;
     }
+    return false;
 }
 
 // Pass in defaultPath (the file name WITHOUT suffix), and the suffix.

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3121,7 +3121,7 @@ extern "C" {
     void recordMouseClick(short x, short y, boolean controlKey, boolean shiftKey);
     void OOSCheck(unsigned long x, short numberOfBytes);
     void RNGCheck();
-    void executePlaybackInput(rogueEvent *recordingInput);
+    boolean executePlaybackInput(rogueEvent *recordingInput);
     void getAvailableFilePath(char *filePath, const char *defaultPath, const char *suffix);
     boolean characterForbiddenInFilename(const char theChar);
     void saveGame();


### PR DESCRIPTION
playback for a long period.

This can be demonstrated by clicking left mouse about 20 times in one place during playback. The playback pauses for a long time as brogue runs through the clicks, pausing for no reason between processing each click even though it doesn't do anything.