### PR TITLE
Hint if item is good or bad

### DIFF
--- a/changes/hint-good-or-bad-items.md
+++ b/changes/hint-good-or-bad-items.md
@@ -1,0 +1,1 @@
+The description of unidentified potions and scrolls now hint whether they are good or bad.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1848,18 +1848,20 @@ void itemDetails(char *buf, item *theItem) {
     } else {
         switch (theItem->category) {
             case POTION:
-                sprintf(buf2, "%s flask%s contain%s a swirling %s liquid. Who knows what %s will do when drunk or thrown?",
+                sprintf(buf2, "%s flask%s contain%s a %s %s liquid. Who knows what %s will do when drunk or thrown?",
                         (singular ? "This" : "These"),
                         (singular ? "" : "s"),
                         (singular ? "s" : ""),
+                        (theItem->kind >= POTION_POISON ? "murky" : "clear"),
                         tableForItemCategory(theItem->category, NULL)[theItem->kind].flavor,
                         (singular ? "it" : "they"));
                 break;
             case SCROLL:
-                sprintf(buf2, "%s parchment%s %s covered with indecipherable writing, and bear%s a title of \"%s.\" Who knows what %s will do when read aloud?",
+                sprintf(buf2, "%s parchment%s %s covered with %s writing, and bear%s a title of \"%s.\" Who knows what %s will do when read aloud?",
                         (singular ? "This" : "These"),
                         (singular ? "" : "s"),
                         (singular ? "is" : "are"),
+                        (theItem->kind >= SCROLL_NEGATION ? "shaky, indecipherable" : "elegant but inscrutable"),
                         (singular ? "s" : ""),
                         tableForItemCategory(theItem->category, NULL)[theItem->kind].flavor,
                         (singular ? "it" : "they"));


### PR DESCRIPTION
One way to avoid the unnecessary frustration of identifying potions, that many players have complained about, is to use different language in the description of unidentified potions and scrolls, to distinguish good vs bad ones. The same approach could be extended to rings, wands and staffs.

This PR is more intended as a conversation starter. For potions I chose *murky* vs *clear* liquid; for scrolls, *shaky* vs *elegant* writing. Adjectives could be changed or randomized to provide some diversity. Some examples:

* Good items: *fine, clean, bright, shimmering, glistening, glittering, glowing, silky, smooth, humming, straight, supple, graceful, exquisite, delicate, neat*...
* Bad items: *cloudy, dirty, muddy, shadowy, hazy, rough, coarse, ugly, smelly, stingy, pungent, acrid, stunted, brittle, scrawny, grotesque, messy, foul, filthy, fetid, putrid, rank, sickly, gross, stale, reeking, pockmarked, stained, irregular*...
