### PR TITLE
Autoidentify wands of invisibility if used on an enemy while telepathic

### DIFF
--- a/changes/autoidentify-wand-of-invisibility-if-telepathic.md
+++ b/changes/autoidentify-wand-of-invisibility-if-telepathic.md
@@ -1,0 +1,1 @@
+autoidentify a wand of invisibility if it turns an enemy invisible while the player has a telepathic bond

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3969,6 +3969,8 @@ boolean imbueInvisibility(creature *monst, short duration) {
     if (monst && !(monst->info.flags & (MONST_INANIMATE | MONST_INVISIBLE | MONST_INVULNERABLE))) {
         if (monst == &player || monst->creatureState == MONSTER_ALLY) {
             autoID = true;
+        } else if (canSeeMonster(monst) && monsterRevealed(monst)) {
+            autoID = true;
         }
         monst->status[STATUS_INVISIBLE] = monst->maxStatus[STATUS_INVISIBLE] = duration;
         refreshDungeonCell(monst->xLoc, monst->yLoc);


### PR DESCRIPTION
If an unidentified wand of invisibility turns a visible enemy invisible, they become displayed as a 'psychic emanation,' which is an indicator that they're now invisible, not teleported away. This disambiguates the signature of a wand of invisibility from any other potential wand, so the wand can be identified.

![image](https://user-images.githubusercontent.com/6645121/98279401-df194580-1f67-11eb-869e-a78d6009125d.png)

There might be a need for some additional text, like

```
You sense a psychic emanation where the <monster> once was.
(Your <wand> must be a wand of invisibility.)
```

I can add that if desired