### PR TITLE
Reduce CPU usage

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -3550,13 +3550,15 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
         // count up the number of candidate locations
         for (k=0; k<max(DROWS, DCOLS); k++) {
             for (i = px-k; i <= px+k; i++) {
-                for (j = py-k; j <= py+k; j++) {
+                // we are scanning concentric squares. The first and last columns
+                // need to be stepped through, but others can be jumped over.
+                short step = (i == px-k || i == px+k) ? 1 : 2*k;
+                for (j = py-k; j <= py+k; j += step) {
+                    if (displayEntityCount >= ROWS - 1) goto no_space_for_more_entities;
                     if (coordinatesAreInMap(i, j)
-                        && (i == px-k || i == px+k || j == py-k || j == py+k)
                         && !addedEntity[i][j]
-                        && (playerCanDirectlySee(i, j) || (indirectVision && (playerCanSeeOrSense(i, j) || rogue.playbackOmniscience)))
                         && cellHasTMFlag(i, j, TM_LIST_IN_SIDEBAR)
-                        && displayEntityCount < ROWS - 1) {
+                        && (playerCanDirectlySee(i, j) || (indirectVision && (playerCanSeeOrSense(i, j) || rogue.playbackOmniscience)))) {
 
                         addedEntity[i][j] = true;
                         entityList[displayEntityCount] = tileCatalog[pmap[i][j].layers[layerWithTMFlag(i, j, TM_LIST_IN_SIDEBAR)]].description;
@@ -3568,6 +3570,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
                 }
             }
         }
+        no_space_for_more_entities:;
     }
 
     // Entities are now listed. Start printing.


### PR DESCRIPTION
70% of the runtime was spent in 1 function, `refreshSideBar`. This patch reorders some instructions to get the same result but with much less computation.

Before:
```
      %   cumulative   self              self     total
    time   seconds   seconds    calls  ms/call  ms/call  name
    70.14      1.01     1.01     1657     0.61     0.62  refreshSideBar
     7.64      1.12     0.11  1879853     0.00     0.00  fp_sqrt
```
After:
```
      %   cumulative   self              self     total
    time   seconds   seconds    calls  ms/call  ms/call  name
    29.20      0.33     0.33 15365339     0.00     0.00  fp_sqrt
    14.16      0.49     0.16     6257     0.03     0.03  refreshSideBar
```