### PR TITLE
Debug mode tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifeq ($(MAC_APP),YES)
 endif
 
 ifeq ($(DEBUG),YES)
-	cflags += -g
+	cflags += -g -Og
 	cppflags += -DENABLE_PLAYBACK_SWITCH
 else
 	cflags += -O2

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -1923,7 +1923,7 @@ void insertRoomAt(short **dungeonMap, short **roomMap, const short roomToDungeon
 void designCavern(short **grid, short minWidth, short maxWidth, short minHeight, short maxHeight) {
     short destX, destY;
     short caveX, caveY, caveWidth, caveHeight;
-    short fillX, fillY;
+    short fillX = 0, fillY = 0;
     boolean foundFillPoint = false;
     short **blobGrid;
     blobGrid = allocGrid();

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2328,7 +2328,7 @@ void displayLoops() {
 }
 
 void exploreKey(const boolean controlKey) {
-    short x, y, finalX, finalY;
+    short x, y, finalX = 0, finalY = 0;
     short **exploreMap;
     enum directions dir;
     boolean tooDark = false;


### PR DESCRIPTION
Suppresses two bogus gcc warnings in debug mode, and adds the `-Og` flag for better gdb support. From gcc's documentation:

> If you are not using some other optimization option, consider using -Og (see Optimize Options) with -g. With no -O option at all, some compiler passes that collect information useful for debugging do not run at all, so that -Og may result in a better debugging experience.