### PR TITLE
Don't leak the identity of a wand or staff in the combat message for reflection

### DIFF
--- a/changes/dont-leak-zap-names-on-reflect.md
+++ b/changes/dont-leak-zap-names-on-reflect.md
@@ -1,0 +1,1 @@
+Fixes an issue where a bolt from an unidentified staff or wand would be referred to by name if it was reflected.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4675,7 +4675,7 @@ boolean zap(short originLoc[2], short targetLoc[2], bolt *theBolt, boolean hideD
                 sprintf(buf, "%s deflect%s the %s",
                         monstName,
                         (monst == &player ? "" : "s"),
-                        theBolt->name);
+                        hideDetails ? "bolt" : theBolt->name);
                 combatMessage(buf, 0);
             }
             if (monst == &player


### PR DESCRIPTION
fixes #115 

Here's an example, where rats are reflective. On first use it's referred to as a bolt, on second use it's identified as flame. Also, poor me, and poor rats.
![image](https://user-images.githubusercontent.com/6645121/96905278-3eeef700-1466-11eb-928d-c69e90b0589f.png)

