### PR TITLE
Fixed code to get rid of some compile time warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include config.mk
 
 cflags := -Isrc/brogue -Isrc/platform -std=c99 \
-	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-format-overflow
+	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-unused-result -Wno-format
 libs := -lm
 cppflags := -DDATADIR=$(DATADIR)
 

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -939,14 +939,14 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short i, j, k, feat, randIndex, totalFreq, gateCandidates[50][2], instance, instanceCount, qualifyingTileCount,
+    short i, j, k, feat, randIndex, totalFreq, gateCandidates[50][2], instance, instanceCount = 0, qualifyingTileCount,
     featX, featY, itemCount, monsterCount,
     sRows[DROWS], sCols[DCOLS],
     **distanceMap, distance25, distance75, distances[100], distanceBound[2],
     personalSpace, failsafe, locationFailsafe,
     machineNumber;
     const unsigned long alternativeFlags[2] = {MF_ALTERNATIVE, MF_ALTERNATIVE_2};
-    boolean success;
+    boolean success = false;
 
     // Our boolean grids:
     //  Interior:       This is the master grid for the machine. All area inside the machine are set to true.
@@ -1351,6 +1351,7 @@ boolean buildAMachine(enum machineTypes bp,
                     // Pick our candidate location randomly, and also strike it from
                     // the candidates map so that subsequent instances of this same feature can't choose it.
                     featX = -1;
+                    featY = -1;
                     randIndex = rand_range(1, qualifyingTileCount);
                     for(i=0; i<DCOLS && featX < 0; i++) {
                         for(j=0; j<DROWS && featX < 0; j++) {

--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -323,7 +323,7 @@ short buttonInputLoop(brogueButton *buttons,
                       short winWidth,
                       short winHeight,
                       rogueEvent *returnEvent) {
-    short x, y, button; // (x, y) keeps track of the mouse location
+    short button;
     boolean canceled;
     rogueEvent theEvent;
     buttonState state = {0};
@@ -331,7 +331,6 @@ short buttonInputLoop(brogueButton *buttons,
     assureCosmeticRNG;
 
     canceled = false;
-    x = y = -1;
     initializeButtonState(&state, buttons, buttonCount, winX, winY, winWidth, winHeight);
 
     do {

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -69,7 +69,6 @@ unsigned long maxLevelChanges;
 char annotationPathname[BROGUE_FILENAME_MAX];   // pathname of annotation file
 unsigned long previousGameSeed;
 
-#pragma mark Colors
 //                                  Red     Green   Blue    RedRand GreenRand   BlueRand    Rand    Dances?
 // basic colors
 const color white =                 {100,   100,    100,    0,      0,          0,          0,      false};
@@ -357,8 +356,6 @@ const color flameTitleColor = {0, 0, 0, 9, 9, 15, 0, true}; // *pale blue**
 //const color flameTitleColor = {0, 0, 0, 15, 15, 9, 0, true}; // pale yellow
 //const color flameTitleColor = {0, 0, 0, 15, 9, 15, 0, true}; // pale purple
 
-#pragma mark Dynamic color references
-
 const color *dynamicColors[NUMBER_DYNAMIC_COLORS][3] = {
     // used color           shallow color               deep color
     {&minersLightColor,     &minersLightStartColor,     &minersLightEndColor},
@@ -368,8 +365,6 @@ const color *dynamicColors[NUMBER_DYNAMIC_COLORS][3] = {
     {&floorBackColor,       &floorBackColorStart,       &floorBackColorEnd},
     {&chasmEdgeBackColor,   &chasmEdgeBackColorStart,   &chasmEdgeBackColorEnd},
 };
-
-#pragma mark Autogenerator definitions
 
 const autoGenerator autoGeneratorCatalog[NUMBER_AUTOGENERATORS] = {
 //   terrain                    layer   DF                          Machine                     reqDungeon  reqLiquid   >Depth  <Depth          freq    minIncp minSlope    maxNumber
@@ -432,8 +427,6 @@ const autoGenerator autoGeneratorCatalog[NUMBER_AUTOGENERATORS] = {
     {0,                         0,      0,                          MT_SENTINEL_AREA,           FLOOR,      NOTHING,    12,     DEEPEST_LEVEL-1,10,     0,      0,          2},
     {0,                         0,      0,                          MT_WORM_AREA,               FLOOR,      NOTHING,    12,     DEEPEST_LEVEL-1,12,     0,      0,          3},
 };
-
-#pragma mark Terrain definitions
 
 const floorTileType tileCatalog[NUMBER_TILETYPES] = {
 
@@ -698,8 +691,6 @@ const floorTileType tileCatalog[NUMBER_TILETYPES] = {
     {WALL_CHAR,     &mudWallForeColor,      &mudWallBackColor,      0,  0,  DF_PLAIN_FIRE,  0,          0,              0,              NO_LIGHT,       (T_OBSTRUCTS_EVERYTHING), (TM_STAND_IN_TILE),                                                       "a mud-covered wall",   "A malodorous layer of clay and fecal matter coats the wall."},
     {OMEGA_CHAR,    &mudWallForeColor,      &refuseBackColor,       25, 50, DF_EMBERS,      0,          0,              0,              NO_LIGHT,       (T_OBSTRUCTS_VISION | T_OBSTRUCTS_GAS | T_IS_FLAMMABLE), (TM_STAND_IN_TILE | TM_VISUALLY_DISTINCT), "hanging animal skins", "you push through the animal skins that hang across the threshold."},
 };
-
-#pragma mark Dungeon Feature definitions
 
 // Features in the gas layer use the startprob as volume, ignore probdecr, and spawn in only a single point.
 // Intercepts and slopes are in units of 0.01.
@@ -1034,8 +1025,6 @@ dungeonFeature dungeonFeatureCatalog[NUMBER_DUNGEON_FEATURES] = {
     {STENCH_SMOKE_GAS,          GAS,        50,     0,      0, "", 0, 0, 0, 0, DF_EMBERS},
 };
 
-#pragma mark Dungeon Profiles
-
 dungeonProfile dungeonProfileCatalog[NUMBER_DUNGEON_PROFILES] = {
     // Room frequencies:
     //      0. Cross room
@@ -1055,8 +1044,6 @@ dungeonProfile dungeonProfileCatalog[NUMBER_DUNGEON_PROFILES] = {
     {{0,    0,  1,  0,  0,  0,  0,  0}, 0},     // Goblin warrens
     {{0,    5,  0,  1,  0,  0,  0,  0}, 0},     // Sentinel sanctuaries
 };
-
-#pragma mark Lights
 
 // radius is in units of 0.01
 const lightSource lightCatalog[NUMBER_LIGHT_KINDS] = {
@@ -1126,8 +1113,6 @@ const lightSource lightCatalog[NUMBER_LIGHT_KINDS] = {
     {&descentLightColor,    {600, 600, 1},          0,      false},     // magical pit light
     {&sacrificeTargetColor, {800, 1200, 1},          0,      true},      // demonic statue light
 };
-
-#pragma mark Blueprints
 
 const blueprint blueprintCatalog[NUMBER_BLUEPRINTS] = {
     {{0}}, // nothing
@@ -1579,8 +1564,6 @@ const blueprint blueprintCatalog[NUMBER_BLUEPRINTS] = {
 };
 
 
-#pragma mark Monster definitions
-
 // Defines all creatures, which include monsters and the player:
 creatureType monsterCatalog[NUMBER_MONSTER_KINDS] = {
     //  name            ch      color           HP      def     acc     damage          reg move    attack  blood           light   DFChance DFType         bolts       behaviorF, abilityF
@@ -1723,8 +1706,6 @@ creatureType monsterCatalog[NUMBER_MONSTER_KINDS] = {
     {0, "mangrove dryad",'M',   &tanColor,      70,     60,     175,    {2, 8, 2},      6,  100,    100,    DF_ASH_BLOOD,   0,      0,      0,              {BOLT_ANCIENT_SPIRIT_VINES},
         (MONST_IMMUNE_TO_WEBS | MONST_ALWAYS_USE_ABILITY | MONST_MAINTAINS_DISTANCE | MONST_NO_POLYMORPH | MONST_MALE | MONST_FEMALE), (0)},
 };
-
-#pragma mark Monster words
 
 const monsterWords monsterText[NUMBER_MONSTER_KINDS] = {
     {"A naked adventurer in an unforgiving place, bereft of equipment and confused about the circumstances.",
@@ -1955,8 +1936,6 @@ const monsterWords monsterText[NUMBER_MONSTER_KINDS] = {
         {"whips", "lashes", "thrashes", "lacerates", {0}}},
 };
 
-#pragma mark Mutation definitions
-
 const mutation mutationCatalog[NUMBER_MUTATORS] = {
     //Title         textColor       healthFactor    moveSpdMult attackSpdMult   defMult damMult DF% DFtype  light   monstFlags  abilityFlags    forbiddenFlags      forbiddenAbilities
     {"explosive",   &orange,        50,             100,        100,            50,     100,    0,  DF_MUTATION_EXPLOSION, EXPLOSIVE_BLOAT_LIGHT, 0, MA_DF_ON_DEATH, MONST_SUBMERGES, 0,
@@ -1976,8 +1955,6 @@ const mutation mutationCatalog[NUMBER_MUTATORS] = {
     {"reflective",  &darkTurquoise, 100,            100,        100,            100,    100,    -1, 0,      0,      MONST_REFLECT_4, 0,         (MONST_REFLECT_4 | MONST_ALWAYS_USE_ABILITY), 0,
         "A rare mutation has coated $HISHER flesh with reflective scales."},
 };
-
-#pragma mark Horde definitions
 
 const hordeType hordeCatalog[NUMBER_HORDES] = {
     // leader       #members    member list                             member numbers                  minL    maxL    freq    spawnsIn        machine         flags
@@ -2186,8 +2163,6 @@ const hordeType hordeCatalog[NUMBER_HORDES] = {
     {MK_GOBLIN,         1,      {MK_GOBLIN},                            {{1, 2, 1}},                    3,      7,      10,     0,              0,              HORDE_MACHINE_GOBLIN_WARREN | HORDE_LEADER_CAPTIVE},
 };
 
-#pragma mark Monster class definitions
-
 const monsterClass monsterClassCatalog[MONSTER_CLASS_COUNT] = {
     // name             frequency   maxDepth    member list
     {"abomination",     10,         -1,         {MK_BOG_MONSTER, MK_UNDERWORM, MK_KRAKEN, MK_TENTACLE_HORROR}},
@@ -2208,8 +2183,6 @@ const monsterClass monsterClassCatalog[MONSTER_CLASS_COUNT] = {
 };
 
 // ITEMS
-
-#pragma mark Item flavors
 
 char itemTitles[NUMBER_SCROLL_KINDS][30];
 
@@ -2328,8 +2301,6 @@ const char itemGemsRef[NUMBER_ITEM_GEMS][30] = {
     "bloodstone",
     "jasper"
 };
-
-#pragma mark Item definitions
 
 //typedef struct itemTable {
 //  char *name;
@@ -2500,8 +2471,6 @@ itemTable charmTable[NUMBER_CHARM_KINDS] = {
     {"negation",        "", "", 5,  700,    0,{1,2,1}, true, false, "A featureless gray disc hangs from a lanyard. When you touch it, your hand and arm go numb."},
 };
 
-#pragma mark Bolt definitions
-
 const bolt boltCatalog[NUMBER_BOLT_KINDS] = {
     {{0}},
     //name                      bolt description                ability description                         char    foreColor       backColor           boltEffect      magnitude       pathDF      targetDF    forbiddenMonsterFlags       flags
@@ -2536,8 +2505,6 @@ const bolt boltCatalog[NUMBER_BOLT_KINDS] = {
     {"whip",                    "whips",                        "wields a whip",                            '*',    &tanColor,      NULL,               BE_ATTACK,      1,              0,          0,          MONST_IMMUNE_TO_WEAPONS,    (BF_TARGET_ENEMIES | BF_NEVER_REFLECTS | BF_NOT_LEARNABLE | BF_DISPLAY_CHAR_ALONG_LENGTH)},
 };
 
-#pragma mark Feat definitions
-
 const feat featTable[FEAT_COUNT] = {
     {"Pure Mage",       "Ascend without using fists or a weapon.", true},
     {"Pure Warrior",    "Ascend without using a staff, wand or charm.", true},
@@ -2551,8 +2518,6 @@ const feat featTable[FEAT_COUNT] = {
     {"Dragonslayer",    "Kill a dragon with a melee attack.", false},
     {"Paladin",         "Ascend without attacking an unaware or fleeing creature.", true},
 };
-
-#pragma mark Miscellaneous definitions
 
 const char monsterBehaviorFlagDescriptions[32][COLS] = {
     "is invisible",                             // MONST_INVISIBLE

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -505,7 +505,7 @@ void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
 
 // This is basically the main loop for the game.
 void mainInputLoop() {
-    short originLoc[2], pathDestination[2], oldTargetLoc[2],
+    short originLoc[2], pathDestination[2], oldTargetLoc[2] = { 0, 0 },
     path[1000][2], steps, oldRNG, dir, newX, newY;
     creature *monst;
     item *theItem;
@@ -3273,7 +3273,7 @@ enum entityDisplayTypes {
 // we won't know if it will fit on the screen in normal order until we try.
 // So if we try and fail, this function will call itself again, but with this set to true.
 void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst) {
-    short printY, oldPrintY, shortestDistance, i, j, k, px, py, x, y, displayEntityCount, indirectVision;
+    short printY, oldPrintY, shortestDistance, i, j, k, px, py, x = 0, y = 0, displayEntityCount, indirectVision;
     creature *monst, *closestMonst;
     item *theItem, *closestItem;
     char buf[COLS];

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -390,6 +390,7 @@ short actionMenu(short x, boolean playingBack) {
         }
     } while (takeActionOurselves[buttonChosen]);
     brogueAssert(false);
+    return -1;
 }
 
 #define MAX_MENU_BUTTON_COUNT 5

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2624,7 +2624,7 @@ char displayInventory(unsigned short categoryMask,
     cellDisplayBuffer dbuf[COLS][ROWS];
     cellDisplayBuffer rbuf[COLS][ROWS];
     brogueButton buttons[50] = {{{0}}};
-    short actionKey;
+    short actionKey = -1;
     color darkItemColor;
 
     char whiteColorEscapeSequence[20],
@@ -4527,7 +4527,7 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
 // returns whether the bolt effect should autoID any staff or wand it came from, if it came from a staff or wand
 boolean zap(short originLoc[2], short targetLoc[2], bolt *theBolt, boolean hideDetails) {
     short listOfCoordinates[MAX_BOLT_LENGTH][2];
-    short i, j, k, x, y, x2, y2, numCells, blinkDistance, boltLength, initialBoltLength, lights[DCOLS][DROWS][3];
+    short i, j, k, x, y, x2, y2, numCells, blinkDistance = 0, boltLength, initialBoltLength, lights[DCOLS][DROWS][3];
     creature *monst = NULL, *shootingMonst;
     char buf[COLS], monstName[COLS];
     boolean autoID = false;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3301,7 +3301,7 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
 short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2], const short targetLoc[2]) {
     fixpt targetVector[2], error[2], largerTargetComponent;
     short currentVector[2], previousVector[2], quadrantTransform[2], i;
-    short currentLoc[2], previousLoc[2];
+    short currentLoc[2];
     short cellNumber = 0;
 
     if (originLoc[0] == targetLoc[0] && originLoc[1] == targetLoc[1]) {
@@ -3328,8 +3328,6 @@ short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2],
 
     do {
         for (i=0; i<= 1; i++) {
-
-            previousLoc[i] = currentLoc[i];
 
             currentVector[i] += targetVector[i] / FP_FACTOR;
             error[i] += (targetVector[i] == FP_FACTOR ? 0 : targetVector[i]);
@@ -5718,7 +5716,7 @@ void throwCommand(item *theItem) {
     item *thrownItem;
     char buf[COLS], theName[COLS];
     unsigned char command[10];
-    short maxDistance, zapTarget[2], originLoc[2], quantity;
+    short maxDistance, zapTarget[2], quantity;
     boolean autoTarget;
 
     command[0] = THROW_KEY;
@@ -5774,8 +5772,6 @@ void throwCommand(item *theItem) {
         thrownItem->quantity = 1;
 
         itemName(thrownItem, theName, false, false, NULL);
-        originLoc[0] = player.xLoc;
-        originLoc[1] = player.yLoc;
 
         throwItem(thrownItem, &player, zapTarget, maxDistance);
     } else {

--- a/src/brogue/Math.c
+++ b/src/brogue/Math.c
@@ -215,7 +215,7 @@ fixpt fp_sqrt(fixpt u) {
     // FP_BASE is the msbpos-1 of FP_FACTOR ("one")
     int k = msbpos(u) - FP_BASE;
 
-    fixpt x, fx, upper, lower;
+    fixpt x = 0, fx, upper, lower;
     // Since 2^(k-1) <= u < 2^k, we have 2^(ceil(k/2)-1) <= sqrt(u) < 2^ceil(k/2).
     // First ineq. from sqrt(u) >= 2^[(k-1)/2] = 2^[k/2 + 1/2 - 1] >= 2^(ceil(k/2) - 1)
     // To calculate ceil(k/2), do k/2 but add 1 to k if positive.

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -4024,7 +4024,7 @@ boolean staffOrWandEffectOnMonsterDescription(char *newText, item *theItem, crea
 void monsterDetails(char buf[], creature *monst) {
     char monstName[COLS], capMonstName[COLS], theItemName[COLS * 3], newText[20*COLS];
     short i, j, combatMath, combatMath2, playerKnownAverageDamage, playerKnownMaxDamage, commaCount, realArmorValue;
-    boolean anyFlags, displayedItemText = false, alreadyDisplayedDominationText = false;
+    boolean anyFlags, alreadyDisplayedDominationText = false;
     item *theItem;
 
     buf[0] = '\0';
@@ -4219,7 +4219,6 @@ void monsterDetails(char buf[], creature *monst) {
             i = strlen(buf);
             i = encodeMessageColor(buf, i, &itemMessageColor);
             strcat(buf, newText);
-            displayedItemText = true;
         }
     }
 

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -647,7 +647,7 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
 // (in which case the player/monster should move instead).
 boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *aborted) {
     creature *defender, *hitList[8] = {0};
-    short originLoc[2], targetLoc[2], range = 2, i = 0, h = 0;
+    short targetLoc[2], range = 2, i = 0, h = 0;
     boolean proceed = false, visualEffect = false;
 
     const char boltChar[DIRECTION_COUNT] = "||--\\//\\";
@@ -661,8 +661,6 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
     } else if (!(attacker->info.abilityFlags & MA_ATTACKS_PENETRATE)) {
         return false;
     }
-    originLoc[0] = attacker->xLoc;
-    originLoc[1] = attacker->yLoc;
 
     for (i = 0; i < range; i++) {
         targetLoc[0] = attacker->xLoc + (1 + i) * nbDirs[dir][0];

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -69,7 +69,7 @@ void playerRuns(short direction) {
 
 enum dungeonLayers highestPriorityLayer(short x, short y, boolean skipGas) {
     short bestPriority = 10000;
-    enum dungeonLayers tt, best;
+    enum dungeonLayers tt, best = 0;
 
     for (tt = 0; tt < NUMBER_TERRAIN_LAYERS; tt++) {
         if (tt == GAS && skipGas) {

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -717,13 +717,13 @@ void promptToAdvanceToLocation(short keystroke) {
 }
 
 void pausePlayback() {
-    short oldRNG;
+    //short oldRNG;
     if (!rogue.playbackPaused) {
         rogue.playbackPaused = true;
         messageWithColor(KEYBOARD_LABELS ? "recording paused. Press space to play." : "recording paused.",
                          &teal, false);
         refreshSideBar(-1, -1, false);
-        oldRNG = rogue.RNG;
+        //oldRNG = rogue.RNG;
         //rogue.RNG = RNG_SUBSTANTIVE;
         mainInputLoop();
         //rogue.RNG = oldRNG;

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -28,8 +28,6 @@
 
 #define RECORDING_HEADER_LENGTH     32  // bytes at the start of the recording file to store global data
 
-#pragma mark Recording functions
-
 void recordChar(unsigned char c) {
     inputRecordBuffer[locationInRecordingBuffer++] = c;
     recordingLocation++;
@@ -231,8 +229,6 @@ void flushBufferToFile() {
         locationInRecordingBuffer = 0;
     }
 }
-
-#pragma mark Playback functions
 
 void fillBufferFromFile() {
 //  short i;
@@ -438,8 +434,6 @@ void displayAnnotation() {
         loadNextAnnotation();
     }
 }
-
-#pragma mark Hybrid and miscellaneous
 
 // creates a game recording file, or if in playback mode,
 // initializes based on and starts reading from the recording file
@@ -1173,8 +1167,6 @@ void loadSavedGame() {
         recordChar(SAVED_GAME_LOADED);
     }
 }
-
-#pragma mark Debug functions
 
 // the following functions are used to create human-readable descriptions of playback files for debugging purposes
 

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -81,7 +81,7 @@ void initScores() {
 // sorts the entries of the scoreBuffer global variable by score in descending order;
 // returns the sorted line number of the most recent entry
 short sortScoreBuffer() {
-    short i, j, highestUnsortedLine, mostRecentSortedLine;
+    short i, j, highestUnsortedLine, mostRecentSortedLine = 0;
     long highestUnsortedScore, mostRecentDate;
     brogueScoreEntry sortedScoreBuffer[HIGH_SCORES_COUNT];
     boolean lineSorted[HIGH_SCORES_COUNT];


### PR DESCRIPTION
What's **not** done:

* warning: ISO C forbids an empty translation unit [-Wpedantic]
* warning: passing argument 1 to restrict-qualified parameter aliases with argument 3 [-Wrestrict] (sprintf)
* warning: address of array 'newItem->inscription' will always evaluate to 'true' [-Wpointer-bool-conversion]