### PR TITLE
Add dar priestess to mage class

### DIFF
--- a/changes/mage-class-update.md
+++ b/changes/mage-class-update.md
@@ -1,0 +1,3 @@
+Dar Priestesses are now included in the 'Mage' monster class. A weapon of mage
+slaying will instantly kill them. And armor of mage immunity will provide
+invulnerability to their feeble attacks.

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -2175,7 +2175,7 @@ const monsterClass monsterClassCatalog[MONSTER_CLASS_COUNT] = {
     {"jelly",           10,         15,         {MK_PINK_JELLY, MK_BLACK_JELLY, MK_ACID_JELLY}},
     {"turret",          5,          18,         {MK_ARROW_TURRET, MK_SPARK_TURRET, MK_DART_TURRET, MK_FLAME_TURRET}},
     {"infernal",        10,         -1,         {MK_FLAMEDANCER, MK_IMP, MK_REVENANT, MK_FURY, MK_PHANTOM, MK_IFRIT}},
-    {"mage",            10,         -1,         {MK_GOBLIN_CONJURER, MK_GOBLIN_MYSTIC, MK_OGRE_SHAMAN, MK_DAR_BATTLEMAGE, MK_PIXIE, MK_LICH}},
+    {"mage",            10,         -1,         {MK_GOBLIN_CONJURER, MK_GOBLIN_MYSTIC, MK_OGRE_SHAMAN, MK_DAR_PRIESTESS, MK_DAR_BATTLEMAGE, MK_PIXIE, MK_LICH}},
     {"waterborne",      10,         17,         {MK_EEL, MK_NAGA, MK_KRAKEN}},
     {"airborne",        10,         15,         {MK_VAMPIRE_BAT, MK_WILL_O_THE_WISP, MK_PIXIE, MK_PHANTOM, MK_FURY, MK_IFRIT, MK_PHOENIX}},
     {"fireborne",       10,         12,         {MK_WILL_O_THE_WISP, MK_SALAMANDER, MK_FLAMEDANCER, MK_PHOENIX}},


### PR DESCRIPTION
Dar Priestesses weren't included under mages in monster class
Editted monsterClassCatalog to fix that

I checked with seed 2170 that the item description is displaying correctly:
![Axe of mage slaying](https://user-images.githubusercontent.com/24632356/89375199-31be3980-d6bb-11ea-92a6-e8f3b3b5e8e3.png)

Let me know if I need to do anything else, I'm a little rusty on git, and super experienced with it to begin with.