### PR TITLE
Fix transference percentage shown as negative (#94)

### DIFF
--- a/changes/fix-negative-transference.md
+++ b/changes/fix-negative-transference.md
@@ -1,0 +1,1 @@
+Fixed a bug where transference allowed over-healing and the health bar displayed the amount as a negative percentage.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1504,7 +1504,11 @@ boolean inflictDamage(creature *attacker, creature *defender,
             transferenceAmount = transferenceAmount * 9 / 10; // enemies get 90% recovery rate, deal with it
         }
 
-        attacker->currentHP += transferenceAmount;
+        if (rogue.patchVersion < 1) {
+            attacker->currentHP += transferenceAmount;
+        } else if (rogue.patchVersion >= 1) {
+            attacker->currentHP = min(attacker->currentHP + transferenceAmount, attacker->info.maxHP); // can't overheal
+        }
 
         if (attacker == &player && player.currentHP <= 0) {
             gameOver("Drained by a cursed ring", true);


### PR DESCRIPTION
I think this change is effectively a nerf to transference since the fix eliminates over-healing.

Prior to the fix, this was the behavior during a single combat turn where both the player and monster land a blow...

Player max HP = 60
Player hits monster and over-heals to 63 HP.
Monster hits player, dealing 6 damage. Player health reduced to 57 HP.
