### PR TITLE
Fix OOS message polluted by player/monsters

### DIFF
--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -295,6 +295,7 @@ void playbackPanic() {
         rogue.playbackFastForward = false;
         rogue.playbackPaused = true;
         rogue.playbackOOS = true;
+        rogue.creaturesWillFlashThisTurn = false;
         blackOutScreen();
         displayLevel();
         refreshSideBar(-1, -1, false);


### PR DESCRIPTION
The OOS message was shown underneath the player, and sometimes monsters.

Before patch -- cf. `recorded ga@e` on the second line:

![Screenshot_20201027_114736](https://user-images.githubusercontent.com/69065091/97344196-0b3d1400-184e-11eb-9df6-7a9c4581f8c5.png)

After patch:

![Screenshot_20201027_115021](https://user-images.githubusercontent.com/69065091/97344208-1132f500-184e-11eb-9ed7-fd4f8579ca9b.png)