### PR TITLE
Fix radialFadeToPercent calculation

### DIFF
--- a/src/brogue/Light.c
+++ b/src/brogue/Light.c
@@ -149,7 +149,7 @@ void updateMinersLightRadius() {
         lightRadius = max(lightRadius / 2, 3 * FP_FACTOR);
     }
 
-    rogue.minersLight.radialFadeToPercent = (35 + max(0, min(65, rogue.lightMultiplier * 5)) * fraction) / FP_FACTOR;
+    rogue.minersLight.radialFadeToPercent = 35 + (max(0, min(65, rogue.lightMultiplier * 5)) * fraction) / FP_FACTOR;
     rogue.minersLight.lightRadius.upperBound = rogue.minersLight.lightRadius.lowerBound = clamp(lightRadius / FP_FACTOR, -30000, 30000);
 }
 


### PR DESCRIPTION
It was originally between 35 and 100%. When the code switched to fixed-point arithmetic, the "35" was accidentally treated as a `fixpt` value, which turns it into 0.000534%. The range effectively became 0 to 65%.