### PR TITLE
Add "go to previous level" key to replay viewer (#55)

### DIFF
--- a/changes/replay-goto-previous-level.md
+++ b/changes/replay-goto-previous-level.md
@@ -1,0 +1,1 @@
+Added "go to previous level" to replay viewer

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -248,6 +248,13 @@ short actionMenu(short x, boolean playingBack) {
             buttons[buttonCount].hotkey[0] = '0';
             buttonCount++;
             if (KEYBOARD_LABELS) {
+                sprintf(buttons[buttonCount].text,  "  %s<:%s Previous Level  ", yellowColorEscape, whiteColorEscape);
+            } else {
+                strcpy(buttons[buttonCount].text, "  Previous Level  ");
+            }
+            buttons[buttonCount].hotkey[0] = ASCEND_KEY;
+            buttonCount++;
+            if (KEYBOARD_LABELS) {
                 sprintf(buttons[buttonCount].text,  "  %s>:%s Next Level  ", yellowColorEscape, whiteColorEscape);
             } else {
                 strcpy(buttons[buttonCount].text, "  Next Level  ");

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -686,16 +686,7 @@ static void seek(unsigned long seekTarget, enum recordingSeekModes seekMode) {
     boolean pauseState, useProgressBar, arrivedAtDestination = false;
     cellDisplayBuffer dbuf[COLS][ROWS];
 
-    if (seekMode == RECORDING_SEEK_MODE_DEPTH && seekTarget > maxLevelChanges) {
-        flashTemporaryAlert(" Already reached deepest depth explored ", 2000);
-        return;
-    }
-
     pauseState = rogue.playbackPaused;
-
-    if (seekMode == RECORDING_SEEK_MODE_DEPTH && seekTarget < 1) {
-        seekTarget = 1;
-    }
 
     // configure progress bar
     switch (seekMode) {
@@ -885,9 +876,13 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                 }
                 return true;
             case ASCEND_KEY:
-                seek(rogue.depthLevel - 1, RECORDING_SEEK_MODE_DEPTH);
+                seek(max(rogue.depthLevel - 1, 1), RECORDING_SEEK_MODE_DEPTH);
                 return true;
             case DESCEND_KEY:
+                if (rogue.depthLevel == maxLevelChanges) {
+                    flashTemporaryAlert(" Already reached deepest depth explored ", 2000);
+                    return false;
+                }
                 seek(rogue.depthLevel + 1, RECORDING_SEEK_MODE_DEPTH);
                 return true;
             case INVENTORY_KEY:

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -34,6 +34,10 @@ static const long keystrokeTable[] = {UP_ARROW, LEFT_ARROW, DOWN_ARROW, RIGHT_AR
 
 static const int keystrokeCount = sizeof(keystrokeTable) / sizeof(*keystrokeTable);
 
+enum recordingSeekModes {
+    RECORDING_SEEK_MODE_TURN,
+    RECORDING_SEEK_MODE_DEPTH
+};
 
 void recordChar(unsigned char c) {
     inputRecordBuffer[locationInRecordingBuffer++] = c;
@@ -598,7 +602,7 @@ boolean unpause() {
     return false;
 }
 
-#define PLAYBACK_HELP_LINE_COUNT    19
+#define PLAYBACK_HELP_LINE_COUNT    20
 
 void printPlaybackHelpScreen() {
     short i, j;
@@ -609,7 +613,8 @@ void printPlaybackHelpScreen() {
         "         <space>: ****pause or unpause playback",
         "   k or up arrow: ****play back faster",
         " j or down arrow: ****play back slower",
-        "               >: ****skip to next level",
+        "               <: ****go to previous level",
+        "               >: ****go to next level",
         "             0-9: ****skip to specified turn number",
         "l or right arrow: ****advance one turn (shift for 5 turns; control for 20)",
         "",
@@ -653,34 +658,84 @@ void printPlaybackHelpScreen() {
     overlayDisplayBuffer(rbuf, NULL);
 }
 
-void advanceToLocation(unsigned long destinationFrame) {
-    unsigned long progressBarInterval, initialFrameNumber;
-    rogueEvent theEvent;
-    boolean useProgressBar, omniscient, stealth, trueColors;
+static void resetPlayback() {
+    boolean omniscient, stealth, trueColors;
 
     omniscient = rogue.playbackOmniscience;
     stealth = rogue.displayAggroRangeMode;
     trueColors = rogue.trueColorMode;
-    rogue.playbackOmniscience = false;
-    rogue.displayAggroRangeMode = false;
-    rogue.trueColorMode = false;
 
+    freeEverything();
+    randomNumbersGenerated = 0;
+    rogue.playbackMode = true;
+    initializeRogue(0); // Seed argument is ignored because we're in playback.
+
+    rogue.playbackOmniscience = omniscient;
+    rogue.displayAggroRangeMode = stealth;
+    rogue.trueColorMode = trueColors;
+
+    rogue.playbackFastForward = false;
+    blackOutScreen();
+    rogue.playbackFastForward = true;
+    startLevel(rogue.depthLevel, 1);
+}
+
+static void seek(unsigned long seekTarget, enum recordingSeekModes seekMode) {
+    unsigned long progressBarRefreshInterval = 1, startTurnNumber = 0, targetTurnNumber = 0, avgTurnsPerLevel = 1;
+    rogueEvent theEvent;
+    boolean pauseState, useProgressBar, arrivedAtDestination = false;
     cellDisplayBuffer dbuf[COLS][ROWS];
 
-    if (destinationFrame < rogue.playerTurnNumber) {
-        useProgressBar = (destinationFrame > 100 ? true : false);
+    if (seekMode == RECORDING_SEEK_MODE_DEPTH && seekTarget > maxLevelChanges) {
+        flashTemporaryAlert(" Already reached deepest depth explored ", 2000);
+        return;
+    }
 
-        // Start the recording over, and fast-forward to chosen frame.
-        freeEverything();
-        randomNumbersGenerated = 0;
-        rogue.playbackMode = true;
-        initializeRogue(0); // Seed argument is ignored because we're in playback.
-        startLevel(rogue.depthLevel, 1);
-        if (useProgressBar) {
-            blackOutScreen();
+    pauseState = rogue.playbackPaused;
+
+    if (seekMode == RECORDING_SEEK_MODE_DEPTH && seekTarget < 1) {
+        seekTarget = 1;
+    }
+
+    // configure progress bar
+    switch (seekMode) {
+        case RECORDING_SEEK_MODE_DEPTH :
+            if (maxLevelChanges > 0) {
+                avgTurnsPerLevel = rogue.howManyTurns / maxLevelChanges;
+            }
+            if (seekTarget <= rogue.depthLevel) {
+                startTurnNumber = 0;
+                targetTurnNumber = avgTurnsPerLevel * seekTarget;
+            } else {
+                startTurnNumber = rogue.playerTurnNumber;
+                targetTurnNumber = rogue.playerTurnNumber + avgTurnsPerLevel;
+            }
+            break;
+        case RECORDING_SEEK_MODE_TURN :
+            if (seekTarget < rogue.playerTurnNumber) {
+                startTurnNumber = 0;
+                targetTurnNumber = seekTarget;
+            } else {
+                startTurnNumber = rogue.playerTurnNumber;
+                targetTurnNumber = seekTarget;
+            }
+            break;
+    }
+
+    if (targetTurnNumber - startTurnNumber > 100) {
+        useProgressBar = true;
+        progressBarRefreshInterval = max(1, (targetTurnNumber) / 500);
+    }
+
+    // there is no rewind, so start over at depth 1
+    if ((seekMode == RECORDING_SEEK_MODE_TURN && seekTarget < rogue.playerTurnNumber)
+        || (seekMode == RECORDING_SEEK_MODE_DEPTH && seekTarget <= rogue.depthLevel)) {
+
+        resetPlayback();
+        if ((seekMode == RECORDING_SEEK_MODE_DEPTH && seekTarget == 1)
+            || (seekMode == RECORDING_SEEK_MODE_TURN && seekTarget == 0)) {
+            arrivedAtDestination = true;
         }
-    } else {
-        useProgressBar = (destinationFrame - rogue.playerTurnNumber > 100 ? true : false);
     }
 
     clearDisplayBuffer(dbuf);
@@ -688,17 +743,14 @@ void advanceToLocation(unsigned long destinationFrame) {
     overlayDisplayBuffer(dbuf, 0);
     commitDraws();
     displayMoreSign();
-
     rogue.playbackFastForward = true;
-    progressBarInterval = max(1, (destinationFrame - rogue.playerTurnNumber) / 500);
-    initialFrameNumber = rogue.playerTurnNumber;
 
-    while (rogue.playerTurnNumber < destinationFrame && !rogue.gameHasEnded && !rogue.playbackOOS) {
-        if (useProgressBar && !(rogue.playerTurnNumber % progressBarInterval)) {
+    while (!arrivedAtDestination && !rogue.gameHasEnded && !rogue.playbackOOS) {
+        if (useProgressBar && !(rogue.playerTurnNumber % progressBarRefreshInterval)) {
             rogue.playbackFastForward = false; // so that pauseBrogue looks for inputs
             printProgressBar((COLS - 20) / 2, ROWS / 2, "[     Loading...   ]",
-                             rogue.playerTurnNumber - initialFrameNumber,
-                             destinationFrame - initialFrameNumber, &darkPurple, false);
+                             rogue.playerTurnNumber - startTurnNumber,
+                             targetTurnNumber - startTurnNumber, &darkPurple, false);
             while (pauseBrogue(0)) { // pauseBrogue(0) is necessary to flush the display to the window in SDL
                 if (rogue.gameHasEnded) {
                     return;
@@ -714,13 +766,15 @@ void advanceToLocation(unsigned long destinationFrame) {
         nextBrogueEvent(&theEvent, false, true, false);
         rogue.RNG = RNG_SUBSTANTIVE;
         executeEvent(&theEvent);
+
+        if ((seekMode == RECORDING_SEEK_MODE_DEPTH && rogue.depthLevel == seekTarget)
+            || (seekMode == RECORDING_SEEK_MODE_TURN && rogue.playerTurnNumber == seekTarget)) {
+
+            arrivedAtDestination = true;
+        }
     }
 
-    rogue.playbackOmniscience = omniscient;
-    rogue.displayAggroRangeMode = stealth;
-    rogue.trueColorMode = trueColors;
-
-    rogue.playbackPaused = true;
+    rogue.playbackPaused = pauseState;
     rogue.playbackFastForward = false;
     confirmMessages();
     updateMessageDisplay();
@@ -753,7 +807,7 @@ void promptToAdvanceToLocation(short keystroke) {
                 sprintf(buf, " Already at turn %li ", destinationFrame);
                 flashTemporaryAlert(buf, 1000);
             } else {
-                advanceToLocation(destinationFrame);
+                seek(destinationFrame, RECORDING_SEEK_MODE_TURN);
             }
             rogue.playbackPaused = true;
         }
@@ -781,10 +835,9 @@ void pausePlayback() {
 // Used to interact with playback -- e.g. changing speed, pausing.
 boolean executePlaybackInput(rogueEvent *recordingInput) {
     signed long key;
-    short newDelay, frameCount, x, y, previousDeepestLevel;
+    short newDelay, frameCount, x, y;
     unsigned long destinationFrame;
-    boolean pauseState, proceed;
-    rogueEvent theEvent;
+    boolean proceed;
     char path[BROGUE_FILENAME_MAX];
 
     if (!rogue.playbackMode) {
@@ -831,31 +884,11 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                     messageWithColor("Omniscience disabled.", &teal, false);
                 }
                 return true;
+            case ASCEND_KEY:
+                seek(rogue.depthLevel - 1, RECORDING_SEEK_MODE_DEPTH);
+                return true;
             case DESCEND_KEY:
-                pauseState = rogue.playbackPaused;
-                previousDeepestLevel = rogue.deepestLevel;
-                if (!rogue.playbackPaused || unpause()) {
-                    if ((unsigned long) rogue.deepestLevel < maxLevelChanges) {
-                        displayCenteredAlert(" Loading... ");
-                        commitDraws();
-                        rogue.playbackFastForward = true;
-                        while ((rogue.deepestLevel <= previousDeepestLevel || !rogue.playbackBetweenTurns)
-                               && !rogue.gameHasEnded) {
-                            rogue.RNG = RNG_COSMETIC; // dancing terrain colors can't influence recordings
-                            nextBrogueEvent(&theEvent, false, true, false);
-                            rogue.RNG = RNG_SUBSTANTIVE;
-                            executeEvent(&theEvent);
-                        }
-                        rogue.playbackFastForward = false;
-                        rogue.playbackPaused = pauseState;
-                        displayLevel();
-                        refreshSideBar(-1, -1, false);
-                        updateMessageDisplay();
-                    } else {
-                        flashTemporaryAlert(" Already reached deepest depth explored ", 1000);
-                    }
-                }
-                rogue.playbackPaused = pauseState;
+                seek(rogue.depthLevel + 1, RECORDING_SEEK_MODE_DEPTH);
                 return true;
             case INVENTORY_KEY:
                 rogue.playbackMode = false;
@@ -873,11 +906,9 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                 }
                 if (recordingInput->shiftKey) {
                     frameCount *= 5;
-                    rogue.playbackFastForward = true;
                 }
                 if (recordingInput->controlKey) {
                     frameCount *= 20;
-                    rogue.playbackFastForward = true;
                 }
 
                 if (frameCount < 0) {
@@ -897,26 +928,11 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                     proceed = (rogue.playerTurnNumber < 100 || confirm("Rewind?", true));
                     rogue.playbackMode = true;
                     if (proceed) {
-                        advanceToLocation(destinationFrame);
+                        seek(destinationFrame, RECORDING_SEEK_MODE_TURN);
                     }
                 } else {
                     // advance by the right number of turns
-                    if (!rogue.playbackPaused || unpause()) {
-                        while (rogue.playerTurnNumber < destinationFrame && !rogue.gameHasEnded && !rogue.playbackOOS) {
-                            rogue.RNG = RNG_COSMETIC; // dancing terrain colors can't influence recordings
-                            rogue.playbackDelayThisTurn = 0;
-                            nextBrogueEvent(&theEvent, false, true, false);
-                            rogue.RNG = RNG_SUBSTANTIVE;
-                            executeEvent(&theEvent);
-                        }
-                        rogue.playbackPaused = true;
-                        if (rogue.playbackFastForward) {
-                            rogue.playbackFastForward = false;
-                            displayLevel();
-                            updateMessageDisplay();
-                        }
-                        refreshSideBar(-1, -1, false);
-                    }
+                    seek(destinationFrame, RECORDING_SEEK_MODE_TURN);
                 }
                 return true;
             case BROGUE_HELP_KEY:


### PR DESCRIPTION
I think persisting the first arrival turn for each level is viable, but this PR doesn't use that approach and consequently there is some duplicated logic with advanceToLocation. I didn't see an obvious way to share the logic other than creating a half-dozen small functions. I ended up just creating one for playbackReset. With persisted turns, advanceToLocation would handle all navigation.

I think a neat way to persist would be a linked list of depth changes. In fact, it might be useful to add "next/previous Depth Change" navigation options. Having said, the current PR gets the job done. :-)