### PR TITLE
Allowing numpad 5 (center) to confirm target

### DIFF
--- a/changes/confirm-target-with-numpad5.md
+++ b/changes/confirm-target-with-numpad5.md
@@ -1,0 +1,1 @@
+Numpad 5 (center) can be used to confirm targetting

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5150,6 +5150,7 @@ boolean moveCursor(boolean *targetConfirmed,
                     *tabKey = true;
                     break;
                 case RETURN_KEY:
+                case NUMPAD_5:
                     *targetConfirmed = true;
                     break;
                 case ESCAPE_KEY:


### PR DESCRIPTION
This change means the right hand does not need to leave the numpad when targetting. 
Numpad 5 is rest when not targetting and has no other existing function when targetting.
The change is also useful for web-brogue since web-brogue supports a d-pad that simulates the numpad.