### PR TITLE
One-turn searches with guaranteed discovery of neighboring squares.

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4130,7 +4130,6 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
         "   (Caterwauling)   ",
     };
     const char statusStrings[NUMBER_OF_STATUS_EFFECTS][COLS] = {
-        "Searching",
         "Donning Armor",
         "Weakened: -",
         "Telepathic",

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1181,18 +1181,7 @@ boolean playerMoves(short direction) {
                 refreshDungeonCell(newX, newY);
             }
 
-            // Discover hidden doors and levers by walking into them
-            if (cellHasTMFlag(newX, newY, TM_IS_SECRET)) {
-                discover(newX, newY);
-                if (!alreadyRecorded) {
-                    recordKeystroke(directionKeys[initialDirection], false, false);
-                    alreadyRecorded = true;
-                }
-                // End the turn, else we have free searching (also triggers light flare)
-                playerTurnEnded();
-            } else {
-                messageWithColor(tileCatalog[i].flavorText, &backgroundMessageColor, false);
-            }
+            messageWithColor(tileCatalog[i].flavorText, &backgroundMessageColor, false);
         }
     }
     return playerMoved;
@@ -2174,7 +2163,7 @@ void manualSearch() {
         x = player.xLoc + i;
         for (j = -1; j < 2; j++) {
             y = player.yLoc + j;
-            if (coordinatesAreInMap(x, y)) {
+            if (coordinatesAreInMap(x, y) && playerCanSee(x, y)) {
               discover(x, y);
             }
         }

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -2164,7 +2164,8 @@ void manualSearch() {
         for (j = -1; j < 2; j++) {
             y = player.yLoc + j;
             if (coordinatesAreInMap(x, y) && playerCanSee(x, y)) {
-              discover(x, y);
+                pmap[i][j].flags |= KNOWN_TO_BE_TRAP_FREE;
+                discover(x, y);
             }
         }
     }

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -2180,7 +2180,7 @@ void manualSearch() {
         }
     }
 
-    search(rogue.awarenessBonus + 30);
+    search(rogue.awarenessBonus < 0 ? 40 : 80);
     rogue.justSearched = true;
     playerTurnEnded();
 }

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -2166,6 +2166,25 @@ boolean search(short searchStrength) {
     return foundSomething;
 }
 
