### PR TITLE
Fix warnings reported by Visual Studio

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -373,7 +373,7 @@ short actionMenu(short x, boolean playingBack) {
         buttonCount++;
         if (KEYBOARD_LABELS) { // No help button if we're not in keyboard mode.
             sprintf(buttons[buttonCount].text, "  %s?: %sHelp  ", yellowColorEscape, whiteColorEscape);
-            buttons[buttonCount].hotkey[0] = HELP_KEY;
+            buttons[buttonCount].hotkey[0] = BROGUE_HELP_KEY;
             buttonCount++;
         }
         sprintf(buttons[buttonCount].text, "    %s---", darkGrayColorEscape);
@@ -2170,17 +2170,17 @@ void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart
                     percentComplete *= 1.0 + (100.0 - min(100, distanceMap[windowToMapX(i)][windowToMapY(j)])) / 100.;
                 }
 
-                weight = (short) percentComplete + weightGrid[i][j][2] * percentComplete * 10;
+                weight = (short)(percentComplete + weightGrid[i][j][2] * percentComplete * 10);
                 weight = min(100, weight);
                 tempColor = black;
 
-                tempColor.red = ((short) percentComplete + weightGrid[i][j][0] * percentComplete * 10) * colorMid.red / 100;
+                tempColor.red = (short)(percentComplete + weightGrid[i][j][0] * percentComplete * 10) * colorMid.red / 100;
                 tempColor.red = min(colorMid.red, tempColor.red);
 
-                tempColor.green = ((short) percentComplete + weightGrid[i][j][1] * percentComplete * 10) * colorMid.green / 100;
+                tempColor.green = (short)(percentComplete + weightGrid[i][j][1] * percentComplete * 10) * colorMid.green / 100;
                 tempColor.green = min(colorMid.green, tempColor.green);
 
-                tempColor.blue = ((short) percentComplete + weightGrid[i][j][2] * percentComplete * 10) * colorMid.blue / 100;
+                tempColor.blue = (short)(percentComplete + weightGrid[i][j][2] * percentComplete * 10) * colorMid.blue / 100;
                 tempColor.blue = min(colorMid.blue, tempColor.blue);
 
                 backColor = black;
@@ -2615,7 +2615,7 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
         case MESSAGE_ARCHIVE_KEY:
             displayMessageArchive();
             break;
