### PR TITLE
Fix display of magic-mapped walls

### DIFF
--- a/changes/fix-magic-mapped-wall-display.md
+++ b/changes/fix-magic-mapped-wall-display.md
@@ -1,0 +1,1 @@
+Walls discovered with the scroll of magic mapping were not smoothed out.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -1278,12 +1278,6 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
             return;
         }
 
-        // Smooth out walls: if there's a "wall-ish" tile drawn below us, just draw the wall top
-        if ((cellChar == G_WALL || cellChar == G_GRANITE) && coordinatesAreInMap(x, y+1)
-            && glyphIsWallish(displayBuffer[mapToWindowX(x)][mapToWindowY(y+1)].character)) {
-            cellChar = G_WALL_TOP;
-        }
-
         if (gasAugmentWeight && ((pmap[x][y].flags & DISCOVERED) || rogue.playbackOmniscience)) {
             if (!rogue.trueColorMode || !needDistinctness) {
                 applyColorAverage(&cellForeColor, &gasAugmentColor, gasAugmentWeight);
@@ -1331,6 +1325,12 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
             cellForeColor = colorFromComponents(pmap[x][y].rememberedAppearance.foreColorComponents);
             cellBackColor = colorFromComponents(pmap[x][y].rememberedAppearance.backColorComponents);
         }
+    }
+
+    // Smooth out walls: if there's a "wall-ish" tile drawn below us, just draw the wall top
+    if ((cellChar == G_WALL || cellChar == G_GRANITE) && coordinatesAreInMap(x, y+1)
+        && glyphIsWallish(displayBuffer[mapToWindowX(x)][mapToWindowY(y+1)].character)) {
+        cellChar = G_WALL_TOP;
     }
 
     if (((pmap[x][y].flags & ITEM_DETECTED) || monsterWithDetectedItem


### PR DESCRIPTION
Walls discovered with the scroll of magic mapping were not displayed correctly. The "Smooth out walls" code didn't apply to them.

![animation](https://user-images.githubusercontent.com/69065091/97785180-0ab3be80-1b69-11eb-917c-b3a71bde6be0.gif)
