### PR TITLE
Fix unresponsive window close button

### DIFF
--- a/changes/fix-close-window-button.md
+++ b/changes/fix-close-window-button.md
@@ -1,0 +1,1 @@
+The `[x]` button now closes the window without delay, also auto-saving the game.

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -392,6 +392,23 @@ void titleMenu() {
     }
 }
 
+// Closes Brogue without any further prompts, animations, or user interaction.
+void quitImmediately() {
+    // If we are recording a game, save it.
+    if (rogue.recording) {
+        flushBufferToFile();
+        if (rogue.gameInProgress && !rogue.quit && !rogue.gameHasEnded) {
+            // Game isn't over yet, create a savegame.
+            saveGameNoPrompt();
+        } else {
+            // Save it as a recording.
+            char path[BROGUE_FILENAME_MAX];
+            saveRecordingNoPrompt(path);
+        }
+    }
+    exit(0);
+}
+
 void dialogAlert(char *message) {
     cellDisplayBuffer rbuf[COLS][ROWS];
 

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1058,6 +1058,19 @@ boolean characterForbiddenInFilename(const char theChar) {
     }
 }
 
+void saveGameNoPrompt() {
+    char filePath[BROGUE_FILENAME_MAX];
+    if (rogue.playbackMode) {
+        return;
+    }
+    getAvailableFilePath(filePath, "Saved game", GAME_SUFFIX);
+    flushBufferToFile();
+    strcat(filePath, GAME_SUFFIX);
+    rename(currentFilePath, filePath);
+    strcpy(currentFilePath, filePath);
+    rogue.gameHasEnded = true;
+}
+
 void saveGame() {
     char filePath[BROGUE_FILENAME_MAX], defaultPath[BROGUE_FILENAME_MAX];
     boolean askAgain;

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -523,6 +523,7 @@ void initRecording() {
         fclose(recordFile);
 
         flushBufferToFile(); // header info never makes it into inputRecordBuffer when recording
+        rogue.recording = true;
     }
     rogue.currentTurnNumber = 0;
 }
