### PR TITLE
Enhance the seed catalog

### DIFF
--- a/changes/enhanced-seed-catalog.md
+++ b/changes/enhanced-seed-catalog.md
@@ -1,0 +1,4 @@
+The seed catalog now contains more information, including items carried by 
+monsters, legendary allies, resurrection altars, and commutation altars.
+Also, gold is aggregated per level, shackled vs. caged status is displayed 
+for captive allies, and keys show which vault they will open. 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1629,6 +1629,40 @@ void itemName(item *theItem, char *root, boolean includeDetails, boolean include
     return;
 }
 
+void seedCatalogItemName(item *theItem, char *name, creature *theMonster) {
+    char buf[500] = "", monster[128] = "", location[36] = "", usageLocation[36] = "";
+
+    itemName(theItem, buf, true, true, NULL);
+
+    //monster
+    if (theMonster != NULL) {
+        sprintf(monster, " (%s)", theMonster->info.monsterName);
+    }
+
+    //location
+    if (pmap[theItem->xLoc][theItem->yLoc].machineNumber > 0) {
+        //not all machines are "vaults" so we need to exclude some.
+        if (pmap[theItem->xLoc][theItem->yLoc].layers[0] != ALTAR_SWITCH
+            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != ALTAR_SWITCH_RETRACTING
+            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != ALTAR_CAGE_RETRACTABLE
+            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != ALTAR_INERT
+            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != AMULET_SWITCH
+            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != FLOOR) {
+
+            sprintf(location, " (vault %i)", pmap[theItem->xLoc][theItem->yLoc].machineNumber);
+        }
+    }
+
+    //usage location
+    if (theItem->category == KEY && theItem->kind == KEY_DOOR) {
+        sprintf(usageLocation, " (opens vault %i)", pmap[theItem->keyLoc[0].x][theItem->keyLoc[0].y].machineNumber - 1);
+    }
+
+    upperCase(buf);
+    sprintf(name, "%s%s%s%s", buf, monster, location, usageLocation);
+    return;
+}
+
 // kindCount is optional
 itemTable *tableForItemCategory(enum itemCategory theCat, short *kindCount) {
     itemTable *returnedTable;

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -617,31 +617,95 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
     }
 }
 
