### PR TITLE
Feature/game lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ Other changes
 -------------
 
 -
+  Adding the `--no-recording-prompt`, `--no-restart` and `no-scores`
+  command line parameters
+-
   Turning on autopilot now requires confirmation
 -
   The graphics backend has been rewritten be the same on all platforms. (The

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -40,6 +40,8 @@
 
 #define MENU_FLAME_DENOMINATOR          (100 + MENU_FLAME_RISE_SPEED + MENU_FLAME_SPREAD_SPEED)
 
+extern boolean noRestart;
+
 void drawMenuFlames(signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3], unsigned char mask[COLS][ROWS]) {
     short i, j, versionStringLength;
     color tempColor = {0};
@@ -749,6 +751,9 @@ void mainBrogueJunction() {
                 startLevel(rogue.depthLevel, 1); // descending into level 1
 
                 mainInputLoop();
+                if(noRestart) {
+                    rogue.nextGame = NG_QUIT;
+                }
                 freeEverything();
                 break;
             case NG_OPEN_GAME:
@@ -772,6 +777,9 @@ void mainBrogueJunction() {
                 rogue.playbackMode = false;
                 rogue.playbackOOS = false;
 
+                if(noRestart) {
+                    rogue.nextGame = NG_QUIT;
+                }
                 break;
             case NG_VIEW_RECORDING:
                 rogue.nextGame = NG_NOTHING;
@@ -816,6 +824,9 @@ void mainBrogueJunction() {
                 rogue.playbackMode = false;
                 rogue.playbackOOS = false;
 
+                if(noRestart) {
+                    rogue.nextGame = NG_QUIT;
+                }
                 break;
             case NG_HIGH_SCORES:
                 rogue.nextGame = NG_NOTHING;

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1045,6 +1045,19 @@ void saveGame() {
     deleteMessages();
 }
 
+void saveRecordingNoPrompt()
+{
+    char filePath[BROGUE_FILENAME_MAX];
+
+    if (rogue.playbackMode) {
+        return;
+    }
+    getAvailableFilePath(filePath, "Recording", RECORDING_SUFFIX);
+    strcat(filePath, RECORDING_SUFFIX);
+    remove(filePath);
+    rename(currentFilePath, filePath);
+}
+
 void saveRecording() {
     char filePath[BROGUE_FILENAME_MAX], defaultPath[BROGUE_FILENAME_MAX];
     boolean askAgain;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3125,6 +3125,7 @@ extern "C" {
     boolean characterForbiddenInFilename(const char theChar);
     void saveGame();
     void saveRecording();
+    void saveRecordingNoPrompt();
     void parseFile();
     void RNGLog(char *message);
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -26,6 +26,7 @@
 #include <time.h>
 
 extern boolean noScores;
+extern boolean noRecordingPrompt;
 
 void rogueMain() {
     previousGameSeed = 0;
@@ -1178,7 +1179,12 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
             printHighScores(true);
         }
         blackOutScreen();
-        saveRecording();
+        if(noRecordingPrompt) {
+            saveRecordingNoPrompt();
+        }
+        else {
+            saveRecording();
+        }
     }
 
     rogue.gameHasEnded = true;
@@ -1288,7 +1294,12 @@ void victory(boolean superVictory) {
     displayMoreSign();
     rogue.playbackMode = isPlayback;
 
-    saveRecording();
+    if (noRecordingPrompt) {
+        saveRecordingNoPrompt();
+    }
+    else {
+        saveRecording();
+    }
 
     if(!noScores) {
         printHighScores(qualified);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -25,6 +25,8 @@
 #include "IncludeGlobals.h"
 #include <time.h>
 
+extern boolean noScores;
+
 void rogueMain() {
     previousGameSeed = 0;
     initializeBrogueSaveLocation();
@@ -1172,7 +1174,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     }
 
     if (!rogue.playbackMode) {
-        if (saveHighScore(theEntry)) {
+        if (saveHighScore(theEntry) && !noScores) {
             printHighScores(true);
         }
         blackOutScreen();
@@ -1288,8 +1290,9 @@ void victory(boolean superVictory) {
 
     saveRecording();
 
-    printHighScores(qualified);
-
+    if(!noScores) {
+        printHighScores(qualified);
+    }
     rogue.gameHasEnded = true;
 }
 

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -4,6 +4,7 @@ extern playerCharacter rogue;
 struct brogueConsole currentConsole;
 
 boolean noMenu = false;
+boolean noRestart = false;
 unsigned long int firstSeed = 0;
 int brogueFontSize = 0;
 
@@ -32,6 +33,7 @@ static void printCommandlineHelp() {
     "-o filename[.broguesave]   open a save file (extension optional)\n"
     "-v recording[.broguerec]   view a recording (extension optional)\n"
     "--no-menu      -M          never display the menu (automatically pick new game)\n"
+    "--no-restart               exit brogue when game ends"
 #ifdef BROGUE_SDL
     "--size N                   starts the game at font size N (1 to 13)\n"
 #endif
@@ -114,6 +116,11 @@ int main(int argc, char *argv[])
         if(strcmp(argv[i], "--no-menu") == 0 || strcmp(argv[i], "-M") == 0) {
             rogue.nextGame = NG_NEW_GAME;
             noMenu = true;
+            continue;
+        }
+
+        if(strcmp(argv[i], "--no-restart") == 0) {
+            noRestart = true;
             continue;
         }
 

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -4,6 +4,7 @@ extern playerCharacter rogue;
 struct brogueConsole currentConsole;
 
 boolean noMenu = false;
+boolean noRecordingPrompt = false;
 boolean noRestart = false;
 boolean noScores = false;
 unsigned long int firstSeed = 0;
@@ -34,6 +35,7 @@ static void printCommandlineHelp() {
     "-o filename[.broguesave]   open a save file (extension optional)\n"
     "-v recording[.broguerec]   view a recording (extension optional)\n"
     "--no-menu      -M          never display the menu (automatically pick new game)\n"
+    "--no-recording-prompt      saves recordings automatically without prompt"
     "--no-restart               exit brogue when game ends"
     "--no-scores                do not print highscores when game ends"
 #ifdef BROGUE_SDL
@@ -118,6 +120,11 @@ int main(int argc, char *argv[])
         if(strcmp(argv[i], "--no-menu") == 0 || strcmp(argv[i], "-M") == 0) {
             rogue.nextGame = NG_NEW_GAME;
             noMenu = true;
+            continue;
+        }
+
+        if (strcmp(argv[i], "--no-recording-prompt") == 0) {
+            noRecordingPrompt = true;
             continue;
         }
 

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -5,6 +5,7 @@ struct brogueConsole currentConsole;
 
 boolean noMenu = false;
 boolean noRestart = false;
+boolean noScores = false;
 unsigned long int firstSeed = 0;
 int brogueFontSize = 0;
 
@@ -34,6 +35,7 @@ static void printCommandlineHelp() {
     "-v recording[.broguerec]   view a recording (extension optional)\n"
     "--no-menu      -M          never display the menu (automatically pick new game)\n"
     "--no-restart               exit brogue when game ends"
+    "--no-scores                do not print highscores when game ends"
 #ifdef BROGUE_SDL
     "--size N                   starts the game at font size N (1 to 13)\n"
 #endif
@@ -121,6 +123,11 @@ int main(int argc, char *argv[])
 
         if(strcmp(argv[i], "--no-restart") == 0) {
             noRestart = true;
+            continue;
+        }
+
+        if(strcmp(argv[i], "--no-scores") == 0) {
+            noScores = true;
             continue;
         }
 


### PR DESCRIPTION
Adds some additional command line parameters to remove the interactive sections around the beginning and end of the game. This complements the existing (but useless) --no-menu - which only currently removes the menu before the game, but returns you to it after game. These options are useful for running the game from another launcher, e.g. web-brogue.