### PR TITLE
Extend seeding to 64 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,7 @@ Other changes
   The sidebar now displays whether a monster is carrying an item
 -
   The maximum seed able to be input in the main menu is now the same on
-  all platforms (2^64 - 1 = 18446744073709551615)
+  all platforms (2^32 - 1 = 4294967295)
 -
   Added a `--print-seed-catalog` command line option to recreate the seed
   catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,7 +267,7 @@ Other changes
   The sidebar now displays whether a monster is carrying an item
 -
   The maximum seed able to be input in the main menu is now the same on
-  all platforms (2^32 - 1 = 4294967295)
+  all platforms (2^64 - 1 = 18446744073709551615)
 -
   Added a `--print-seed-catalog` command line option to recreate the seed
   catalog

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -67,7 +67,7 @@ unsigned long lengthOfPlaybackFile;
 unsigned long recordingLocation;
 unsigned long maxLevelChanges;
 char annotationPathname[BROGUE_FILENAME_MAX];   // pathname of annotation file
-unsigned long previousGameSeed;
+uint64_t previousGameSeed;
 
 //                                  Red     Green   Blue    RedRand GreenRand   BlueRand    Rand    Dances?
 // basic colors

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4132,7 +4132,7 @@ void displayGrid(short **map) {
 
 void printSeed() {
     char buf[COLS];
-    sprintf(buf, "Dungeon seed #%lu; turn #%lu; version %s", rogue.seed, rogue.playerTurnNumber, BROGUE_VERSION_STRING);
+    sprintf(buf, "Dungeon seed #%llu; turn #%lu; version %s", (long long unsigned)rogue.seed, rogue.playerTurnNumber, BROGUE_VERSION_STRING);
     message(buf, false);
 }
 

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4132,7 +4132,7 @@ void displayGrid(short **map) {
 
 void printSeed() {
     char buf[COLS];
-    sprintf(buf, "Dungeon seed #%llu; turn #%lu; version %s", (long long unsigned)rogue.seed, rogue.playerTurnNumber, BROGUE_VERSION_STRING);
+    sprintf(buf, "Dungeon seed #%llu; turn #%lu; version %s", (unsigned long long)rogue.seed, rogue.playerTurnNumber, BROGUE_VERSION_STRING);
     message(buf, false);
 }
 

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -67,7 +67,7 @@ extern unsigned long lengthOfPlaybackFile;
 extern unsigned long recordingLocation;
 extern unsigned long maxLevelChanges;
 extern char annotationPathname[BROGUE_FILENAME_MAX];    // pathname of annotation file
-extern unsigned long previousGameSeed;
+extern uint64_t previousGameSeed;
 
 // basic colors
 extern color white;

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -636,8 +636,8 @@ void scumMonster(creature *monst) {
     }
 }
 
-void scum(unsigned long startingSeed, short numberOfSeedsToScan, short scanThroughDepth) {
-    unsigned long theSeed;
+void scum(uint64_t startingSeed, short numberOfSeedsToScan, short scanThroughDepth) {
+    uint64_t theSeed;
     char path[BROGUE_FILENAME_MAX];
     item *theItem;
     creature *monst;
@@ -648,11 +648,13 @@ void scum(unsigned long startingSeed, short numberOfSeedsToScan, short scanThrou
     getAvailableFilePath(path, LAST_GAME_NAME, GAME_SUFFIX);
     strcat(path, GAME_SUFFIX);
 
-    printf("Brogue seed catalog, seeds %li to %li, through depth %i.\n\n\
+    printf("Brogue seed catalog, seeds %llu to %llu, through depth %i.\n\n\
 To play one of these seeds, press control-N from the title screen \
 and enter the seed number. Knowing which items will appear on \
 the first %i depths will, of course, make the game significantly easier.",
-            startingSeed, startingSeed + numberOfSeedsToScan - 1, scanThroughDepth, scanThroughDepth);
+            (long long unsigned)startingSeed,
+            (long long unsigned)(startingSeed + numberOfSeedsToScan - 1),
+            scanThroughDepth, scanThroughDepth);
 
     for (theSeed = startingSeed; theSeed < startingSeed + numberOfSeedsToScan; theSeed++) {
         printf("\n\nSeed %li:", theSeed);
@@ -703,7 +705,7 @@ the first %i depths will, of course, make the game significantly easier.",
 void mainBrogueJunction() {
     rogueEvent theEvent;
     char path[BROGUE_FILENAME_MAX], buf[100], seedDefault[100];
-    char *maxSeed = "4294967295"; // 2^32 - 1
+    char *maxSeed = "18446744073709551615"; // 2^64 - 1
     short i, j, k;
     boolean seedTooBig;
 
@@ -750,7 +752,7 @@ void mainBrogueJunction() {
                         if (previousGameSeed == 0) {
                             seedDefault[0] = '\0';
                         } else {
-                            sprintf(seedDefault, "%lu", previousGameSeed);
+                            sprintf(seedDefault, "%llu", (long long unsigned)previousGameSeed);
                         }
                         if (getInputTextString(buf, "Generate dungeon with seed number:",
                                                strlen(maxSeed),
@@ -770,7 +772,7 @@ void mainBrogueJunction() {
                                     }
                                 }
                             }
-                            sscanf(seedTooBig ? maxSeed : buf, "%lu", &rogue.nextGameSeed);
+                            rogue.nextGameSeed = decimalToU64(seedTooBig ? maxSeed : buf);
                         } else {
                             rogue.nextGame = NG_NOTHING;
                             break; // Don't start a new game after all.

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -652,8 +652,8 @@ void scum(uint64_t startingSeed, short numberOfSeedsToScan, short scanThroughDep
 To play one of these seeds, press control-N from the title screen \
 and enter the seed number. Knowing which items will appear on \
 the first %i depths will, of course, make the game significantly easier.",
-            (long long unsigned)startingSeed,
-            (long long unsigned)(startingSeed + numberOfSeedsToScan - 1),
+            (unsigned long long)startingSeed,
+            (unsigned long long)(startingSeed + numberOfSeedsToScan - 1),
             scanThroughDepth, scanThroughDepth);
 
     for (theSeed = startingSeed; theSeed < startingSeed + numberOfSeedsToScan; theSeed++) {
@@ -705,9 +705,7 @@ the first %i depths will, of course, make the game significantly easier.",
 void mainBrogueJunction() {
     rogueEvent theEvent;
     char path[BROGUE_FILENAME_MAX], buf[100], seedDefault[100];
-    char *maxSeed = "18446744073709551615"; // 2^64 - 1
     short i, j, k;
-    boolean seedTooBig;
 
     // clear screen and display buffer
     for (i=0; i<COLS; i++) {
@@ -752,27 +750,19 @@ void mainBrogueJunction() {
                         if (previousGameSeed == 0) {
                             seedDefault[0] = '\0';
                         } else {
-                            sprintf(seedDefault, "%llu", (long long unsigned)previousGameSeed);
+                            sprintf(seedDefault, "%llu", (unsigned long long)previousGameSeed);
                         }
                         if (getInputTextString(buf, "Generate dungeon with seed number:",
-                                               strlen(maxSeed),
+                                               20, // length of "18446744073709551615" (2^64 - 1)
                                                seedDefault,
                                                "",
                                                TEXT_INPUT_NUMBERS,
                                                true)
                             && buf[0] != '\0') {
-                            seedTooBig = false;
-                            if (strlen(buf) == strlen(maxSeed)) {
-                                for (i=0; maxSeed[i]; i++) {
-                                    if (maxSeed[i] > buf[i]) {
-                                        break; // we're good
-                                    } else if (maxSeed[i] < buf[i]) {
-                                        seedTooBig = true;
-                                        break;
-                                    }
-                                }
+                            if (!tryParseUint64(buf, &rogue.nextGameSeed)) {
+                                // seed is too large, default to the largest possible seed
+                                rogue.nextGameSeed = 18446744073709551615ULL;
                             }
-                            rogue.nextGameSeed = decimalToU64(seedTooBig ? maxSeed : buf);
                         } else {
                             rogue.nextGame = NG_NOTHING;
                             break; // Don't start a new game after all.

--- a/src/brogue/Math.c
+++ b/src/brogue/Math.c
@@ -165,6 +165,15 @@ int rand_range(int lowerBound, int upperBound) {
 }
 #endif
 
+uint64_t rand_64bits() {
+    if (rogue.RNG == RNG_SUBSTANTIVE) {
+        randomNumbersGenerated++;
+    }
+    uint64_t hi = ranval(&(RNGState[rogue.RNG]));
+    uint64_t lo = ranval(&(RNGState[rogue.RNG]));
+    return (hi << 32) | lo;
+}
+
 // seeds with the time if called with a parameter of 0; returns the seed regardless.
 // All RNGs are seeded simultaneously and identically.
 uint64_t seedRandomGenerator(uint64_t seed) {

--- a/src/brogue/Math.c
+++ b/src/brogue/Math.c
@@ -170,12 +170,6 @@ int rand_range(int lowerBound, int upperBound) {
 uint64_t seedRandomGenerator(uint64_t seed) {
     if (seed == 0) {
         seed = (uint64_t) time(NULL) - 1352700000;
-        // bit mixing (from MurmurHash3)
-        seed ^= seed >> 33;
-        seed *= 0xff51afd7ed558ccd;
-        seed ^= seed >> 33;
-        seed *= 0xc4ceb9fe1a85ec53;
-        seed ^= seed >> 33;
     }
     raninit(&(RNGState[RNG_SUBSTANTIVE]), seed);
     raninit(&(RNGState[RNG_COSMETIC]), seed);

--- a/src/brogue/Math.c
+++ b/src/brogue/Math.c
@@ -98,9 +98,10 @@ u4 ranval( ranctx *x ) {
     return x->d;
 }
 
-void raninit( ranctx *x, u4 seed ) {
+void raninit( ranctx *x, uint64_t seed ) {
     u4 i;
-    x->a = 0xf1ea5eed, x->b = x->c = x->d = seed;
+    x->a = 0xf1ea5eed, x->b = x->c = x->d = (u4)seed;
+    x->c ^= (u4)(seed >> 32);
     for (i=0; i<20; ++i) {
         (void)ranval(x);
     }
@@ -166,9 +167,15 @@ int rand_range(int lowerBound, int upperBound) {
 
 // seeds with the time if called with a parameter of 0; returns the seed regardless.
 // All RNGs are seeded simultaneously and identically.
-unsigned long seedRandomGenerator(unsigned long seed) {
+uint64_t seedRandomGenerator(uint64_t seed) {
     if (seed == 0) {
-        seed = (unsigned long) time(NULL) - 1352700000;
+        seed = (uint64_t) time(NULL) - 1352700000;
+        // bit mixing (from MurmurHash3)
+        seed ^= seed >> 33;
+        seed *= 0xff51afd7ed558ccd;
+        seed ^= seed >> 33;
+        seed *= 0xc4ceb9fe1a85ec53;
+        seed ^= seed >> 33;
     }
     raninit(&(RNGState[RNG_SUBSTANTIVE]), seed);
     raninit(&(RNGState[RNG_COSMETIC]), seed);

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -26,7 +26,7 @@
 #include "Rogue.h"
 #include "IncludeGlobals.h"
 
-#define RECORDING_HEADER_LENGTH     32  // bytes at the start of the recording file to store global data
+#define RECORDING_HEADER_LENGTH     36  // bytes at the start of the recording file to store global data
 
 static const int keystrokeTable[] = {UP_ARROW, LEFT_ARROW, DOWN_ARROW, RIGHT_ARROW,
     ESCAPE_KEY, RETURN_KEY, DELETE_KEY, TAB_KEY, NUMPAD_0, NUMPAD_1,
@@ -175,8 +175,8 @@ void writeHeaderInfo(char *path) {
         c[i] = BROGUE_RECORDING_VERSION_STRING[i];
     }
     i = 16;
-    numberToString(rogue.seed, 4, &c[i]);
-    i += 4;
+    numberToString(rogue.seed, 8, &c[i]);
+    i += 8;
     numberToString(rogue.playerTurnNumber, 4, &c[i]);
     i += 4;
     numberToString(rogue.deepestLevel, 4, &c[i]);
@@ -480,7 +480,7 @@ void initRecording() {
             rogue.playbackOOS = false;
             rogue.gameHasEnded = true;
         }
-        rogue.seed              = recallNumber(4);          // master random seed
+        rogue.seed              = recallNumber(8);          // master random seed
         rogue.howManyTurns      = recallNumber(4);          // how many turns are in this recording
         maxLevelChanges         = recallNumber(4);          // how many times the player changes depths
         lengthOfPlaybackFile    = recallNumber(4);
@@ -1244,7 +1244,8 @@ boolean selectFile(char *prompt, char *defaultName, char *suffix) {
 
 void parseFile() {
     FILE *descriptionFile;
-    unsigned long oldFileLoc, oldRecLoc, oldLength, oldBufLoc, i, seed, numTurns, numDepths, fileLength, startLoc;
+    unsigned long oldFileLoc, oldRecLoc, oldLength, oldBufLoc, i, numTurns, numDepths, fileLength, startLoc;
+    uint64_t seed;
     unsigned char c;
     char description[1000], versionString[500];
     short x, y;
@@ -1268,7 +1269,7 @@ void parseFile() {
             versionString[i] = recallChar();
         }
 
-        seed        = recallNumber(4);
+        seed        = recallNumber(8);
         numTurns    = recallNumber(4);
         numDepths   = recallNumber(4);
         fileLength  = recallNumber(4);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2588,7 +2588,7 @@ extern "C" {
     void gameOver(char *killedBy, boolean useCustomPhrasing);
     void victory(boolean superVictory);
     void enableEasyMode();
-    int tryParseUint64(char *str, uint64_t *num);
+    boolean tryParseUint64(char *str, uint64_t *num);
     uint64_t rand_64bits();
     int rand_range(int lowerBound, int upperBound);
     uint64_t seedRandomGenerator(uint64_t seed);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2206,7 +2206,7 @@ typedef struct playerCharacter {
     boolean trueColorMode;              // whether lighting effects are disabled
     boolean displayAggroRangeMode;      // whether your stealth range is displayed
     boolean quit;                       // to skip the typical end-game theatrics when the player quits
-    unsigned long seed;                 // the master seed for generating the entire dungeon
+    uint64_t seed;                      // the master seed for generating the entire dungeon
     short RNG;                          // which RNG are we currently using?
     unsigned long gold;                 // how much gold we have
     unsigned long goldGenerated;        // how much gold has been generated on the levels, not counting gold held by monsters
@@ -2299,7 +2299,7 @@ typedef struct playerCharacter {
     // What do you want to do, player -- play, play with seed, resume, recording, high scores or quit?
     enum NGCommands nextGame;
     char nextGamePath[BROGUE_FILENAME_MAX];
-    unsigned long nextGameSeed;
+    uint64_t nextGameSeed;
 } playerCharacter;
 
 // Stores the necessary info about a level so it can be regenerated:
@@ -2310,7 +2310,7 @@ typedef struct levelData {
     struct creature *monsters;
     struct creature *dormantMonsters;
     short **scentMap;
-    unsigned long levelSeed;
+    uint64_t levelSeed;
     short upStairsLoc[2];
     short downStairsLoc[2];
     short playerExitedVia[2];
@@ -2584,12 +2584,13 @@ extern "C" {
     boolean fileExists(const char *pathname);
     boolean chooseFile(char *path, char *prompt, char *defaultName, char *suffix);
     boolean openFile(const char *path);
-    void initializeRogue(unsigned long seed);
+    void initializeRogue(uint64_t seed);
     void gameOver(char *killedBy, boolean useCustomPhrasing);
     void victory(boolean superVictory);
     void enableEasyMode();
+    uint64_t decimalToU64(char *s);
     int rand_range(int lowerBound, int upperBound);
-    unsigned long seedRandomGenerator(unsigned long seed);
+    uint64_t seedRandomGenerator(uint64_t seed);
     short randClumpedRange(short lowerBound, short upperBound, short clumpFactor);
     short randClump(randomRange theRange);
     boolean rand_percent(short percent);
@@ -2655,7 +2656,7 @@ extern "C" {
     short getHighScoresList(rogueHighScoresEntry returnList[HIGH_SCORES_COUNT]);
     boolean saveHighScore(rogueHighScoresEntry theEntry);
     fileEntry *listFiles(short *fileCount, char **dynamicMemoryBuffer);
-    void initializeLaunchArguments(enum NGCommands *command, char *path, unsigned long *seed);
+    void initializeLaunchArguments(enum NGCommands *command, char *path, uint64_t *seed);
 
     char nextKeyPress(boolean textInput);
     void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2589,6 +2589,7 @@ extern "C" {
     void victory(boolean superVictory);
     void enableEasyMode();
     int tryParseUint64(char *str, uint64_t *num);
+    uint64_t rand_64bits();
     int rand_range(int lowerBound, int upperBound);
     uint64_t seedRandomGenerator(uint64_t seed);
     short randClumpedRange(short lowerBound, short upperBound, short clumpFactor);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2588,7 +2588,7 @@ extern "C" {
     void gameOver(char *killedBy, boolean useCustomPhrasing);
     void victory(boolean superVictory);
     void enableEasyMode();
-    uint64_t decimalToU64(char *s);
+    int tryParseUint64(char *str, uint64_t *num);
     int rand_range(int lowerBound, int upperBound);
     uint64_t seedRandomGenerator(uint64_t seed);
     short randClumpedRange(short lowerBound, short upperBound, short clumpFactor);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -185,12 +185,17 @@ void initializeRogue(uint64_t seed) {
 
     // initialize the levels list
     for (i=0; i<DEEPEST_LEVEL+1; i++) {
-        do {
-            levels[i].levelSeed
-                =  (uint64_t)rand_range(0, 4194303)         // 22 bits +
-                ^ ((uint64_t)rand_range(0, 4194303) << 22)  // 22 bits +
-                ^ ((uint64_t)rand_range(0, 1048575) << 44); // 20 bits = 64 bits
-        } while (levels[i].levelSeed == 0);
+        if (rogue.seed >> 32) {
+            // generate a 64-bit seed
+            levels[i].levelSeed = rand_64bits();
+        } else {
+            // backward-compatible seed
+            levels[i].levelSeed = (unsigned long) rand_range(0, 9999);
+            levels[i].levelSeed += (unsigned long) 10000 * rand_range(0, 9999);
+        }
+        if (levels[i].levelSeed == 0) { // seed 0 is not acceptable
+            levels[i].levelSeed = i + 1;
+        }
         levels[i].monsters = NULL;
         levels[i].dormantMonsters = NULL;
         levels[i].items = NULL;
@@ -623,10 +628,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
         // generate a seed from the current RNG state
         do {
-            oldSeed
-                =  (uint64_t)rand_range(0, 4194303)         // 22 bits +
-                ^ ((uint64_t)rand_range(0, 4194303) << 22)  // 22 bits +
-                ^ ((uint64_t)rand_range(0, 1048575) << 44); // 20 bits = 64 bits
+            oldSeed = rand_64bits();
         } while (oldSeed == 0);
 
         // generate new level

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -57,7 +57,7 @@ static void badArgument(const char *arg) {
     printCommandlineHelp();
 }
 
-int tryParseUint64(char *str, uint64_t *num) {
+boolean tryParseUint64(char *str, uint64_t *num) {
     unsigned long long n;
     char buf[100];
     if (strlen(str)                 // we need some input
@@ -65,9 +65,9 @@ int tryParseUint64(char *str, uint64_t *num) {
         && sprintf(buf, "%llu", n)  // convert back to string
         && !strcmp(buf, str)) {     // compare (we need them equal)
         *num = (uint64_t)n;
-        return 1; // success
+        return true; // success
     } else {
-        return 0; // input was too large or not a decimal number
+        return false; // input was too large or not a decimal number
     }
 }
 

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -57,6 +57,18 @@ static void badArgument(const char *arg) {
     printCommandlineHelp();
 }
 
+uint64_t decimalToU64(char *s) {
+    uint64_t n = 0;
+    while (*s) {
+        char c = *s;
+        if (c >= '0' && c <= '9') {
+            n = n * 10 + (c - '0');
+        }
+        s++;
+    }
+    return n;
+}
+
 int main(int argc, char *argv[])
 {
 
@@ -75,7 +87,7 @@ int main(int argc, char *argv[])
     currentConsole = sdlConsole;
 #elif BROGUE_WEB
     currentConsole = webConsole;
-#else
+#elif BROGUE_CURSES
     currentConsole = cursesConsole;
 #endif
 
@@ -97,13 +109,15 @@ int main(int argc, char *argv[])
         if (strcmp(argv[i], "--seed") == 0 || strcmp(argv[i], "-s") == 0) {
             // pick a seed!
             if (i + 1 < argc) {
-                unsigned int seed = atof(argv[i + 1]); // plenty of precision in a double, and simpler than any other option
+                uint64_t seed = decimalToU64(argv[i + 1]);
+
                 if (seed != 0) {
-                    i++;
                     rogue.nextGameSeed = seed;
                     rogue.nextGame = NG_NEW_GAME_WITH_SEED;
-                    continue;
                 }
+
+                i++;
+                continue;
             }
         }
 

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -553,7 +553,7 @@ fileEntry *listFiles(short *fileCount, char **namebuffer) {
 
 // end of file listing
 
-void initializeLaunchArguments(enum NGCommands *command, char *path, unsigned long *seed) {
+void initializeLaunchArguments(enum NGCommands *command, char *path, uint64_t *seed) {
     // we've actually already done this at this point, except for the seed.
 }
 


### PR DESCRIPTION
This patch allows 64-bit seeds, extending the number of possible unique games from 4 billions to 18 quintillions.

It also fixes a bug with level seeding: before the patch, each level had a one in 100,000,000 chance of being seeded with the time when the player enters it (seed 0). Recordings of such games cannot be replayed, because the time when the level is replayed and the time when the player entered it are not the same. The patch ensures that level seeds are non-zero.

New games are still seeded using the system time, so 2 people starting a game at the same time will play the same dungeon. I'd like to use 64 bits of entropy, but this would require platform-specific code (e.g urandom) and I didn't want to open Pandora's box.

For seeds with 32 bits or fewer, the resulting dungeons are identical to prior versions. Recordings are not backward compatible though, because the header has been adjusted to store bigger seeds.