@@ -1069,6 +1070,7 @@ void saveGameNoPrompt() {
     rename(currentFilePath, filePath);
     strcpy(currentFilePath, filePath);
     rogue.gameHasEnded = true;
+    rogue.recording = false;
 }
 
 void saveGame() {
@@ -1092,6 +1094,7 @@ void saveGame() {
                 flushBufferToFile();
                 rename(currentFilePath, filePath);
                 strcpy(currentFilePath, filePath);
+                rogue.recording = false;
                 message("Saved.", true);
                 rogue.gameHasEnded = true;
             } else {
@@ -1111,6 +1114,7 @@ void saveRecordingNoPrompt(char *filePath)
     strcat(filePath, RECORDING_SUFFIX);
     remove(filePath);
     rename(currentFilePath, filePath);
+    rogue.recording = false;
 }
 
 void saveRecording(char *filePath) {
@@ -1133,6 +1137,7 @@ void saveRecording(char *filePath) {
             if (!fileExists(filePath) || confirm("File of that name already exists. Overwrite?", true)) {
                 remove(filePath);
                 rename(currentFilePath, filePath);
+                rogue.recording = false;
             } else {
                 askAgain = true;
             }
@@ -1143,6 +1148,7 @@ void saveRecording(char *filePath) {
                 remove(filePath);
             }
             rename(currentFilePath, filePath);
+            rogue.recording = false;
         }
     } while (askAgain);
     deleteMessages();
@@ -1178,6 +1184,7 @@ void switchToPlaying() {
     rogue.playbackMode          = false;
     rogue.playbackFastForward   = false;
     rogue.playbackOmniscience   = false;
+    rogue.recording             = true;
     locationInRecordingBuffer   = 0;
     copyFile(currentFilePath, lastGamePath, recordingLocation);
 #ifndef ENABLE_PLAYBACK_SWITCH

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3185,6 +3185,7 @@ extern "C" {
     void checkForDungeonErrors();
 
     boolean dialogChooseFile(char *path, const char *suffix, const char *prompt);
+    void quitImmediately();
     void dialogAlert(char *message);
     void mainBrogueJunction();
     void printSeedCatalog(unsigned long startingSeed, unsigned long numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3142,6 +3142,7 @@ extern "C" {
     void getAvailableFilePath(char *filePath, const char *defaultPath, const char *suffix);
     boolean characterForbiddenInFilename(const char theChar);
     void saveGame();
+    void saveGameNoPrompt();
     void saveRecording(char *filePath);
     void saveRecordingNoPrompt(char *filePath);
     void parseFile();

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2201,6 +2201,7 @@ typedef struct playerCharacter {
     short depthLevel;                   // which dungeon level are we on
     short deepestLevel;
     boolean disturbed;                  // player should stop auto-acting
+    boolean gameInProgress;             // the game is in progress (the player has not died, won or quit yet)
     boolean gameHasEnded;               // stop everything and go to death screen
     boolean highScoreSaved;             // so that it saves the high score only once
     boolean blockCombatText;            // busy auto-fighting
@@ -2269,6 +2270,7 @@ typedef struct playerCharacter {
     short **mapToSafeTerrain;           // so monsters can get to safety
 
     // recording info
+    boolean recording;                  // whether we are recording the game
     boolean playbackMode;               // whether we're viewing a recording instead of playing
     unsigned short patchVersion;        // what patch version of the game this was recorded on
     unsigned long currentTurnNumber;    // how many turns have elapsed

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -157,6 +157,7 @@ void initializeRogue(unsigned long seed) {
     rogue.wizard = wizard;
 
     rogue.gameHasEnded = false;
+    rogue.gameInProgress = true;
     rogue.highScoreSaved = false;
     rogue.cautiousMode = false;
     rogue.milliseconds = 0;
@@ -950,12 +951,11 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     if (player.bookkeepingFlags & MB_IS_DYING) {
         // we've already been through this once; let's avoid overkill.
         return;
-    } else {
-        player.bookkeepingFlags |= MB_IS_DYING;
     }
 
+    player.bookkeepingFlags |= MB_IS_DYING;
     rogue.autoPlayingLevel = false;
-
+    rogue.gameInProgress = false;
     flushBufferToFile();
 
     if (rogue.quit) {
@@ -1012,6 +1012,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
             player.status[STATUS_NUTRITION] = STOMACH_SIZE;
         }
         player.bookkeepingFlags &= ~MB_IS_DYING;
+        rogue.gameInProgress = true;
         return;
     }
 
@@ -1102,6 +1103,7 @@ void victory(boolean superVictory) {
     cellDisplayBuffer dbuf[COLS][ROWS];
     char recordingFilename[BROGUE_FILENAME_MAX] = {0};
 
+    rogue.gameInProgress = false;
     flushBufferToFile();
 
     //

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -252,20 +252,9 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
     // ~ for (int i=0; i < 100 && SDL_PollEvent(&event); i++) {
     while (SDL_PollEvent(&event)) {
         if (event.type == SDL_QUIT) {
-            // the player wants to close the window...
-            if (rogue.recording) {
-                // auto-save
-                flushBufferToFile();
-                if (rogue.gameInProgress && !rogue.quit && !rogue.gameHasEnded) {
-                    saveGameNoPrompt();
-                } else {
-                    char path[BROGUE_FILENAME_MAX];
-                    saveRecordingNoPrompt(path);
-                }
-            }
-            // exit immediately without further ado
+            // the player clicked the X button!
             SDL_Quit();
-            exit(0);
+            quitImmediately();
         } else if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
             brogueFontSize = fitFontSize(event.window.data1, event.window.data2);
             loadFont(brogueFontSize);

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -252,11 +252,20 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
     // ~ for (int i=0; i < 100 && SDL_PollEvent(&event); i++) {
     while (SDL_PollEvent(&event)) {
         if (event.type == SDL_QUIT) {
-            rogue.gameHasEnded = true; // causes the game loop to terminate quickly
-            rogue.nextGame = NG_QUIT; // causes the menu to drop out immediately
-            returnEvent->eventType = KEYSTROKE;
-            returnEvent->param1 = ESCAPE_KEY;
-            return true;
+            // the player wants to close the window...
+            if (rogue.recording) {
+                // auto-save
+                flushBufferToFile();
+                if (rogue.gameInProgress && !rogue.quit && !rogue.gameHasEnded) {
+                    saveGameNoPrompt();
+                } else {
+                    char path[BROGUE_FILENAME_MAX];
+                    saveRecordingNoPrompt(path);
+                }
+            }
+            // exit immediately without further ado
+            SDL_Quit();
+            exit(0);
         } else if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
             brogueFontSize = fitFontSize(event.window.data1, event.window.data2);
             loadFont(brogueFontSize);


### PR DESCRIPTION
The window now closes immediately on the first click of the `[x]` button, no matter what the situation is (play, auto-play, recording playback, text input, message acknowledgement...)

The game (or recording) is automatically and fully saved. Previously, closing the window while a game was in progress did not flush the buffer to file, so the savegame could be missing several turns.

Closing the window after the game is over (e.g at message "You died") automatically saves the recording.

Fixes #54.