### PR TITLE
Fix negative transference percentage (#94)

### DIFF
--- a/changes/fix-negative-transference.md
+++ b/changes/fix-negative-transference.md
@@ -1,0 +1,3 @@
+Fixed a bug which caused the player's health bar to display a negative percentage when landing a hit with a transference
+ring equipped. This occurred because transference provides a temporary health bonus in excess of the player's maximum.
+If the player takes no damage during the turn, the health bonus is lost. 

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4238,7 +4238,8 @@ short creatureHealthChangePercent(creature *monst) {
     if (monst->previousHealthPoints <= 0) {
         return 0;
     }
-    return 100 * (monst->currentHP - monst->previousHealthPoints) / monst->info.maxHP;
+    // ignore overhealing from tranference
+    return 100 * (monst->currentHP - min(monst->previousHealthPoints, monst->info.maxHP)) / monst->info.maxHP;
 }
 
 // returns the y-coordinate after the last line printed


### PR DESCRIPTION
This fixes the display issue only.

Fixed a bug which caused the player's health bar to display a negative percentage when landing a hit with a transference
ring equipped. This occurred because transference provides a temporary health bonus in excess of the player's maximum.
If the player takes no damage during the turn, the health bonus is lost. 