### PR TITLE
Various recording fixes

### DIFF
--- a/changes/recording-fixes.md
+++ b/changes/recording-fixes.md
@@ -1,0 +1,7 @@
+Made the loading bars show up on screen.
+
+You can now quit the program while loading a save file or cancel with the escape key.
+
+Made '6' key work like the other number keys in playback instead of moving forward a turn.
+
+Allowed entering turn number when a playback is OOS.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -475,7 +475,6 @@ void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
         }
         buttons[buttonCount].hotkey[0] = RIGHT_KEY;
         buttons[buttonCount].hotkey[1] = RIGHT_ARROW;
-        buttons[buttonCount].hotkey[2] = NUMPAD_6;
         buttonCount++;
 
         strcpy(buttons[buttonCount].text,       "  Menu  ");

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -728,8 +728,9 @@ void mainBrogueJunction() {
                 }
 
                 if (openFile(path)) {
-                    loadSavedGame();
-                    mainInputLoop();
+                    if (loadSavedGame()) {
+                        mainInputLoop();
+                    }
                     freeEverything();
                 } else {
                     //dialogAlert("File not found.");

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -712,7 +712,7 @@ void promptToAdvanceToLocation(short keystroke) {
     unsigned long destinationFrame;
     boolean enteredText;
 
-    if (!rogue.playbackPaused || unpause()) {
+    if (rogue.playbackOOS || !rogue.playbackPaused || unpause()) {
         buf[0] = (keystroke == '0' ? '\0' : keystroke);
         buf[1] = '\0';
 
@@ -726,6 +726,8 @@ void promptToAdvanceToLocation(short keystroke) {
 
             if (destinationFrame >= rogue.howManyTurns) {
                 flashTemporaryAlert(" Past end of recording ", 3000);
+            } else if (rogue.playbackOOS && destinationFrame > rogue.playerTurnNumber) {
+                flashTemporaryAlert(" Out of sync ", 3000);
             } else if (destinationFrame == rogue.playerTurnNumber) {
                 sprintf(buf, " Already at turn %li ", destinationFrame);
                 flashTemporaryAlert(buf, 1000);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3127,7 +3127,7 @@ extern "C" {
     void recallEvent(rogueEvent *event);
     void pausePlayback();
     void displayAnnotation();
-    void loadSavedGame();
+    boolean loadSavedGame();
     void switchToPlaying();
     void recordKeystroke(int keystroke, boolean controlKey, boolean shiftKey);
     void recordKeystrokeSequence(unsigned char *commandSequence);


### PR DESCRIPTION
- Made the loading bars show up on screen by calling pauseBrogue(0) instead of commitDraws. Seems like pauseBrogue and nextBrogueEvent are the only functions that flush the display to screen
- Allow the user to click X or cancel loading while a saved game is loading
- The '6' key now enters a turn number; it used to act like the right arrow
- Turn numbers can now be entered during OOS replays; they used to do nothing
