### PR TITLE
Allow taking control of the player during playback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ endif
 
 ifeq ($(DEBUG),YES)
 	cflags += -g
+	cppflags += -DENABLE_PLAYBACK_SWITCH
 else
 	cflags += -O2
 endif

--- a/changes/allow-recording-switch-to-play.md
+++ b/changes/allow-recording-switch-to-play.md
@@ -1,0 +1,1 @@
+Allow the player to take control of recordings in debug mode

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -205,6 +205,19 @@ short actionMenu(short x, boolean playingBack) {
         buttonCount = 0;
 
         if (playingBack) {
+#ifdef ENABLE_PLAYBACK_SWITCH
+            if (KEYBOARD_LABELS) {
+                sprintf(buttons[buttonCount].text,  "  %sP: %sPlay from here  ", yellowColorEscape, whiteColorEscape);
+            } else {
+                strcpy(buttons[buttonCount].text, "  Play from here  ");
+            }
+            buttons[buttonCount].hotkey[0] = SWITCH_TO_PLAYING_KEY;
+            buttonCount++;
+
+            sprintf(buttons[buttonCount].text, "    %s---", darkGrayColorEscape);
+            buttons[buttonCount].flags &= ~B_ENABLED;
+            buttonCount++;
+#endif
             if (KEYBOARD_LABELS) {
                 sprintf(buttons[buttonCount].text,  "  %sk: %sFaster playback  ", yellowColorEscape, whiteColorEscape);
             } else {
@@ -808,6 +821,13 @@ void mainInputLoop() {
             if (playingBack) {
                 rogue.playbackMode = true;
                 executePlaybackInput(&theEvent);
+#ifdef ENABLE_PLAYBACK_SWITCH
+                if (!rogue.playbackMode) {
+                    // Playback mode is off, user must have taken control
+                    // Redraw buttons to reflect that
+                    initializeMenuButtons(&state, buttons);
+                }
+#endif
                 playingBack = rogue.playbackMode;
                 rogue.playbackMode = false;
             } else {

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -842,7 +842,13 @@ void mainBrogueJunction() {
                             rogue.playbackPaused = false;
                             pausePlayback();
                         }
-
+#ifdef ENABLE_PLAYBACK_SWITCH
+                        // We are coming from the end of a recording the user has taken over.
+                        // No more event checks, that has already been handled
+                        if (rogue.gameHasEnded) {
+                            break;
+                        }
+#endif
                         rogue.RNG = RNG_COSMETIC; // dancing terrain colors can't influence recordings
                         rogue.playbackBetweenTurns = true;
                         nextBrogueEvent(&theEvent, false, true, false);
@@ -878,4 +884,3 @@ void mainBrogueJunction() {
         }
     } while (rogue.nextGame != NG_QUIT);
 }
-

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -953,6 +953,15 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                 //rogue.playbackMode = true;
                 printSeed();
                 return true;
+            case SWITCH_TO_PLAYING_KEY:
+#ifdef ENABLE_PLAYBACK_SWITCH
+                    if (!rogue.gameHasEnded && !rogue.playbackOOS) {
+                        switchToPlaying();
+                        lengthOfPlaybackFile = recordingLocation;
+                    }
+                    return true;
+#endif
+                return false;
             default:
                 if (key >= '0' && key <= '9'
                     || key >= NUMPAD_0 && key <= NUMPAD_9) {
@@ -1114,9 +1123,10 @@ void switchToPlaying() {
     rogue.playbackOmniscience   = false;
     locationInRecordingBuffer   = 0;
     copyFile(currentFilePath, lastGamePath, recordingLocation);
-
-#ifdef DELETE_SAVE_FILE_AFTER_LOADING
-    remove(currentFilePath);
+#ifndef ENABLE_PLAYBACK_SWITCH
+    if (DELETE_SAVE_FILE_AFTER_LOADING) {
+        remove(currentFilePath);
+    }
 #endif
 
     strcpy(currentFilePath, lastGamePath);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1117,6 +1117,7 @@ enum tileFlags {
 #define SAVE_GAME_KEY       'S'
 #define NEW_GAME_KEY        'N'
 #define GRAPHICS_KEY        'G'
+#define SWITCH_TO_PLAYING_KEY 'P'
 #define NUMPAD_0            48
 #define NUMPAD_1            49
 #define NUMPAD_2            50
@@ -3107,6 +3108,7 @@ extern "C" {
     void pausePlayback();
     void displayAnnotation();
     void loadSavedGame();
+    void switchToPlaying();
     void recordKeystroke(int keystroke, boolean controlKey, boolean shiftKey);
     void recordKeystrokeSequence(unsigned char *commandSequence);
     void recordMouseClick(short x, short y, boolean controlKey, boolean shiftKey);


### PR DESCRIPTION
If DEBUG is defined in config.mk, pressing 'P' during a recording
hands control over to the player indefinitely, allowing for more
extensive debugging. Switching conserves the old recording, and creates
a new one from the player's inputs.