### PR TITLE
Allow pausing playback with mouse or Escape key

### DIFF
--- a/changes/pause-playback-with-mouse-or-Esc.md
+++ b/changes/pause-playback-with-mouse-or-Esc.md
@@ -1,0 +1,1 @@
+Recording playback can now also be paused with the mouse or the Escape key.

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1006,6 +1006,12 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                     return true;
 #endif
                 return false;
+            case ESCAPE_KEY:
+                if (!rogue.playbackPaused) {
+                    rogue.playbackPaused = true;
+                    return true;
+                }
+                return false;
             default:
                 if (key >= '0' && key <= '9'
                     || key >= NUMPAD_0 && key <= NUMPAD_9) {
@@ -1023,6 +1029,10 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
             rogue.playbackMode = false;
             displayMessageArchive();
             rogue.playbackMode = true;
+            return true;
+        } else if (!rogue.playbackPaused) {
+            // clicking anywhere else pauses the playback
+            rogue.playbackPaused = true;
             return true;
         }
     } else if (recordingInput->eventType == RIGHT_MOUSE_UP) {


### PR DESCRIPTION
Playback could be un-paused with the mouse, but not paused. This patch allows pausing by clicking anywhere in the window where it previously had no effect. The Escape key now also pauses playback, as it is the key's customary purpose.