### PR TITLE
Make monsters flee properly outside player view

### DIFF
--- a/changes/monkey-lava.md
+++ b/changes/monkey-lava.md
@@ -1,0 +1,1 @@
+Fixed a bug that would cause monkeys with keys to jump into lava.

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -851,6 +851,11 @@ creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFla
         leader->info.intrinsicLightType = SACRIFICE_MARK_LIGHT;
     }
 
+    if (rogue.patchVersion >= 3 && (theHorde->flags & HORDE_MACHINE_THIEF)) {
+        leader->safetyMap = allocGrid(); // Keep thieves from fleeing before they see the player
+        fillGrid(leader->safetyMap, 0);
+    }
+
     preexistingMonst = monsterAtLoc(x, y);
     if (preexistingMonst) {
         killCreature(preexistingMonst, true); // If there's already a monster here, quietly bury the body.
@@ -3260,6 +3265,9 @@ void monstersTurn(creature *monst) {
             dir = nextStep(safetyMap, monst->xLoc, monst->yLoc, NULL, true);
         } else {
             if (!monst->safetyMap) {
+                if (rogue.patchVersion >= 3 && !rogue.updatedSafetyMapThisTurn) {
+                    updateSafetyMap();
+                }
                 monst->safetyMap = allocGrid();
                 copyGrid(monst->safetyMap, safetyMap);
             }

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -574,7 +574,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             freeGrid(monst->mapToMe);
             monst->mapToMe = NULL;
         }
-        if (monst->safetyMap) {
+        if (rogue.patchVersion < 3 && monst->safetyMap) {
             freeGrid(monst->safetyMap);
             monst->safetyMap = NULL;
         }


### PR DESCRIPTION
Originally, monsters that begin fleeing outside player view use the last safety map generated, which doesn't apply to the monster and could be from several floors prior. This is why monkeys in key holders would occasonally jump into lava. Aside from updating the safety map properly, the rest of the code makes sure monkeys/imps on the altars stay still until the player sees them.