-        case HELP_KEY:
+        case BROGUE_HELP_KEY:
             printHelpScreen();
             break;
         case DISCOVERIES_KEY:

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2170,7 +2170,7 @@ void itemDetails(char *buf, item *theItem) {
                                     && runicWeaponChance(theItem, false, 0) < runicWeaponChance(theItem, true, enchant + enchantIncrement(theItem))){
                                     sprintf(buf2, "(If the %s is enchanted, the chance will increase to %i%%",
                                             theName,
-                                            runicWeaponChance(theItem, true, (float) (enchant + enchantIncrement(theItem))));
+                                            runicWeaponChance(theItem, true, enchant + enchantIncrement(theItem)));
                                     strcat(buf, buf2);
                                     if (nextLevelState) {
                                         if (theItem->enchant2 == W_FORCE) {
@@ -2337,7 +2337,7 @@ void itemDetails(char *buf, item *theItem) {
             // charges
             new = apparentRingBonus(RING_WISDOM);
             if ((theItem->flags & ITEM_IDENTIFIED)  || rogue.playbackOmniscience) {
-                sprintf(buf2, "\n\nThe %s has %i charges remaining out of a maximum of %i charges, and%s recovers a charge in approximately %i turns. ",
+                sprintf(buf2, "\n\nThe %s has %i charges remaining out of a maximum of %i charges, and%s recovers a charge in approximately %lli turns. ",
                         theName,
                         theItem->charges,
                         theItem->enchant1,
@@ -2345,7 +2345,7 @@ void itemDetails(char *buf, item *theItem) {
                         FP_DIV(staffChargeDuration(theItem), 10 * ringWisdomMultiplier(new * FP_FACTOR)));
                 strcat(buf, buf2);
             } else if (theItem->flags & ITEM_MAX_CHARGES_KNOWN) {
-                sprintf(buf2, "\n\nThe %s has a maximum of %i charges, and%s recovers a charge in approximately %i turns. ",
+                sprintf(buf2, "\n\nThe %s has a maximum of %i charges, and%s recovers a charge in approximately %lli turns. ",
                         theName,
                         theItem->enchant1,
                         new == 0 ? "" : ", with your current rings,",

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -778,7 +778,7 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
         switch (key) {
             case UP_ARROW:
             case UP_KEY:
-                newDelay = max(1, min(rogue.playbackDelayPerTurn / 1.5, rogue.playbackDelayPerTurn - 1));
+                newDelay = max(1, min(rogue.playbackDelayPerTurn * 2/3, rogue.playbackDelayPerTurn - 1));
                 if (newDelay != rogue.playbackDelayPerTurn) {
                     flashTemporaryAlert(" Faster ", 300);
                 }
@@ -787,7 +787,7 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                 return true;
             case DOWN_ARROW:
             case DOWN_KEY:
-                newDelay = min(3000, max(rogue.playbackDelayPerTurn * 1.5, rogue.playbackDelayPerTurn + 1));
+                newDelay = min(3000, max(rogue.playbackDelayPerTurn * 3/2, rogue.playbackDelayPerTurn + 1));
                 if (newDelay != rogue.playbackDelayPerTurn) {
                     flashTemporaryAlert(" Slower ", 300);
                 }
@@ -899,7 +899,7 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                     }
                 }
                 return true;
-            case HELP_KEY:
+            case BROGUE_HELP_KEY:
                 printPlaybackHelpScreen();
                 return true;
             case DISCOVERIES_KEY:
@@ -1252,7 +1252,7 @@ void describeKeystroke(unsigned char key, char *description) {
         DESCEND_KEY, ASCEND_KEY, REST_KEY, AUTO_REST_KEY, SEARCH_KEY, INVENTORY_KEY,
         ACKNOWLEDGE_KEY, EQUIP_KEY, UNEQUIP_KEY, APPLY_KEY, THROW_KEY, RELABEL_KEY, DROP_KEY, CALL_KEY,
         //FIGHT_KEY, FIGHT_TO_DEATH_KEY,
-        HELP_KEY, DISCOVERIES_KEY, RETURN_KEY,
+        BROGUE_HELP_KEY, DISCOVERIES_KEY, RETURN_KEY,
         EXPLORE_KEY, AUTOPLAY_KEY, SEED_KEY, EASY_MODE_KEY, ESCAPE_KEY,
         RETURN_KEY, DELETE_KEY, TAB_KEY, PERIOD_KEY, VIEW_RECORDING_KEY, NUMPAD_0,
         NUMPAD_1, NUMPAD_2, NUMPAD_3, NUMPAD_4, NUMPAD_5, NUMPAD_6, NUMPAD_7, NUMPAD_8,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1118,7 +1118,7 @@ enum tileFlags {
 #define CALL_KEY            'c'
 #define QUIT_KEY            'Q'
 #define MESSAGE_ARCHIVE_KEY 'M'
-#define HELP_KEY            '?'
+#define BROGUE_HELP_KEY     '?'
 #define DISCOVERIES_KEY     'D'
 #define EXPLORE_KEY         'x'
 #define AUTOPLAY_KEY        'A'


### PR DESCRIPTION
When compiling Brogue CE with Visual Studio 2019 Community Edition, at warning level `/W2`, the compiler detects a few issues:

- several unintended or unnecessary conversions from/to `double`
- `%i` was used in two places for `long long int` values
- `HELP_KEY` conflicts with a symbol from the Win32 API