### PR TITLE
Fix integer portability

### DIFF
--- a/src/brogue/Math.c
+++ b/src/brogue/Math.c
@@ -116,9 +116,9 @@ void raninit( ranctx *x, u4 seed ) {
 
 #define RAND_MAX_COMBO ((unsigned long) UINT32_MAX)
 
-int range(int n, short RNG) {
+long range(long n, short RNG) {
     unsigned long div;
-    int r;
+    long r;
 
     div = RAND_MAX_COMBO/n;
 
@@ -132,35 +132,35 @@ int range(int n, short RNG) {
 // Get a random int between lowerBound and upperBound, inclusive, with uniform probability distribution
 
 #ifdef AUDIT_RNG // debug version
-int rand_range(int lowerBound, int upperBound) {
+long rand_range(long lowerBound, long upperBound) {
     int retval;
     char RNGMessage[100];
-
-    brogueAssert(lowerBound <= INT_MAX && upperBound <= INT_MAX);
-
     if (upperBound <= lowerBound) {
         return lowerBound;
     }
-    retval = lowerBound + range(upperBound-lowerBound+1, rogue.RNG);
+    long interval = upperBound - lowerBound + 1;
+    brogueAssert(interval > 1); // to verify that we didn't wrap around
+    retval = lowerBound + range(interval, rogue.RNG);
     if (rogue.RNG == RNG_SUBSTANTIVE) {
         randomNumbersGenerated++;
         if (1) { //randomNumbersGenerated >= 1128397) {
-            sprintf(RNGMessage, "\n#%lu, %i to %i: %i", randomNumbersGenerated, lowerBound, upperBound, retval);
+            sprintf(RNGMessage, "\n#%lu, %ld to %ld: %ld", randomNumbersGenerated, lowerBound, upperBound, retval);
             RNGLog(RNGMessage);
         }
     }
     return retval;
 }
 #else // normal version
-int rand_range(int lowerBound, int upperBound) {
-    brogueAssert(lowerBound <= INT_MAX && upperBound <= INT_MAX);
+long rand_range(long lowerBound, long upperBound) {
     if (upperBound <= lowerBound) {
         return lowerBound;
     }
     if (rogue.RNG == RNG_SUBSTANTIVE) {
         randomNumbersGenerated++;
     }
-    return lowerBound + range(upperBound-lowerBound+1, rogue.RNG);
+    long interval = upperBound - lowerBound + 1;
+    brogueAssert(interval > 1); // to verify that we didn't wrap around
+    return lowerBound + range(interval, rogue.RNG);
 }
 #endif
 

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -28,9 +28,11 @@
 
 #define RECORDING_HEADER_LENGTH     32  // bytes at the start of the recording file to store global data
 
-static const int keystrokeTable[] = {UP_ARROW, LEFT_ARROW, DOWN_ARROW, RIGHT_ARROW,
+static const long keystrokeTable[] = {UP_ARROW, LEFT_ARROW, DOWN_ARROW, RIGHT_ARROW,
     ESCAPE_KEY, RETURN_KEY, DELETE_KEY, TAB_KEY, NUMPAD_0, NUMPAD_1,
     NUMPAD_2, NUMPAD_3, NUMPAD_4, NUMPAD_5, NUMPAD_6, NUMPAD_7, NUMPAD_8, NUMPAD_9};
+
+static const int keystrokeCount = sizeof(keystrokeTable) / sizeof(*keystrokeTable);
 
 
 void recordChar(unsigned char c) {
@@ -45,10 +47,10 @@ void considerFlushingBufferToFile() {
 }
 
 // compresses a int into a char, discarding stuff we don't need
-unsigned char compressKeystroke(int c) {
+unsigned char compressKeystroke(long c) {
     short i;
 
-    for (i=0; i<18; i++) {
+    for (i = 0; i < keystrokeCount; i++) {
         if (keystrokeTable[i] == c) {
             return (unsigned char) (128 + i);
         }
@@ -260,11 +262,11 @@ unsigned char recallChar() {
     return c;
 }
 
-int uncompressKeystroke(int c) {
-    if (c >= 128 && c <= UNKNOWN_KEY) {
+long uncompressKeystroke(unsigned char c) {
+    if (c >= 128 && (c - 128) < keystrokeCount) {
         return keystrokeTable[c - 128];
     }
-    return (int) c;
+    return (long)c;
 }
 
 unsigned long recallNumber(short numberOfBytes) {
@@ -1192,8 +1194,8 @@ void loadSavedGame() {
 
 void describeKeystroke(unsigned char key, char *description) {
     short i;
-    int c;
-    const int keyList[51] = {UP_KEY, DOWN_KEY, LEFT_KEY, RIGHT_KEY, UP_ARROW, LEFT_ARROW,
+    long c;
+    const long keyList[51] = {UP_KEY, DOWN_KEY, LEFT_KEY, RIGHT_KEY, UP_ARROW, LEFT_ARROW,
         DOWN_ARROW, RIGHT_ARROW, UPLEFT_KEY, UPRIGHT_KEY, DOWNLEFT_KEY, DOWNRIGHT_KEY,
         DESCEND_KEY, ASCEND_KEY, REST_KEY, AUTO_REST_KEY, SEARCH_KEY, INVENTORY_KEY,
         ACKNOWLEDGE_KEY, EQUIP_KEY, UNEQUIP_KEY, APPLY_KEY, THROW_KEY, RELABEL_KEY, DROP_KEY, CALL_KEY,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2589,7 +2589,7 @@ extern "C" {
     void gameOver(char *killedBy, boolean useCustomPhrasing);
     void victory(boolean superVictory);
     void enableEasyMode();
-    int rand_range(int lowerBound, int upperBound);
+    long rand_range(long lowerBound, long upperBound);
     unsigned long seedRandomGenerator(unsigned long seed);
     short randClumpedRange(short lowerBound, short upperBound, short clumpFactor);
     short randClump(randomRange theRange);


### PR DESCRIPTION
On some architectures, `int` type is 16 bits (C99's minimum requirement).
Because it cannot store numbers higher than 32767, wraparound issues arise related to:
- keyboard commands, like `UP_ARROW` (63232)
- `rand_range()` is called with numbers as high as 60000

For those, use `long` instead.

Related to issue #4.