### PR TITLE
Fix title screen menu item mouseover

### DIFF
--- a/changes/main-menu-mouseover.md
+++ b/changes/main-menu-mouseover.md
@@ -1,0 +1,1 @@
+Menu items in the title screen react to mouse-over again.

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -656,7 +656,9 @@ void mainBrogueJunction() {
         switch (rogue.nextGame) {
             case NG_NOTHING:
                 // Run the main menu to get a decision out of the player.
+                inTitleMenu = true;
                 titleMenu();
+                inTitleMenu = false;
                 break;
             case NG_NEW_GAME:
             case NG_NEW_GAME_WITH_SEED:

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2591,6 +2591,7 @@ typedef struct buttonState {
 } buttonState;
 
 extern boolean serverMode;
+extern boolean inTitleMenu;
 extern boolean hasGraphics;
 extern boolean graphicsEnabled;
 

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -9,6 +9,7 @@ struct brogueConsole currentConsole;
 int brogueFontSize = 0;
 char dataDirectory[BROGUE_FILENAME_MAX] = STRINGIFY(DATADIR);
 boolean serverMode = false;
+boolean inTitleMenu = false;
 boolean hasGraphics = false;
 boolean graphicsEnabled = false;
 boolean isCsvFormat = false;

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -384,19 +384,17 @@ static void _gameLoop() {
     SDL_Quit();
 }
 
+static boolean isInterrupting(rogueEvent event) {
+    return lastEvent.eventType != EVENT_ERROR
+        && (lastEvent.eventType != MOUSE_ENTERED_CELL || inTitleMenu);
+}
 
 static boolean _pauseForMilliseconds(short ms) {
     SDL_UpdateWindowSurface(Win);
     SDL_Delay(ms);
-
-    if (lastEvent.eventType != EVENT_ERROR
-        && lastEvent.eventType != MOUSE_ENTERED_CELL) {
-        return true; // SDL already gave us an interrupting event to process
-    }
-
-    return pollBrogueEvent(&lastEvent, false) // ask SDL for a new event if one is available
-        && lastEvent.eventType != EVENT_ERROR // and check if it is interrupting
-        && lastEvent.eventType != MOUSE_ENTERED_CELL;
+    return isInterrupting(lastEvent)            // SDL already gave us an interrupting event to process
+        || (pollBrogueEvent(&lastEvent, false)  // ask SDL for a new event if one is available
+            && isInterrupting(lastEvent));      // ...and check if it is interrupting
 }
 
 


### PR DESCRIPTION
The title screen wasn't reacting to mouse movements like it was supposed to; only to mouse clicks and keypresses. This small patch finally fixes it.