### PR TITLE
Fix pause during replay

### DIFF
--- a/changes/fix-input-during-replay.md
+++ b/changes/fix-input-during-replay.md
@@ -1,0 +1,1 @@
+Fix keyboard events lost during recording playback

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -388,7 +388,14 @@ static void _gameLoop() {
 static boolean _pauseForMilliseconds(short ms) {
     SDL_UpdateWindowSurface(Win);
     SDL_Delay(ms);
-    return (pollBrogueEvent(&lastEvent, false) || lastEvent.eventType != EVENT_ERROR)
+
+    if (lastEvent.eventType != EVENT_ERROR
+        && lastEvent.eventType != MOUSE_ENTERED_CELL) {
+        return true; // SDL already gave us an interrupting event to process
+    }
+
+    return pollBrogueEvent(&lastEvent, false) // ask SDL for a new event if one is available
+        && lastEvent.eventType != EVENT_ERROR // and check if it is interrupting
         && lastEvent.eventType != MOUSE_ENTERED_CELL;
 }
 


### PR DESCRIPTION
While playing a recording, if you hit space during combat (which lasts 0.5 second) the game freezes, but resumes as soon as you move the mouse; the game does not print "Recording paused" either. This issue affects the SDL2 platform only.

Cause: The keypress event is detected and saved into `lastEvent` variable, but gets overwritten before it is processed. The event that gets processed is whichever event follows it (usually a mouse move) once there is one.

Solution: Check if we already have a valid, pending event in `lastEvent`. If so, process it instead of polling for a new one. (Note that `lastEvent` is reset to `EVENT_ERROR` when `_nextKeyOrMouseEvent` returns it, so there is no risk of processing the same event twice.)

Fixes #42.