### PR TITLE
Fix a crash from moving entranced monsters

### DIFF
--- a/changes/fix-entrance-crashes.md
+++ b/changes/fix-entrance-crashes.md
@@ -1,0 +1,1 @@
+Fixed a bug that could cause crashes when entranced monsters move.

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -481,16 +481,37 @@ void moveEntrancedMonsters(enum directions dir) {
 
     dir = oppositeDirection(dir);
 
-    for (monst = monsters->nextCreature; monst != NULL; monst = nextMonst) {
-        nextMonst = monst->nextCreature;
-        if (monst->status[STATUS_ENTRANCED]
-            && !monst->status[STATUS_STUCK]
-            && !monst->status[STATUS_PARALYZED]
-            && !(monst->bookkeepingFlags & MB_CAPTIVE)) {
+    if (rogue.patchVersion >= 3) {
+        for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
+            monst->bookkeepingFlags &= ~MB_HAS_ENTRANCED_MOVED;
+        }
 
-            moveMonster(monst, nbDirs[dir][0], nbDirs[dir][1]);
+        for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
+            if (!(monst->bookkeepingFlags & MB_HAS_ENTRANCED_MOVED)
+                && monst->status[STATUS_ENTRANCED]
+                && !monst->status[STATUS_STUCK]
+                && !monst->status[STATUS_PARALYZED]
+                && !(monst->bookkeepingFlags & MB_CAPTIVE)) {
+
+                moveMonster(monst, nbDirs[dir][0], nbDirs[dir][1]);
+                monst->bookkeepingFlags |= MB_HAS_ENTRANCED_MOVED;
+                monst = monsters; // loop through from the beginning to be safe
+            }
+        }
+
+    } else {
+        for (monst = monsters->nextCreature; monst != NULL; monst = nextMonst) {
+            nextMonst = monst->nextCreature;
+            if (monst->status[STATUS_ENTRANCED]
+                && !monst->status[STATUS_STUCK]
+                && !monst->status[STATUS_PARALYZED]
+                && !(monst->bookkeepingFlags & MB_CAPTIVE)) {
+
+                moveMonster(monst, nbDirs[dir][0], nbDirs[dir][1]);
+            }
         }
     }
+
 }
 
 void becomeAllyWith(creature *monst) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2030,6 +2030,7 @@ enum monsterBookkeepingFlags {
     MB_IS_DORMANT               = Fl(21),   // lurking, waiting to burst out
     MB_HAS_SOUL                 = Fl(22),   // slaying the monster will count toward weapon auto-ID
     MB_ALREADY_SEEN             = Fl(23),   // seeing this monster won't interrupt exploration
+    MB_HAS_ENTRANCED_MOVED      = Fl(24)    // has already moved while entranced and should not move again
 };
 
 // Defines all creatures, which include monsters and the player:


### PR DESCRIPTION
moveEntrancedMonsters didn't account for a monster dying in the middle of the turn. If an entranced monster moves and the next monster in the chain dies, the rest of the function will iterate across the rest of the dead monsters from that turn, potentially moving an already dead monster and causing crashes.

This code makes the loop similar to what happens in regular monster movement. It restarts every time an entranced monster moves and uses a new bookkeeping flag to keep track of who has already moved.