### PR TITLE
Extend seeding to 64 bits

### DIFF
--- a/changes/64-bit-seeds.md
+++ b/changes/64-bit-seeds.md
@@ -1,0 +1,2 @@
+Accept seeds as high as 18446744073709551615
+Fix non-deterministic dungeon levels

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -67,7 +67,7 @@ unsigned long lengthOfPlaybackFile;
 unsigned long recordingLocation;
 unsigned long maxLevelChanges;
 char annotationPathname[BROGUE_FILENAME_MAX];   // pathname of annotation file
-unsigned long previousGameSeed;
+uint64_t previousGameSeed;
 
 //                                  Red     Green   Blue    RedRand GreenRand   BlueRand    Rand    Dances?
 // basic colors

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4132,7 +4132,7 @@ void displayGrid(short **map) {
 
 void printSeed() {
     char buf[COLS];
-    sprintf(buf, "Dungeon seed #%lu; turn #%lu; version %s", rogue.seed, rogue.playerTurnNumber, BROGUE_VERSION_STRING);
+    sprintf(buf, "Dungeon seed #%llu; turn #%lu; version %s", (unsigned long long)rogue.seed, rogue.playerTurnNumber, BROGUE_VERSION_STRING);
     message(buf, false);
 }
 

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -67,7 +67,7 @@ extern unsigned long lengthOfPlaybackFile;
 extern unsigned long recordingLocation;
 extern unsigned long maxLevelChanges;
 extern char annotationPathname[BROGUE_FILENAME_MAX];    // pathname of annotation file
-extern unsigned long previousGameSeed;
+extern uint64_t previousGameSeed;
 
 // basic colors
 extern color white;

--- a/src/brogue/Math.c
+++ b/src/brogue/Math.c
@@ -98,9 +98,10 @@ u4 ranval( ranctx *x ) {
     return x->d;
 }
 
-void raninit( ranctx *x, u4 seed ) {
+void raninit( ranctx *x, uint64_t seed ) {
     u4 i;
-    x->a = 0xf1ea5eed, x->b = x->c = x->d = seed;
+    x->a = 0xf1ea5eed, x->b = x->c = x->d = (u4)seed;
+    x->c ^= (u4)(seed >> 32);
     for (i=0; i<20; ++i) {
         (void)ranval(x);
     }
@@ -164,11 +165,20 @@ int rand_range(int lowerBound, int upperBound) {
 }
 #endif
 
+uint64_t rand_64bits() {
+    if (rogue.RNG == RNG_SUBSTANTIVE) {
+        randomNumbersGenerated++;
+    }
+    uint64_t hi = ranval(&(RNGState[rogue.RNG]));
+    uint64_t lo = ranval(&(RNGState[rogue.RNG]));
+    return (hi << 32) | lo;
+}
+
 // seeds with the time if called with a parameter of 0; returns the seed regardless.
 // All RNGs are seeded simultaneously and identically.
-unsigned long seedRandomGenerator(unsigned long seed) {
+uint64_t seedRandomGenerator(uint64_t seed) {
     if (seed == 0) {
-        seed = (unsigned long) time(NULL) - 1352700000;
+        seed = (uint64_t) time(NULL) - 1352700000;
     }
     raninit(&(RNGState[RNG_SUBSTANTIVE]), seed);
     raninit(&(RNGState[RNG_COSMETIC]), seed);

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -26,7 +26,7 @@
 #include "Rogue.h"
 #include "IncludeGlobals.h"
 
-#define RECORDING_HEADER_LENGTH     32  // bytes at the start of the recording file to store global data
+#define RECORDING_HEADER_LENGTH     36  // bytes at the start of the recording file to store global data
 
 static const int keystrokeTable[] = {UP_ARROW, LEFT_ARROW, DOWN_ARROW, RIGHT_ARROW,
     ESCAPE_KEY, RETURN_KEY, DELETE_KEY, TAB_KEY, NUMPAD_0, NUMPAD_1,
@@ -175,8 +175,8 @@ void writeHeaderInfo(char *path) {
         c[i] = BROGUE_RECORDING_VERSION_STRING[i];
     }
     i = 16;
-    numberToString(rogue.seed, 4, &c[i]);
-    i += 4;
+    numberToString(rogue.seed, 8, &c[i]);
+    i += 8;
     numberToString(rogue.playerTurnNumber, 4, &c[i]);
     i += 4;
     numberToString(rogue.deepestLevel, 4, &c[i]);
@@ -480,7 +480,7 @@ void initRecording() {
             rogue.playbackOOS = false;
             rogue.gameHasEnded = true;
         }
-        rogue.seed              = recallNumber(4);          // master random seed
+        rogue.seed              = recallNumber(8);          // master random seed
         rogue.howManyTurns      = recallNumber(4);          // how many turns are in this recording
         maxLevelChanges         = recallNumber(4);          // how many times the player changes depths
         lengthOfPlaybackFile    = recallNumber(4);
@@ -1244,7 +1244,8 @@ boolean selectFile(char *prompt, char *defaultName, char *suffix) {
 
 void parseFile() {
     FILE *descriptionFile;
-    unsigned long oldFileLoc, oldRecLoc, oldLength, oldBufLoc, i, seed, numTurns, numDepths, fileLength, startLoc;
+    unsigned long oldFileLoc, oldRecLoc, oldLength, oldBufLoc, i, numTurns, numDepths, fileLength, startLoc;
+    uint64_t seed;
     unsigned char c;
     char description[1000], versionString[500];
     short x, y;
@@ -1268,7 +1269,7 @@ void parseFile() {
             versionString[i] = recallChar();
         }
 
-        seed        = recallNumber(4);
+        seed        = recallNumber(8);
         numTurns    = recallNumber(4);
         numDepths   = recallNumber(4);
         fileLength  = recallNumber(4);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2206,7 +2206,7 @@ typedef struct playerCharacter {
     boolean trueColorMode;              // whether lighting effects are disabled
     boolean displayAggroRangeMode;      // whether your stealth range is displayed
     boolean quit;                       // to skip the typical end-game theatrics when the player quits
-    unsigned long seed;                 // the master seed for generating the entire dungeon
+    uint64_t seed;                      // the master seed for generating the entire dungeon
     short RNG;                          // which RNG are we currently using?
     unsigned long gold;                 // how much gold we have
     unsigned long goldGenerated;        // how much gold has been generated on the levels, not counting gold held by monsters
@@ -2299,7 +2299,7 @@ typedef struct playerCharacter {
     // What do you want to do, player -- play, play with seed, resume, recording, high scores or quit?
     enum NGCommands nextGame;
     char nextGamePath[BROGUE_FILENAME_MAX];
-    unsigned long nextGameSeed;
+    uint64_t nextGameSeed;
 } playerCharacter;
 
 // Stores the necessary info about a level so it can be regenerated:
@@ -2310,7 +2310,7 @@ typedef struct levelData {
     struct creature *monsters;
     struct creature *dormantMonsters;
     short **scentMap;
-    unsigned long levelSeed;
+    uint64_t levelSeed;
     short upStairsLoc[2];
     short downStairsLoc[2];
     short playerExitedVia[2];
@@ -2584,12 +2584,14 @@ extern "C" {
     boolean fileExists(const char *pathname);
     boolean chooseFile(char *path, char *prompt, char *defaultName, char *suffix);
     boolean openFile(const char *path);
-    void initializeRogue(unsigned long seed);
+    void initializeRogue(uint64_t seed);
     void gameOver(char *killedBy, boolean useCustomPhrasing);
     void victory(boolean superVictory);
     void enableEasyMode();
+    boolean tryParseUint64(char *str, uint64_t *num);
+    uint64_t rand_64bits();
     int rand_range(int lowerBound, int upperBound);
-    unsigned long seedRandomGenerator(unsigned long seed);
+    uint64_t seedRandomGenerator(uint64_t seed);
     short randClumpedRange(short lowerBound, short upperBound, short clumpFactor);
     short randClump(randomRange theRange);
     boolean rand_percent(short percent);
@@ -2655,7 +2657,7 @@ extern "C" {
     short getHighScoresList(rogueHighScoresEntry returnList[HIGH_SCORES_COUNT]);
     boolean saveHighScore(rogueHighScoresEntry theEntry);
     fileEntry *listFiles(short *fileCount, char **dynamicMemoryBuffer);
-    void initializeLaunchArguments(enum NGCommands *command, char *path, unsigned long *seed);
+    void initializeLaunchArguments(enum NGCommands *command, char *path, uint64_t *seed);
 
     char nextKeyPress(boolean textInput);
     void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst);

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -57,6 +57,20 @@ static void badArgument(const char *arg) {
     printCommandlineHelp();
 }
 
+boolean tryParseUint64(char *str, uint64_t *num) {
+    unsigned long long n;
+    char buf[100];
+    if (strlen(str)                 // we need some input
+        && sscanf(str, "%llu", &n)  // try to convert to number
+        && sprintf(buf, "%llu", n)  // convert back to string
+        && !strcmp(buf, str)) {     // compare (we need them equal)
+        *num = (uint64_t)n;
+        return true; // success
+    } else {
+        return false; // input was too large or not a decimal number
+    }
+}
+
 int main(int argc, char *argv[])
 {
 
@@ -96,15 +110,17 @@ int main(int argc, char *argv[])
 
         if (strcmp(argv[i], "--seed") == 0 || strcmp(argv[i], "-s") == 0) {
             // pick a seed!
-            if (i + 1 < argc) {
-                unsigned int seed = atof(argv[i + 1]); // plenty of precision in a double, and simpler than any other option
-                if (seed != 0) {
-                    i++;
-                    rogue.nextGameSeed = seed;
-                    rogue.nextGame = NG_NEW_GAME_WITH_SEED;
-                    continue;
-                }
+            uint64_t seed;
+            if (i + 1 == argc || !tryParseUint64(argv[i + 1], &seed)) {
+                printf("Invalid seed, please specify a number between 1 and 18446744073709551615\n");
+                return 1;
             }
+            if (seed != 0) {
+                rogue.nextGameSeed = seed;
+                rogue.nextGame = NG_NEW_GAME_WITH_SEED;
+            }
+            i++;
+            continue;
         }
 
         if (strcmp(argv[i], "-n") == 0) {

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -553,7 +553,7 @@ fileEntry *listFiles(short *fileCount, char **namebuffer) {
 
 // end of file listing
 
-void initializeLaunchArguments(enum NGCommands *command, char *path, unsigned long *seed) {
+void initializeLaunchArguments(enum NGCommands *command, char *path, uint64_t *seed) {
     // we've actually already done this at this point, except for the seed.
 }
 


### PR DESCRIPTION
Also fixes a bug related to level seeds: each level had 1 in 100,000,000 chance of being non-deterministic (level seed = 0), i.e different on every play or recording replay.

Seeds up to 2^32-1 generate the same dungeons as prior versions.

Recordings are not backward compatible, as the header has increased in size to store the now larger seed.