### PR TITLE
Deal force damage only on impact with solid object

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -476,7 +476,7 @@ void specialHit(creature *attacker, creature *defender, short damage) {
 }
 
 boolean forceWeaponHit(creature *defender, item *theItem) {
-    short oldLoc[2], newLoc[2], forceDamage;
+    short oldLoc[2], newLoc[2], forceDamage = 0;
     char buf[DCOLS*3], buf2[COLS], monstName[DCOLS];
     creature *otherMonster = NULL;
     boolean knowFirstMonsterDied = false, autoID = false;
@@ -512,7 +512,6 @@ boolean forceWeaponHit(creature *defender, item *theItem) {
         }
         
         // Only deal force damage if target collides with solid object
-        forceDamage = 0;
         if (otherMonster || !(tileCatalog[pmap[defender->xLoc + newLoc[0] - oldLoc[0]][defender->yLoc + newLoc[1] - oldLoc[1]].layers[DUNGEON]].flags & (T_LAVA_INSTA_DEATH | T_AUTO_DESCENT | T_IS_DEEP_WATER))) {
 
             forceDamage = distanceBetween(oldLoc[0], oldLoc[1], defender->xLoc, defender->yLoc);

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -510,30 +510,35 @@ boolean forceWeaponHit(creature *defender, item *theItem) {
             otherMonster = NULL;
             strcpy(buf2, tileCatalog[pmap[defender->xLoc + newLoc[0] - oldLoc[0]][defender->yLoc + newLoc[1] - oldLoc[1]].layers[highestPriorityLayer(defender->xLoc + newLoc[0] - oldLoc[0], defender->yLoc + newLoc[1] - oldLoc[1], true)]].description);
         }
+        
+        // Only deal force damage if target collides with solid object
+        forceDamage = 0;
+        if (otherMonster || !(tileCatalog[pmap[defender->xLoc + newLoc[0] - oldLoc[0]][defender->yLoc + newLoc[1] - oldLoc[1]].layers[DUNGEON]].flags & (T_LAVA_INSTA_DEATH | T_AUTO_DESCENT | T_IS_DEEP_WATER))) {
 
-        forceDamage = distanceBetween(oldLoc[0], oldLoc[1], defender->xLoc, defender->yLoc);
+            forceDamage = distanceBetween(oldLoc[0], oldLoc[1], defender->xLoc, defender->yLoc);
 
-        if (!(defender->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))
-            && inflictDamage(NULL, defender, forceDamage, &white, false)) {
+            if (!(defender->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))
+                && inflictDamage(NULL, defender, forceDamage, &white, false)) {
 
-            if (canDirectlySeeMonster(defender)) {
-                knowFirstMonsterDied = true;
-                sprintf(buf, "%s %s on impact with %s",
-                        monstName,
-                        (defender->info.flags & MONST_INANIMATE) ? "is destroyed" : "dies",
-                        buf2);
-                buf[DCOLS] = '\0';
-                combatMessage(buf, messageColorFromVictim(defender));
-                autoID = true;
-            }
-        } else {
-            if (canDirectlySeeMonster(defender)) {
-                sprintf(buf, "%s slams against %s",
-                        monstName,
-                        buf2);
-                buf[DCOLS] = '\0';
-                combatMessage(buf, messageColorFromVictim(defender));
-                autoID = true;
+                if (canDirectlySeeMonster(defender)) {
+                    knowFirstMonsterDied = true;
+                    sprintf(buf, "%s %s on impact with %s",
+                            monstName,
+                            (defender->info.flags & MONST_INANIMATE) ? "is destroyed" : "dies",
+                            buf2);
+                    buf[DCOLS] = '\0';
+                    combatMessage(buf, messageColorFromVictim(defender));
+                    autoID = true;
+                }
+            } else {
+                if (canDirectlySeeMonster(defender)) {
+                    sprintf(buf, "%s slams against %s",
+                            monstName,
+                            buf2);
+                    buf[DCOLS] = '\0';
+                    combatMessage(buf, messageColorFromVictim(defender));
+                    autoID = true;
+                }
             }
         }
         moralAttack(&player, defender);


### PR DESCRIPTION
Additional damage from the force runic is now dealt only on contact with a solid object.  No more "$monster dies on impact with a chasm." Terrain types that are not considered solid if they have any of the flags T_AUTO_DESCEND, T_IS_DEEP_WATER, or T_LAVA_INSTA_DEATH.