### PR TITLE
Fix invalid pointers to freed memory

### DIFF
--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -3845,8 +3845,13 @@ void demoteMonsterFromLeadership(creature *monst) {
         freeGrid(monst->mapToMe);
         monst->mapToMe = NULL;
     }
-    for (follower = monsters->nextCreature; follower != NULL; follower = follower->nextCreature) {
-        if (follower->leader == monst && monst != follower) {
+
+    for (int level = 0; level <= DEEPEST_LEVEL; level++) {
+        if (rogue.patchVersion < 1 && level > 0) break; // to play back 1.9.0 recordings, skip other levels
+        // we'll work on this level's monsters first, so that the new leader is preferably on the same level
+        creature *firstMonster = (level == 0 ? monsters->nextCreature : levels[level-1].monsters);
+        for (follower = firstMonster; follower != NULL; follower = follower->nextCreature) {
+            if (follower == monst || follower->leader != monst) continue;
             if (follower->bookkeepingFlags & MB_BOUND_TO_LEADER) {
                 // gonna die in playerTurnEnded().
                 follower->leader = NULL;
@@ -3866,12 +3871,17 @@ void demoteMonsterFromLeadership(creature *monst) {
             }
         }
     }
+
     if (newLeader
         && !atLeastOneNewFollower) {
         newLeader->bookkeepingFlags &= ~MB_LEADER;
     }
-    for (follower = dormantMonsters->nextCreature; follower != NULL; follower = follower->nextCreature) {
-        if (follower->leader == monst && monst != follower) {
+
+    for (int level = 0; level <= DEEPEST_LEVEL; level++) {
+        if (rogue.patchVersion < 1 && level > 0) break;
+        creature *firstMonster = (level == 0 ? dormantMonsters->nextCreature : levels[level-1].dormantMonsters);
+        for (follower = firstMonster; follower != NULL; follower = follower->nextCreature) {
+            if (follower == monst || follower->leader != monst) continue;
             follower->leader = NULL;
             follower->bookkeepingFlags &= ~MB_FOLLOWER;
         }


### PR DESCRIPTION
This is the same patch as #137 but with an additional check for v1.9.0 recording playback. It does not need to (and shouldn't) be merged into `master`.