+void manualSearch() {
+    short i, j, x, y;
+
+    // Guaranteed discovery of all adjacent locations
+    for (i = -1; i < 2; i++) {
+        x = player.xLoc + i;
+        for (j = -1; j < 2; j++) {
+            y = player.yLoc + j;
+            if (coordinatesAreInMap(x, y)) {
+              discover(x, y);
+            }
+        }
+    }
+
+    search(rogue.awarenessBonus + 30);
+    rogue.justSearched = true;
+    playerTurnEnded();
+}
+
 boolean proposeOrConfirmLocation(short x, short y, char *failureMessage) {
     boolean retval = false;
     if (player.xLoc == x && player.yLoc == y) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1023,7 +1023,7 @@ enum tileFlags {
     IN_FIELD_OF_VIEW            = Fl(6),    // player has unobstructed line of sight whether or not there is enough light
     WAS_VISIBLE                 = Fl(7),
     HAS_STAIRS                  = Fl(8),
-    SEARCHED_FROM_HERE          = Fl(9),    // player already auto-searched here; can't auto-search here again
+    // unused                   = Fl(9),
     IS_IN_SHADOW                = Fl(10),   // so that a player gains an automatic stealth bonus
     MAGIC_MAPPED                = Fl(11),
     ITEM_DETECTED               = Fl(12),
@@ -1048,10 +1048,9 @@ enum tileFlags {
 
     IS_IN_MACHINE               = (IS_IN_ROOM_MACHINE | IS_IN_AREA_MACHINE),    // sacred ground; don't generate items here, or teleport randomly to it
 
-    PERMANENT_TILE_FLAGS = (DISCOVERED | MAGIC_MAPPED | ITEM_DETECTED | HAS_ITEM | HAS_DORMANT_MONSTER
-                            | HAS_STAIRS | SEARCHED_FROM_HERE | PRESSURE_PLATE_DEPRESSED
-                            | STABLE_MEMORY | KNOWN_TO_BE_TRAP_FREE | IN_LOOP
-                            | IS_CHOKEPOINT | IS_GATE_SITE | IS_IN_MACHINE | IMPREGNABLE),
+    PERMANENT_TILE_FLAGS = (DISCOVERED | MAGIC_MAPPED | ITEM_DETECTED | HAS_ITEM | HAS_DORMANT_MONSTER | HAS_STAIRS
+                            | PRESSURE_PLATE_DEPRESSED | STABLE_MEMORY | KNOWN_TO_BE_TRAP_FREE | IN_LOOP | IS_CHOKEPOINT
+                            | IS_GATE_SITE | IS_IN_MACHINE | IMPREGNABLE),
 
     ANY_KIND_OF_VISIBLE         = (VISIBLE | CLAIRVOYANT_VISIBLE | TELEPATHIC_VISIBLE),
 };

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1871,8 +1871,7 @@ enum terrainMechanicalFlagCatalog {
 };
 
 enum statusEffects {
-    STATUS_SEARCHING = 0,
-    STATUS_DONNING,
+    STATUS_DONNING = 0,
     STATUS_WEAKENED,
     STATUS_TELEPATHIC,
     STATUS_HALLUCINATING,

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -676,10 +676,6 @@ short currentAggroValue() {
         if (rogue.justRested) {
             stealthVal = (stealthVal + 1) / 2;
         }
-        // Double while manually searching.
-        if (player.status[STATUS_SEARCHING] > 0) {
-            stealthVal *= 2;
-        }
 
         if (player.status[STATUS_AGGRAVATING] > 0) {
             stealthVal += player.status[STATUS_AGGRAVATING];
@@ -2112,43 +2108,6 @@ void autoRest() {
     rogue.automationActive = false;
 }
 
-void searchTurn() {
-    boolean foundSomething = false;
-    recordKeystroke(SEARCH_KEY, false, false);
-    if (player.status[STATUS_SEARCHING] <= 0) {
-        player.status[STATUS_SEARCHING] = player.maxStatus[STATUS_SEARCHING] = 5;
-    } else {
-        player.status[STATUS_SEARCHING]--;
-        if (player.status[STATUS_SEARCHING] <= 0) {
-            // Manual search complete!
-            foundSomething = search(200);
-            if (foundSomething) {
-                message("you finish searching the area.", false);
-            } else {
-                message("you finish searching the area, but find nothing.", false);
-            }
-        }
-    }
-    rogue.justSearched = true;
-    playerTurnEnded();
-}
-
-void manualSearch() {
-    if (rogue.playbackMode) {
-        searchTurn();
-    } else {
-        rogue.disturbed = false;
-        rogue.automationActive = true;
-        do {
-            searchTurn();
-            if (pauseBrogue(80)) {
-                rogue.disturbed = true;
-            }
-        } while (player.status[STATUS_SEARCHING] > 0 && !rogue.disturbed);
-        rogue.automationActive = false;
-    }
-}
-
 // Call this periodically (when haste/slow wears off and when moving between depths)
 // to keep environmental updates in sync with player turns.
 void synchronizePlayerTimeState() {
@@ -2250,11 +2209,6 @@ void playerTurnEnded() {
             // Low-grade auto-search wherever you step, but only once per tile.
             search(rogue.awarenessBonus + 30);
             pmap[player.xLoc][player.yLoc].flags |= SEARCHED_FROM_HERE;
-        }
-        if (!rogue.justSearched && player.status[STATUS_SEARCHING] > 0) {
-            // If you don't resume manually searching when interrupted, abort the search and post a message.
-            player.status[STATUS_SEARCHING] = 0;
-            message("you abandon your search.", false);
         }
         if (rogue.staleLoopMap) {
             analyzeMap(false); // Don't need to update the chokemap.

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -2205,10 +2205,8 @@ void playerTurnEnded() {
             }
         }
 
-        if (rogue.awarenessBonus > -30 && !(pmap[player.xLoc][player.yLoc].flags & SEARCHED_FROM_HERE)) {
-            // Low-grade auto-search wherever you step, but only once per tile.
+        if (rogue.awarenessBonus > -30) {
             search(rogue.awarenessBonus + 30);
-            pmap[player.xLoc][player.yLoc].flags |= SEARCHED_FROM_HERE;
         }
         if (rogue.staleLoopMap) {
             analyzeMap(false); // Don't need to update the chokemap.


### PR DESCRIPTION
This patch restores manual search behavior to its state in 1.7.4, with the alteration that any secrets on the eight neighbors are _always_ discovered. This still solves the search-walking problem, but does so by making a much smaller change to the behavior of searching.

It may be considered an extension of the CE rule that walking into a secret door will reveal it (and in fact it replaces this behavior). It is both a nerf and a buff relative to the CE rule, because searching and finding nothing wastes a turn, whereas in feeling for a door and not finding one in CE 1.8.1. does not, yet a one-turn search in this patch searches eight squares at once _and_ reveals traps as well as doors.

The manualSearch() function is kept, but its contents are rewritten and, being no longer a multi-turn action, it is moved from Time.c to Movement.c.