### PR TITLE
Preserve patchVersion from reloaded game

### DIFF
--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -177,8 +177,8 @@ void writeHeaderInfo(char *path) {
     }
 
     // Note the version string to gracefully deny compatibility when necessary.
-    for (i = 0; BROGUE_RECORDING_VERSION_STRING[i] != '\0'; i++) {
-        c[i] = BROGUE_RECORDING_VERSION_STRING[i];
+    for (i = 0; rogue.versionString[i] != '\0'; i++) {
+        c[i] = rogue.versionString[i];
     }
     c[15] = rogue.wizard;
     i = 16;
@@ -453,7 +453,7 @@ void initRecording() {
     short i;
     boolean wizardMode;
     unsigned short gamePatch, recPatch;
-    char versionString[16] = {0}, buf[100];
+    char buf[100], *versionString = rogue.versionString;
     FILE *recordFile;
 
 #ifdef AUDIT_RNG
@@ -540,6 +540,7 @@ void initRecording() {
     } else {
         // If present, set the patch version for playing the game.
         getPatchVersion(BROGUE_RECORDING_VERSION_STRING, &rogue.patchVersion);
+        strcpy(versionString, BROGUE_RECORDING_VERSION_STRING);
 
         lengthOfPlaybackFile = 1;
         remove(currentFilePath);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2281,6 +2281,7 @@ typedef struct playerCharacter {
     boolean recording;                  // whether we are recording the game
     boolean playbackMode;               // whether we're viewing a recording instead of playing
     unsigned short patchVersion;        // what patch version of the game this was recorded on
+    char versionString[16];             // the version string saved into the recording file
     unsigned long currentTurnNumber;    // how many turns have elapsed
     unsigned long howManyTurns;         // how many turns are in this recording
     short howManyDepthChanges;          // how many times the player changes depths


### PR DESCRIPTION
When loading a savegame made with an earlier version, then saving it again, the new savegame may go out-of-sync because the header contains the new version number but the first turns still need the old version to be applied correctly.

This patch ensures the header contains the version that the game was started with.