### PR TITLE
Fix Spiderweb OOS bug

### DIFF
--- a/changes/prevent-webs-oos.md
+++ b/changes/prevent-webs-oos.md
@@ -1,0 +1,1 @@
+Fixed a bug with nets and spiderwebs that caused an OOS when the player cancelled a move on their last stuck turn

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -859,31 +859,6 @@ boolean playerMoves(short direction) {
                 return true;
             }
         }
-
-        if (player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
-                // Don't interrupt exploration with this message.
-            if (--player.status[STATUS_STUCK]) {
-                if (!rogue.automationActive) {
-                    message("you struggle but cannot free yourself.", false);
-                }
-            } else {
-                if (!rogue.automationActive) {
-                    message("you break free!", false);
-                }
-                if (tileCatalog[pmap[x][y].layers[SURFACE]].flags & T_ENTANGLES) {
-                    pmap[x][y].layers[SURFACE] = NOTHING;
-                }
-            }
-            moveEntrancedMonsters(direction);
-            if (!alreadyRecorded) {
-                recordKeystroke(directionKeys[initialDirection], false, false);
-                alreadyRecorded = true;
-            }
-            if (player.status[STATUS_STUCK]) {
-                playerTurnEnded();
-                return true;
-            }
-        }
     }
 
     if (((!cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY) || (cellHasTMFlag(newX, newY, TM_PROMOTES_WITH_KEY) && keyInPackFor(newX, newY)))
@@ -1093,6 +1068,31 @@ boolean playerMoves(short direction) {
             }
             if (rand_percent(25)) {
                 vomit(&player);
+                playerTurnEnded();
+                return true;
+            }
+        }
+
+        if (player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
+                // Don't interrupt exploration with this message.
+            if (--player.status[STATUS_STUCK]) {
+                if (!rogue.automationActive) {
+                    message("you struggle but cannot free yourself.", false);
+                }
+            } else {
+                if (!rogue.automationActive) {
+                    message("you break free!", false);
+                }
+                if (tileCatalog[pmap[x][y].layers[SURFACE]].flags & T_ENTANGLES) {
+                    pmap[x][y].layers[SURFACE] = NOTHING;
+                }
+            }
+            moveEntrancedMonsters(direction);
+            if (!alreadyRecorded) {
+                recordKeystroke(directionKeys[initialDirection], false, false);
+                alreadyRecorded = true;
+            }
+            if (player.status[STATUS_STUCK]) {
                 playerTurnEnded();
                 return true;
             }


### PR DESCRIPTION
Last-turn web movement was handled before any confirmation (move into chasms, attack an acid mound etc.), which caused an extra record without an RNG check before the turn ended. I moved the spiderweb code right before the rogue attempts to change position instead, which should guarantee that they will move if it is their last stuck turn.