### PR TITLE
Moved charm change to Bug fixes in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,13 +108,13 @@ Gameplay changes
   on the attacked cells would be hit, including allies. Now the monsters hit are
   only those that would trigger a spear attack if they were there alone. (This
   excludes hidden monsters)
--
-  Tweaked some charm stats to match 1.7.4 behaviour
 
 
 Bug fixes
 ---------
 
+-
+  Fixed charm durations which were affected by bugs
 -
   Monsters now have a 3% chance per turn to forget you, instead of 97%
 -


### PR DESCRIPTION
The charm changes in 1.7.5-flend1 restore all charms to v1.7.4 behaviour
where the charms were affected by bugs introduced during the change to
fixed point in v1.7.5. There were no intended charm changes according to
the v1.7.5 changelog and it was clear the changes were due to bugs (and
unbalanced the game in many cases). The charms now behave as in v1.7.4
although there are some off-by-1 changes that are not obviously bugs,
just side effects of the new maths.