### PR TITLE
Fix invalid pointers to freed memory

### DIFF
--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -3843,8 +3843,12 @@ void demoteMonsterFromLeadership(creature *monst) {
         freeGrid(monst->mapToMe);
         monst->mapToMe = NULL;
     }
-    for (follower = monsters->nextCreature; follower != NULL; follower = follower->nextCreature) {
-        if (follower->leader == monst && monst != follower) {
+
+    for (int level = 0; level <= DEEPEST_LEVEL; level++) {
+        // we'll work on this level's monsters first, so that the new leader is preferably on the same level
+        creature *firstMonster = (level == 0 ? monsters->nextCreature : levels[level-1].monsters);
+        for (follower = firstMonster; follower != NULL; follower = follower->nextCreature) {
+            if (follower == monst || follower->leader != monst) continue;
             if (follower->bookkeepingFlags & MB_BOUND_TO_LEADER) {
                 // gonna die in playerTurnEnded().
                 follower->leader = NULL;
@@ -3864,12 +3868,16 @@ void demoteMonsterFromLeadership(creature *monst) {
             }
         }
     }
+
     if (newLeader
         && !atLeastOneNewFollower) {
         newLeader->bookkeepingFlags &= ~MB_LEADER;
     }
-    for (follower = dormantMonsters->nextCreature; follower != NULL; follower = follower->nextCreature) {
-        if (follower->leader == monst && monst != follower) {
+
+    for (int level = 0; level <= DEEPEST_LEVEL; level++) {
+        creature *firstMonster = (level == 0 ? dormantMonsters->nextCreature : levels[level-1].dormantMonsters);
+        for (follower = firstMonster; follower != NULL; follower = follower->nextCreature) {
+            if (follower == monst || follower->leader != monst) continue;
             follower->leader = NULL;
             follower->bookkeepingFlags &= ~MB_FOLLOWER;
         }


### PR DESCRIPTION
When a monster is demoted, we are assigning a new (or no) leader to the monsters on the same level but not to those on other levels. When the monster dies, its memory is freed. Its former followers now hold pointers to freed (and possibly reassigned) memory. This wasn't usually causing a crash, but it was making the game state dependent on `malloc`'s memory management, which isn't good.

This patch checks all levels, to correctly clean up all `leader` pointers.

One of the games on WebRogue's top list was affected by it, resulting in OOS. Possibly many other games that go OOS have the same root cause.

Submitting the patch to `master`, not `release`, because it breaks recordings made with Brogue CE 1.9, which unintentionally *relies* on pointers pointing to the same invalid memory addresses during playback as they did during recording.