-void scumMonster(creature *monst) {
-    char buf[500];
-    if (monst->bookkeepingFlags & MB_CAPTIVE) {
-        monsterName(buf, monst, false);
-        upperCase(buf);
-        printf("\n        %s (captive)", buf);
-        if (monst->machineHome > 0) {
-            printf(" (vault %i)", monst->machineHome);
+void printSeedCatalogMonsters(boolean includeAll) {
+    creature *theMonster;
+    char name[500];
+
+    for (theMonster = monsters->nextCreature; theMonster != NULL; theMonster = theMonster->nextCreature) {
+        seedCatalogMonsterName(name, theMonster);
+        upperCase(name);
+        if (theMonster->bookkeepingFlags & MB_CAPTIVE || theMonster->creatureState == MONSTER_ALLY || includeAll) {
+            printf("        %s\n", name);
         }
-    } else if (monst->creatureState == MONSTER_ALLY) {
-        monsterName(buf, monst, false);
-        upperCase(buf);
-        printf("\n        %s (allied)", buf);
-        if (monst->machineHome) {
-            printf(" (vault %i)", monst->machineHome);
+    }
+
+    for (theMonster = dormantMonsters->nextCreature; theMonster != NULL; theMonster = theMonster->nextCreature) {
+        seedCatalogMonsterName(name, theMonster);
+        upperCase(name);
+        if (theMonster->bookkeepingFlags & MB_CAPTIVE || theMonster->creatureState == MONSTER_ALLY || includeAll) {
+            printf("        %s\n", name);
         }
     }
 }
 
-void scum(unsigned long startingSeed, short numberOfSeedsToScan, short scanThroughDepth) {
+void printSeedCatalogMonsterItems() {
+    creature *theMonster;
+    char name[500];
+
+    for (theMonster = monsters->nextCreature; theMonster != NULL; theMonster = theMonster->nextCreature) {
+        if (theMonster->carriedItem != NULL && theMonster->carriedItem->category != GOLD) {
+                seedCatalogItemName(theMonster->carriedItem, name, theMonster);
+                printf("        %s\n", name);
+        }
+    }
+
+    for (theMonster = dormantMonsters->nextCreature; theMonster != NULL; theMonster = theMonster->nextCreature) {
+        if (theMonster->carriedItem != NULL && theMonster->carriedItem->category != GOLD) {
+            seedCatalogItemName(theMonster->carriedItem, name, theMonster);
+            printf("        %s\n", name);
+        }
+    }
+}
+
+void printSeedCatalogFloorItems() {
+    item *theItem;
+    int gold = 0;
+    short piles = 0;
+    char buf[500];
+
+    for (theItem = floorItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+        if (theItem->category == GOLD) {
+            piles++;
+            gold += theItem->quantity;
+        } else if (theItem->category == AMULET) {
+        } else {
+            seedCatalogItemName(theItem, buf, NULL);
+            printf("        %s\n", buf);
+        }
+    }
+    if (piles == 1) {
+        printf("        %i gold pieces\n", gold);
+    }
+    if (piles > 1) {
+        printf("        %i gold pieces (%i piles)\n", gold, piles);
+    }
+}
+
+void printSeedCatalogAltars() {
+    short i, j;
+    boolean c_altars[100] = {0};
+
+    for (j = 0; j < DROWS; j++) {
+        for (i = 0; i < DCOLS; i++) {
+            if (pmap[i][j].layers[0] == RESURRECTION_ALTAR) {
+                printf("        A resurrection altar (vault %i)\n", pmap[i][j].machineNumber);
+            }
+            // commutation altars come in pairs. we only want to print 1.
+            if (pmap[i][j].layers[0] == COMMUTATION_ALTAR) {
+                c_altars[pmap[i][j].machineNumber] = true;
+            }
+        }
+    }
+    for (i = 0; i < 100; i++){
+        if (c_altars[i]) {
+            printf("        A commutation altar (vault %i)\n",i);
+        }
+    }
+}
+
+void printSeedCatalog(unsigned long startingSeed, short numberOfSeedsToScan, short scanThroughDepth) {
     unsigned long theSeed;
     char path[BROGUE_FILENAME_MAX];
-    item *theItem;
-    creature *monst;
-    char buf[500];
 
     rogue.nextGame = NG_NOTHING;
 
@@ -651,11 +715,11 @@ void scum(unsigned long startingSeed, short numberOfSeedsToScan, short scanThrou
     printf("Brogue seed catalog, seeds %li to %li, through depth %i.\n\n\
 To play one of these seeds, press control-N from the title screen \
 and enter the seed number. Knowing which items will appear on \
-the first %i depths will, of course, make the game significantly easier.",
+the first %i depths will, of course, make the game significantly easier.\n\n",
             startingSeed, startingSeed + numberOfSeedsToScan - 1, scanThroughDepth, scanThroughDepth);
 
     for (theSeed = startingSeed; theSeed < startingSeed + numberOfSeedsToScan; theSeed++) {
-        printf("\n\nSeed %li:", theSeed);
+        printf("Seed %li:\n", theSeed);
         fprintf(stderr, "Scanning seed %li...\n", theSeed);
         rogue.nextGamePath[0] = '\0';
         randomNumbersGenerated = 0;
@@ -669,26 +733,20 @@ the first %i depths will, of course, make the game significantly easier.",
         rogue.playbackOmniscience = true;
         for (rogue.depthLevel = 1; rogue.depthLevel <= scanThroughDepth; rogue.depthLevel++) {
             startLevel(rogue.depthLevel == 1 ? 1 : rogue.depthLevel - 1, 1); // descending into level n
-            printf("\n    Depth %i:", rogue.depthLevel);
-            for (theItem = floorItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
-                itemName(theItem, buf, true, true, NULL);
-                upperCase(buf);
-                printf("\n        %s", buf);
-                if (pmap[theItem->xLoc][theItem->yLoc].machineNumber > 0) {
-                    printf(" (vault %i)", pmap[theItem->xLoc][theItem->yLoc].machineNumber);
-                }
-            }
-            for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
-                scumMonster(monst);
-            }
-            for (monst = dormantMonsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
-                scumMonster(monst);
+            printf("    Depth %i:\n", rogue.depthLevel);
+
+            printSeedCatalogFloorItems();
+            printSeedCatalogMonsterItems();
+            printSeedCatalogMonsters(false); // captives and allies only
+            if (rogue.depthLevel >= 13) { // resurrection & commutation altars can spawn starting on 13
+                printSeedCatalogAltars();
             }
         }
+
         freeEverything();
         remove(currentFilePath); // Don't add a spurious LastGame file to the brogue folder.
     }
-    printf("\n");
+
 }
 
 // This is the basic program loop.
@@ -872,8 +930,8 @@ void mainBrogueJunction() {
                 rogue.nextGame = NG_NOTHING;
                 printHighScores(false);
                 break;
-            case NG_SCUM:
-                scum(1, 1000, 5);
+            case NG_PRINT_SEED_CATALOG:
+                printSeedCatalog(1, 1000, 5);
                 rogue.nextGame = NG_QUIT;
                 break;
             case NG_QUIT:

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -261,6 +261,22 @@ void monsterName(char *buf, creature *monst, boolean includeArticle) {
     }
 }
 
+void seedCatalogMonsterName(char *name, creature *theMonster) {
+    char descriptor[16] = "";
+    char location[16] = "";
+
+    if (theMonster->bookkeepingFlags & MB_CAPTIVE) {
+        if (cellHasTMFlag(theMonster->xLoc, theMonster->yLoc, TM_PROMOTES_WITH_KEY)) {
+            strcpy(descriptor,"A caged ");
+        } else {
+            strcpy(descriptor,"A shackled ");
+        }
+    } else if (theMonster->creatureState == MONSTER_ALLY) {
+        strcpy(descriptor, "An allied ");
+    }
+    sprintf(name,"%s%s%s", descriptor, theMonster->info.monsterName, location);
+}
+
 boolean monsterIsInClass(const creature *monst, const short monsterClass) {
     short i;
     for (i = 0; monsterClassCatalog[monsterClass].memberList[i] != 0; i++) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2157,7 +2157,7 @@ enum NGCommands {
     NG_OPEN_GAME,
     NG_VIEW_RECORDING,
     NG_HIGH_SCORES,
-    NG_SCUM,
+    NG_PRINT_SEED_CATALOG,
     NG_QUIT,
 };
 
@@ -2902,6 +2902,7 @@ extern "C" {
     boolean canSeeMonster(creature *monst);
     boolean canDirectlySeeMonster(creature *monst);
     void monsterName(char *buf, creature *monst, boolean includeArticle);
+    void seedCatalogMonsterName(char *name, creature *theMonster);
     boolean monsterIsInClass(const creature *monst, const short monsterClass);
     fixpt strengthModifier(item *theItem);
     fixpt netEnchant(item *theItem);
@@ -2966,6 +2967,7 @@ extern "C" {
     void checkForDisenchantment(item *theItem);
     void updateFloorItems();
     void itemName(item *theItem, char *root, boolean includeDetails, boolean includeArticle, color *baseColor);
+    void seedCatalogItemName(item *theItem, char *name, creature *theMonster);
     char displayInventory(unsigned short categoryMask,
                           unsigned long requiredFlags,
                           unsigned long forbiddenFlags,

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
         }
 
         if (strcmp(argv[i], "--print-seed-catalog") == 0) {
-            rogue.nextGame = NG_SCUM;
+            rogue.nextGame = NG_PRINT_SEED_CATALOG;
             continue;
         }
 


### PR DESCRIPTION
Add items carried by monsters, shackled vs. caged status for captive 
monsters, and which vault a key will open. Aggregate gold per level. 
Remove the extraneous '+0' from non-enchanted weapons. Remove the 
rating and strength requirement from armor. Add legendary allies 
and both resurrection and commutation altars. Rename 
operations/variables from scum to seed catalog.