### PR TITLE
Prevent Alt + Enter fullscreen from affecting game

### DIFF
--- a/changes/fix-alt-enter-fullscreen.md
+++ b/changes/fix-alt-enter-fullscreen.md
@@ -1,0 +1,1 @@
+Prevented Alt + Enter fullscreen from causing an Enter input in-game

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -276,6 +276,7 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
                 SDL_SetWindowFullscreen(Win,
                     (SDL_GetWindowFlags(Win) & SDL_WINDOW_FULLSCREEN_DESKTOP) ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP);
                 refreshWindow();
+                return false;
             }
 
             if (eventFromKey(returnEvent, key)) {

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -276,7 +276,7 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
                 SDL_SetWindowFullscreen(Win,
                     (SDL_GetWindowFlags(Win) & SDL_WINDOW_FULLSCREEN_DESKTOP) ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP);
                 refreshWindow();
-                return false;
+                continue;
             }
 
             if (eventFromKey(returnEvent, key)) {


### PR DESCRIPTION
Using Alt + Enter for fullscreen used to affect gameplay; it no longer does.