### PR TITLE
Take a screenshot with printscreen key. Available only with SDL version.

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2598,7 +2598,7 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             break;
         case PRINTSCREEN_KEY:
             if (takeScreenshot()) {
-                flashTemporaryAlert("You take a new screenshot", 2000);
+                flashTemporaryAlert(" Screenshot saved in save directory ", 2000);
             }
             break;
         default:

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2598,7 +2598,7 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             break;
         case PRINTSCREEN_KEY:
             if (takeScreenshot()) {
-                flashTemporaryAlert("You take a new screenshot", 22000);
+                flashTemporaryAlert("You take a new screenshot", 2000);
             }
             break;
         default:

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2596,6 +2596,11 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
                 enableEasyMode();
             //}
             break;
+        case PRINTSCREEN_KEY:
+            if (takeScreenshot()) {
+                flashTemporaryAlert("You take a new screenshot", 22000);
+            }
+            break;
         default:
             break;
     }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1161,6 +1161,7 @@ enum tileFlags {
 #define NUMPAD_9            57
 #define PAGE_UP_KEY         63276
 #define PAGE_DOWN_KEY       63277
+#define PRINTSCREEN_KEY     '\054'
 
 #define UNKNOWN_KEY         (128+19)
 
@@ -2616,6 +2617,7 @@ extern "C" {
     void gameOver(char *killedBy, boolean useCustomPhrasing);
     void victory(boolean superVictory);
     void notifyEvent(short eventId, int data1, int data2, const char *str1, const char *str2);
+    boolean takeScreenshot();
     void enableEasyMode();
     int rand_range(int lowerBound, int upperBound);
     unsigned long seedRandomGenerator(unsigned long seed);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -99,6 +99,7 @@ typedef long long fixpt;
 #define GAME_SUFFIX             ".broguesave"
 #define ANNOTATION_SUFFIX       ".txt"
 #define RNG_LOG                 "RNGLog.txt"
+#define SCREENSHOT_SUFFIX       ".png"
 
 #define BROGUE_FILENAME_MAX     (min(1024*4, FILENAME_MAX))
 

--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -214,7 +214,7 @@ static void curses_notifyEvent(short eventId, int data1, int data2, const char *
     //Unused
 }
 
-static boolean _takeScreenshot() {
+static boolean curses_takeScreenshot() {
     return false;
 }
 
@@ -226,5 +226,5 @@ struct brogueConsole cursesConsole = {
     curses_remap,
     modifier_held,
     curses_notifyEvent,
-    _takeScreenshot
+    curses_takeScreenshot
 };

--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -214,6 +214,10 @@ static void curses_notifyEvent(short eventId, int data1, int data2, const char *
     //Unused
 }
 
+static boolean _takeScreenshot() {
+    return false;
+}
+
 struct brogueConsole cursesConsole = {
     gameLoop,
     curses_pauseForMilliseconds,
@@ -221,5 +225,6 @@ struct brogueConsole cursesConsole = {
     curses_plotChar,
     curses_remap,
     modifier_held,
-    curses_notifyEvent
+    curses_notifyEvent,
+    _takeScreenshot
 };

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -41,6 +41,11 @@ struct brogueConsole {
     Notifies the platform code of an event during the game - e.g. victory
     */
     void (*notifyEvent)(short eventId, int data1, int data2, const char *str1, const char *str2);
+
+    /*
+    Take a screenshot in current working directory
+    */
+    boolean (*takeScreeshot)();
 };
 
 // defined in platform

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -45,7 +45,7 @@ struct brogueConsole {
     /*
     Take a screenshot in current working directory
     */
-    boolean (*takeScreeshot)();
+    boolean (*takeScreenshot)();
 };
 
 // defined in platform

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -71,7 +71,11 @@ void notifyEvent(short eventId, int data1, int data2, const char *str1, const ch
 }
 
 boolean takeScreenshot() {
-    return currentConsole.takeScreeshot();
+    if (currentConsole.takeScreenshot) {
+        return currentConsole.takeScreenshot();
+    } else {
+        return false;
+    }
 }
 
 // creates an empty high scores file

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -70,6 +70,10 @@ void notifyEvent(short eventId, int data1, int data2, const char *str1, const ch
     currentConsole.notifyEvent(eventId, data1, data2, str1, str2);
 }
 
+boolean takeScreenshot() {
+    return currentConsole.takeScreeshot();
+}
+
 // creates an empty high scores file
 void initScores() {
     short i;

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -71,11 +71,7 @@ void notifyEvent(short eventId, int data1, int data2, const char *str1, const ch
 }
 
 boolean takeScreenshot() {
-    if (currentConsole.takeScreenshot) {
-        return currentConsole.takeScreenshot();
-    } else {
-        return false;
-    }
+    return currentConsole.takeScreenshot();
 }
 
 // creates an empty high scores file

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -236,6 +236,8 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
     SDL_Event event;
     boolean ret = false;
 
+    char screenshotFilepath[BROGUE_FILENAME_MAX];
+
     // ~ for (int i=0; i < 100 && SDL_PollEvent(&event); i++) {
     while (SDL_PollEvent(&event)) {
         if (event.type == SDL_QUIT) {
@@ -263,7 +265,15 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
                 SDL_SetWindowFullscreen(Win,
                     (SDL_GetWindowFlags(Win) & SDL_WINDOW_FULLSCREEN_DESKTOP) ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP);
                 refreshWindow();
+            } else if (key == SDLK_PRINTSCREEN) {
+                // Take screenshot in current working directory (ScreenshotN.png)
+                getAvailableFilePath(screenshotFilepath, "Screenshot", SCREENSHOT_SUFFIX);
+                strcat(screenshotFilepath, SCREENSHOT_SUFFIX);
+                if (WinSurf) {
+                    IMG_SavePNG(WinSurf, screenshotFilepath);
+                }
             }
+
 
             if (eventFromKey(returnEvent, key)) {
                 returnEvent->eventType = KEYSTROKE;

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -151,6 +151,9 @@ static boolean eventFromKey(rogueEvent *event, SDL_Keycode key) {
         case SDLK_TAB:
             event->param1 = TAB_KEY;
             return true;
+        case SDLK_PRINTSCREEN:
+            event->param1 = PRINTSCREEN_KEY;
+            return true;
     }
 
     /*
@@ -236,7 +239,6 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
     SDL_Event event;
     boolean ret = false;
 
-    char screenshotFilepath[BROGUE_FILENAME_MAX];
 
     // ~ for (int i=0; i < 100 && SDL_PollEvent(&event); i++) {
     while (SDL_PollEvent(&event)) {
@@ -265,15 +267,7 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
                 SDL_SetWindowFullscreen(Win,
                     (SDL_GetWindowFlags(Win) & SDL_WINDOW_FULLSCREEN_DESKTOP) ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP);
                 refreshWindow();
-            } else if (key == SDLK_PRINTSCREEN) {
-                // Take screenshot in current working directory (ScreenshotN.png)
-                getAvailableFilePath(screenshotFilepath, "Screenshot", SCREENSHOT_SUFFIX);
-                strcat(screenshotFilepath, SCREENSHOT_SUFFIX);
-                if (WinSurf) {
-                    IMG_SavePNG(WinSurf, screenshotFilepath);
-                }
-            }
-
+            } 
 
             if (eventFromKey(returnEvent, key)) {
                 returnEvent->eventType = KEYSTROKE;
@@ -497,6 +491,22 @@ static void _notifyEvent(short eventId, int data1, int data2, const char *str1, 
     //Unused
 }
 
+/*
+ * Take screenshot in current working directory (ScreenshotN.png)
+ */
+static boolean _takeScreenshot() {
+    char screenshotFilepath[BROGUE_FILENAME_MAX];
+
+    getAvailableFilePath(screenshotFilepath, "Screenshot", SCREENSHOT_SUFFIX);
+    strcat(screenshotFilepath, SCREENSHOT_SUFFIX);
+
+    if (WinSurf) {
+        IMG_SavePNG(WinSurf, screenshotFilepath);
+        return true;
+    }
+    return false;
+}
+
 struct brogueConsole sdlConsole = {
     _gameLoop,
     _pauseForMilliseconds,
@@ -504,5 +514,6 @@ struct brogueConsole sdlConsole = {
     _plotChar,
     _remap,
     _modifierHeld,
-    _notifyEvent
+    _notifyEvent,
+    _takeScreenshot
 };

--- a/src/platform/web-platform.c
+++ b/src/platform/web-platform.c
@@ -320,7 +320,7 @@ static void web_notifyEvent(short eventId, int data1, int data2, const char *str
     flushOutputBuffer();
 }
 
-static boolean _takeScreenshot() {
+static boolean web_takeScreenshot() {
     return false;
 }
 
@@ -332,5 +332,5 @@ struct brogueConsole webConsole = {
     web_remap,
     web_modifierHeld,
     web_notifyEvent,
-    _takeScreenshot
+    web_takeScreenshot
 };

--- a/src/platform/web-platform.c
+++ b/src/platform/web-platform.c
@@ -320,6 +320,10 @@ static void web_notifyEvent(short eventId, int data1, int data2, const char *str
     flushOutputBuffer();
 }
 
+static boolean _takeScreenshot() {
+    return false;
+}
+
 struct brogueConsole webConsole = {
     gameLoop,
     web_pauseForMilliseconds,
@@ -327,5 +331,6 @@ struct brogueConsole webConsole = {
     web_plotChar,
     web_remap,
     web_modifierHeld,
-    web_notifyEvent
+    web_notifyEvent,
+    _takeScreenshot
 };


### PR DESCRIPTION
The file is save in current working directory in PNG format. With different number if screenshots already exists ("Screenshot N.png").

In response to https://github.com/tmewett/BrogueCE/issues/65