### PR TITLE
Handle 'G' keypress during playback

### DIFF
--- a/changes/handle-G-keypress-in-playback.md
+++ b/changes/handle-G-keypress-in-playback.md
@@ -1,0 +1,1 @@
+Allow switching tiles on/off with either mouse or keyboard during playback

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -949,6 +949,18 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                                      &teal, false);
                 }
                 return true;
+            case GRAPHICS_KEY:
+                if (hasGraphics) {
+                    graphicsEnabled = setGraphicsEnabled(!graphicsEnabled);
+                    if (graphicsEnabled) {
+                        messageWithColor(KEYBOARD_LABELS ? "Enabled graphical tiles. Press 'G' again to disable." : "Enable graphical tiles.",
+                                        &teal, false);
+                    } else {
+                        messageWithColor(KEYBOARD_LABELS ? "Disabled graphical tiles. Press 'G' again to enable." : "Disabled graphical tiles.",
+                                        &teal, false);
+                    }
+                }
+                return true;
             case SEED_KEY:
                 //rogue.playbackMode = false;
                 //DEBUG {displayGrid(safetyMap); displayMoreSign(); displayLevel();}


### PR DESCRIPTION
Unlike in play mode, during playback you could only enable tiles with the mouse, not with the keyboard.