### PR TITLE
Use platform directives consistently

### DIFF
--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
     currentConsole = sdlConsole;
 #elif BROGUE_WEB
     currentConsole = webConsole;
-#else
+#elif BROGUE_CURSES
     currentConsole = cursesConsole;
 #endif
 


### PR DESCRIPTION
VS Code complains that `cursesConsole` struct is undefined when none of the three platform symbols is defined.

The error has no effect in practice because the game is always compiled with exactly 1 symbol defined (it wouldn't compile otherwise) but the VS Code highlight is annoying.