### PR TITLE
Show granite wall around negative spaces (granite)

### DIFF
--- a/changes/display-granite-around-voids.md
+++ b/changes/display-granite-around-voids.md
@@ -1,0 +1,1 @@
+Voids between rooms are now lined with granite instead of bricks.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -1333,6 +1333,11 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
         cellChar = G_WALL_TOP;
     }
 
+    // If the tile below hasn't been discovered, show granite intead of brick
+    if (cellChar == G_WALL && !(coordinatesAreInMap(x, y+1) && (pmap[x][y+1].flags & DISCOVERED))) {
+        cellChar = G_GRANITE;
+    }
+
     if (((pmap[x][y].flags & ITEM_DETECTED) || monsterWithDetectedItem
          || (monst && monsterRevealed(monst)))
         && !playerCanSeeOrSense(x, y)) {


### PR DESCRIPTION
I'd be curious to know what you think of this one. We are currently showing bricks around the voids between rooms. Since these voids are actually solid granite, why not use the granite tile? It seems to make the map easier to understand, as it clearly differentiates between rooms (where you can go) and solid mass (where you can't).

![animation](https://user-images.githubusercontent.com/69065091/97771613-fbe6f080-1b03-11eb-91ac-c8364cff2f39.gif)
