### PR TITLE
Fix memory leak in burnItem()

### DIFF
--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -831,6 +831,7 @@ void burnItem(item *theItem) {
     x = theItem->xLoc;
     y = theItem->yLoc;
     removeItemFromChain(theItem, floorItems);
+    deleteItem(theItem);
     pmap[x][y].flags &= ~(HAS_ITEM | ITEM_DETECTED);
     if (pmap[x][y].flags & (ANY_KIND_OF_VISIBLE | DISCOVERED | ITEM_DETECTED)) {
         refreshDungeonCell(x, y);


### PR DESCRIPTION
Burnt item wasn't `free`'d.

Fixes most memory leaks reported by @flend 