### PR TITLE
Fix issues with off-level monster pathing

### DIFF
--- a/changes/fix-offlevel-monster-pathing.md
+++ b/changes/fix-offlevel-monster-pathing.md
@@ -1,0 +1,4 @@
+Fixed issues with off-level monster pathing that could get two monsters stuck on one another,
+causing one of them to go into a corrupted state that cannot be attacked.
+
+Made monsters move the correct distance and to the correct spot when reloading a level

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3466,8 +3466,11 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
         } else {
             theMap = mapToStairs;
         }
+
+        pmap[*x][*y].flags &= ~HAS_MONSTER;
         if (theMap) {
-            turnCount = ((theMap[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100) - monst->status[STATUS_ENTERS_LEVEL_IN]);
+            // STATUS_ENTERS_LEVEL_IN accounts for monster speed; convert back to map distance and subtract from distance to stairs
+            turnCount = (theMap[monst->xLoc][monst->yLoc] - (monst->status[STATUS_ENTERS_LEVEL_IN] * 100 / monst->movementSpeed));
             for (i=0; i < turnCount; i++) {
                 if ((dir = nextStep(theMap, monst->xLoc, monst->yLoc, NULL, true)) != NO_DIRECTION) {
                     monst->xLoc += nbDirs[dir][0];

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1024,7 +1024,7 @@ enum tileFlags {
     IS_IN_MACHINE               = (IS_IN_ROOM_MACHINE | IS_IN_AREA_MACHINE),    // sacred ground; don't generate items here, or teleport randomly to it
 
     PERMANENT_TILE_FLAGS = (DISCOVERED | MAGIC_MAPPED | ITEM_DETECTED | HAS_ITEM | HAS_DORMANT_MONSTER
-                            | HAS_STAIRS | SEARCHED_FROM_HERE | PRESSURE_PLATE_DEPRESSED
+                            | HAS_MONSTER | HAS_STAIRS | SEARCHED_FROM_HERE | PRESSURE_PLATE_DEPRESSED
                             | STABLE_MEMORY | KNOWN_TO_BE_TRAP_FREE | IN_LOOP
                             | IS_CHOKEPOINT | IS_GATE_SITE | IS_IN_MACHINE | IMPREGNABLE),
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -588,7 +588,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (pmap[i][j].flags & VISIBLE) {
+            if (pmap[i][j].flags & ANY_KIND_OF_VISIBLE) {
                 // Remember visible cells upon exiting.
                 storeMemories(i, j);
             }
@@ -727,18 +727,6 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             restoreItem(theItem);
         }
 
-        mapToStairs = allocGrid();
-        mapToPit = allocGrid();
-        fillGrid(mapToStairs, 0);
-        fillGrid(mapToPit, 0);
-        calculateDistances(mapToStairs, player.xLoc, player.yLoc, T_PATHING_BLOCKER, NULL, true, true);
-        calculateDistances(mapToPit, levels[rogue.depthLevel-1].playerExitedVia[0],
-                           levels[rogue.depthLevel-1].playerExitedVia[0], T_PATHING_BLOCKER, NULL, true, true);
-        for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
-            restoreMonster(monst, mapToStairs, mapToPit);
-        }
-        freeGrid(mapToStairs);
-        freeGrid(mapToPit);
     }
 
     // Simulate the environment!
@@ -812,6 +800,21 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
         && !cellHasTerrainFlag(player.xLoc, player.yLoc, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
         rogue.inWater = true;
+    }
+
+    if (levels[rogue.depthLevel - 1].visited) {
+        mapToStairs = allocGrid();
+        mapToPit = allocGrid();
+        fillGrid(mapToStairs, 0);
+        fillGrid(mapToPit, 0);
+        calculateDistances(mapToStairs, player.xLoc, player.yLoc, T_PATHING_BLOCKER, NULL, true, true);
+        calculateDistances(mapToPit, levels[rogue.depthLevel-1].playerExitedVia[0],
+                           levels[rogue.depthLevel-1].playerExitedVia[1], T_PATHING_BLOCKER, NULL, true, true);
+        for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
+            restoreMonster(monst, mapToStairs, mapToPit);
+        }
+        freeGrid(mapToStairs);
+        freeGrid(mapToPit);
     }
 
     updateMapToShore();

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1830,6 +1830,8 @@ void monsterEntersLevel(creature *monst, short n) {
     char monstName[COLS], buf[COLS];
     boolean pit = false;
 
+    levels[n].mapStorage[monst->xLoc][monst->yLoc].flags &= ~HAS_MONSTER;
+
     // place traversing monster near the stairs on this level
     if (monst->bookkeepingFlags & MB_APPROACHING_DOWNSTAIRS) {
         monst->xLoc = rogue.upLoc[0];


### PR DESCRIPTION
Make sure enemies pathing towards stairs or a pit from the previous level path towards the right tile at the right speed. Previously, mapToPit used the wrong coordinates and mapToStairs mapped to the player's coordinates from the previous level. Also prevents monsters from walking onto each other when the player comes back to a level, which permanently screws up the existing monster.