### PR TITLE
"<monster> seizes your legs!" displayed in error

### DIFF
--- a/changes/bugfix-grappling-salamander.md
+++ b/changes/bugfix-grappling-salamander.md
@@ -1,0 +1,1 @@
+Fixed a bug where the message "<monster> seizes your legs!" was displayed in error.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1044,7 +1044,10 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
     monsterName(defenderName, defender, true);
 
     if ((attacker->info.abilityFlags & MA_SEIZES)
-        && (!(attacker->bookkeepingFlags & MB_SEIZING) || !(defender->bookkeepingFlags & MB_SEIZED))) {
+        && (!(attacker->bookkeepingFlags & MB_SEIZING) || !(defender->bookkeepingFlags & MB_SEIZED))
+        && (rogue.patchVersion < 2 ||
+            (distanceBetween(attacker->xLoc, attacker->yLoc, defender->xLoc, defender->yLoc) == 1
+            && !diagonalBlocked(attacker->xLoc, attacker->yLoc, defender->xLoc, defender->yLoc, false)))) {
 
         attacker->bookkeepingFlags |= MB_SEIZING;
         defender->bookkeepingFlags |= MB_SEIZED;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -33,11 +33,11 @@
 #define USE_UNICODE
 
 // Brogue version: what the user sees in the menu and title
-#define BROGUE_VERSION_STRING "CE 1.9.1"
+#define BROGUE_VERSION_STRING "CE 1.9.2"
 
 // Recording version. Saved into recordings and save files made by this version.
 // Cannot be longer than 16 chars
-#define BROGUE_RECORDING_VERSION_STRING "CE 1.9.1"
+#define BROGUE_RECORDING_VERSION_STRING "CE 1.9.2"
 
 /* Patch pattern. A scanf format string which matches an unsigned short. If this
 matches against a recording version string, it defines a "patch version." During


### PR DESCRIPTION
Fixed a bug where the message "<monster> seizes your legs!" was displayed in error. The message occurred when attacked by a non-adjacent grappling salamander. The player was still free to move, since seizing only takes effect when the monster is adjacent.