### PR TITLE
Include seed and depth in default save/recording file names

### DIFF
--- a/changes/include-seed-in-filenames.md
+++ b/changes/include-seed-in-filenames.md
@@ -1,0 +1,1 @@
+Include the seed and level into save and recording file names

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1086,11 +1086,7 @@ void getAvailableFilePath(char *returnPath, const char *defaultPath, const char 
     strcpy(returnPath, defaultPath);
     sprintf(fullPath, "%s%s", returnPath, suffix);
     while (fileExists(fullPath)) {
-#ifdef BROGUE_WEB
-        sprintf(returnPath, "%s_%i", defaultPath, fileNameIterator);
-#else
         sprintf(returnPath, "%s (%i)", defaultPath, fileNameIterator);
-#endif
         sprintf(fullPath, "%s%s", returnPath, suffix);
         fileNameIterator++;
     }

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1086,7 +1086,11 @@ void getAvailableFilePath(char *returnPath, const char *defaultPath, const char 
     strcpy(returnPath, defaultPath);
     sprintf(fullPath, "%s%s", returnPath, suffix);
     while (fileExists(fullPath)) {
-        sprintf(returnPath, "%s %i", defaultPath, fileNameIterator);
+#ifdef BROGUE_WEB
+        sprintf(returnPath, "%s_%i", defaultPath, fileNameIterator);
+#else
+        sprintf(returnPath, "%s (%i)", defaultPath, fileNameIterator);
+#endif
         sprintf(fullPath, "%s%s", returnPath, suffix);
         fileNameIterator++;
     }
@@ -1100,12 +1104,46 @@ boolean characterForbiddenInFilename(const char theChar) {
     }
 }
 
+void getDefaultFilePath(char *defaultPath, boolean gameOver) {
+    char seed[21];
+
+    // 32-bit numbers are printed in full
+    // 64-bit numbers longer than 11 digits are shortened to e.g "184...51615"
+    sprintf(seed, "%llu", (unsigned long long)rogue.seed);
+    if (strlen(seed) > 11) sprintf(seed+3, "...%05lu", (unsigned long)(rogue.seed % 100000));
+
+#ifdef BROGUE_WEB
+    // With WebBrogue, filenames must fit into 30 bytes, including extension and terminal \0.
+    // It is enough for the seed and the optional file counter. The longest filename will be:
+    // "#184...51615_99999.broguesave" (30 bytes)
+    sprintf(defaultPath, "#%s", seed);
+#else
+    if (!gameOver) {
+        sprintf(defaultPath, "Saved #%s at depth %d", seed, rogue.depthLevel);
+    } else if (rogue.quit) {
+        sprintf(defaultPath, "#%s Quit at depth %d", seed, rogue.depthLevel);
+    } else if (player.bookkeepingFlags & MB_IS_DYING) {
+        sprintf(defaultPath, "#%s Died at depth %d", seed, rogue.depthLevel);
+    } else if (rogue.depthLevel > 26) {
+        sprintf(defaultPath, "#%s Mastered the dungeons", seed);
+    } else {
+        sprintf(defaultPath, "#%s Escaped the dungeons", seed);
+    }
+    if (rogue.wizard) {
+        strcat(defaultPath, " (wizard)");
+    } else if (rogue.easyMode) {
+        strcat(defaultPath, " (easy)");
+    }
+#endif
+}
+
 void saveGameNoPrompt() {
-    char filePath[BROGUE_FILENAME_MAX];
+    char filePath[BROGUE_FILENAME_MAX], defaultPath[BROGUE_FILENAME_MAX];
     if (rogue.playbackMode) {
         return;
     }
-    getAvailableFilePath(filePath, "Saved game", GAME_SUFFIX);
+    getDefaultFilePath(defaultPath, false);
+    getAvailableFilePath(filePath, defaultPath, GAME_SUFFIX);
     flushBufferToFile();
     strcat(filePath, GAME_SUFFIX);
     rename(currentFilePath, filePath);
@@ -1122,13 +1160,14 @@ void saveGame() {
         return; // Call me paranoid, but I'd rather it be impossible to embed malware in a recording.
     }
 
-    getAvailableFilePath(defaultPath, "Saved game", GAME_SUFFIX);
+    getDefaultFilePath(defaultPath, false);
+    getAvailableFilePath(filePath, defaultPath, GAME_SUFFIX);
 
     deleteMessages();
     do {
         askAgain = false;
         if (getInputTextString(filePath, "Save game as (<esc> to cancel): ",
-                               BROGUE_FILENAME_MAX - strlen(GAME_SUFFIX), defaultPath, GAME_SUFFIX, TEXT_INPUT_FILENAME, false)) {
+                               BROGUE_FILENAME_MAX - strlen(GAME_SUFFIX), filePath, GAME_SUFFIX, TEXT_INPUT_FILENAME, false)) {
             strcat(filePath, GAME_SUFFIX);
             if (!fileExists(filePath) || confirm("File of that name already exists. Overwrite?", true)) {
                 remove(filePath);
@@ -1146,12 +1185,13 @@ void saveGame() {
     deleteMessages();
 }
 
-void saveRecordingNoPrompt(char *filePath)
-{
+void saveRecordingNoPrompt(char *filePath) {
+    char defaultPath[BROGUE_FILENAME_MAX];
     if (rogue.playbackMode) {
         return;
     }
-    getAvailableFilePath(filePath, "Recording", RECORDING_SUFFIX);
+    getDefaultFilePath(defaultPath, true);
+    getAvailableFilePath(filePath, defaultPath, RECORDING_SUFFIX);
     strcat(filePath, RECORDING_SUFFIX);
     remove(filePath);
     rename(currentFilePath, filePath);
@@ -1166,13 +1206,14 @@ void saveRecording(char *filePath) {
         return;
     }
 
-    getAvailableFilePath(defaultPath, "Recording", RECORDING_SUFFIX);
+    getDefaultFilePath(defaultPath, true);
+    getAvailableFilePath(filePath, defaultPath, RECORDING_SUFFIX);
 
     deleteMessages();
     do {
         askAgain = false;
         if (getInputTextString(filePath, "Save recording as (<esc> to cancel): ",
-                               BROGUE_FILENAME_MAX - strlen(RECORDING_SUFFIX), defaultPath, RECORDING_SUFFIX, TEXT_INPUT_FILENAME, false)) {
+                               BROGUE_FILENAME_MAX - strlen(RECORDING_SUFFIX), filePath, RECORDING_SUFFIX, TEXT_INPUT_FILENAME, false)) {
 
             strcat(filePath, RECORDING_SUFFIX);
             if (!fileExists(filePath) || confirm("File of that name already exists. Overwrite?", true)) {

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1108,12 +1108,14 @@ void getDefaultFilePath(char *defaultPath, boolean gameOver) {
     sprintf(seed, "%llu", (unsigned long long)rogue.seed);
     if (strlen(seed) > 11) sprintf(seed+3, "...%05lu", (unsigned long)(rogue.seed % 100000));
 
-#ifdef BROGUE_WEB
-    // With WebBrogue, filenames must fit into 30 bytes, including extension and terminal \0.
-    // It is enough for the seed and the optional file counter. The longest filename will be:
-    // "#184...51615_99999.broguesave" (30 bytes)
-    sprintf(defaultPath, "#%s", seed);
-#else
+    if (serverMode) {
+        // With WebBrogue, filenames must fit into 30 bytes, including extension and terminal \0.
+        // It is enough for the seed and the optional file counter. The longest filename will be:
+        // "#184...51615 (999).broguesave" (30 bytes)
+        sprintf(defaultPath, "#%s", seed);
+        return;
+    }
+
     if (!gameOver) {
         sprintf(defaultPath, "Saved #%s at depth %d", seed, rogue.depthLevel);
     } else if (rogue.quit) {
@@ -1130,7 +1132,6 @@ void getDefaultFilePath(char *defaultPath, boolean gameOver) {
     } else if (rogue.easyMode) {
         strcat(defaultPath, " (easy)");
     }
-#endif
 }
 
 void saveGameNoPrompt() {


### PR DESCRIPTION
Includes the seed number, depth, mode and situation in default save/recording file names. Players who don't care to edit them will find it easier to browse their list of recordings or saved games.

This patch is forward-compatible with 64-bit seeds. If the seed is very long it gets shortened, to keep a reasonable file name length.

![image](https://user-images.githubusercontent.com/69065091/95607847-8b274980-0a19-11eb-9963-38a11ac1f487.png)

![image](https://user-images.githubusercontent.com/69065091/95607889-9aa69280-0a19-11eb-84b3-5e71e7f57332.png)
