### PR TITLE
fix conflicting types uint64_t and unsigned long for printSeedCatalog

### DIFF
--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3182,7 +3182,7 @@ extern "C" {
     boolean dialogChooseFile(char *path, const char *suffix, const char *prompt);
     void dialogAlert(char *message);
     void mainBrogueJunction();
-    void printSeedCatalog(unsigned long startingSeed, unsigned long numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat);
+    void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat);
 
     void initializeButton(brogueButton *button);
     void drawButtonsInState(buttonState *state);


### PR DESCRIPTION
printSeedCatalog has two type-conflicting declarations. Based on use of the function, the correct type is uint64_t. Using clang on OpenBSD I had the error below while compiling. With the fix the game compiled and worked fine on OpenBSD. Thanks for your work on making Brogue more portable!

src/brogue/SeedCatalog.c:217:6: error: conflicting types for 'printSeedCatalog'                                                                    
void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth,                                          
     ^                                                                                                                                             
src/brogue/Rogue.h:3185:10: note: previous declaration is here                                                                                     
    void printSeedCatalog(unsigned long startingSeed, unsigned long numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat);      
         ^                                                                                                                                         
1 error generated.                                                                                                                                 
gmake: *** [Makefile:44: src/brogue/SeedCatalog.o] Error 1