### PR TITLE
Ww/build full releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: "Compile"
       run: |
-        make bin/brogue
+        make LINUX_APP=YES bin/brogue
 
     - name: "Upload artifact"
       uses: actions/upload-artifact@v1
@@ -68,7 +68,7 @@ jobs:
       run: |
         $env:path = $env:path + ";" + (Join-Path $pwd.Drive.Root "opt/local/x86_64-w64-mingw32/bin")
         $env:path = $env:path + ';C:\Program Files (x86)\Windows Kits\10\bin\x64'
-        mingw32-make CC=gcc bin/brogue.exe
+        mingw32-make CC=gcc WINDOWS_APP=YES bin/brogue.exe
     - name: "Package"
       run: |
         cp .\SDL2\x86_64-w64-mingw32\bin\SDL2.dll .\bin\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
 
     - name: "Compile"
       run: |
-        make LINUX_APP=YES bin/brogue
+        make LINUX_APP=YES linux.tar.gz
 
     - name: "Upload artifact"
       uses: actions/upload-artifact@v1
       with:
-        name: linux-bin
-        path: bin
+        name: linux-artifacts
+        path: linux.tar.gz
 
   macos:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,20 +40,16 @@ jobs:
 
     - name: "Compile"
       run: |
-        make MAC_APP=YES Brogue.app
+        make MAC_APP=YES macos.zip
       env:
         # 10.6 is the version targeted by the SDL build scripts
         MACOSX_DEPLOYMENT_TARGET: "10.6"
 
-    - name: "Fix and bundle dylib references"
-      run: |
-        cd Brogue.app/Contents && dylibbundler -cd -b -x MacOS/brogue
-
     - name: "Upload artifact"
       uses: actions/upload-artifact@v1
       with:
-        name: Brogue.app
-        path: Brogue.app
+        name: macos-artifacts
+        path: macos.zip
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,15 +64,9 @@ jobs:
       run: |
         $env:path = $env:path + ";" + (Join-Path $pwd.Drive.Root "opt/local/x86_64-w64-mingw32/bin")
         $env:path = $env:path + ';C:\Program Files (x86)\Windows Kits\10\bin\x64'
-        mingw32-make CC=gcc WINDOWS_APP=YES bin/brogue.exe
-    - name: "Package"
-      run: |
-        cp .\SDL2\x86_64-w64-mingw32\bin\SDL2.dll .\bin\
-        cp .\SDL2_image\x86_64-w64-mingw32\bin\zlib1.dll .\bin\
-        cp .\SDL2_image\x86_64-w64-mingw32\bin\SDL2_image.dll .\bin\
-        cp .\SDL2_image\x86_64-w64-mingw32\bin\libpng16-16.dll .\bin\
+        mingw32-make CC=gcc WINDOWS_APP=YES windows.zip
     - name: "Upload artifact"
       uses: actions/upload-artifact@v1
       with:
-        name: windows-mingw-bin
-        path: bin
+        name: windows-artifacts
+        path: windows.zip

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ bin/brogue.exe: $(objects)
 
 clean:
 	$(RM) src/brogue/*.o src/platform/*.o $(binary) \
-	  seed-catalog.txt README.txt CHANGELOG.txt
+	  seed-catalog.txt README.txt CHANGELOG.txt \
+	  linux.tar.gz
 
 common-files := README.txt CHANGELOG.txt LICENSE.txt seed-catalog.txt
 common-bin := bin/assets bin/keymap.txt

--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,17 @@ bin/brogue.exe: $(objects)
 	mt -manifest windows/brogue.exe.manifest '-outputresource:bin/brogue.exe;1'
 
 clean:
-	$(RM) src/brogue/*.o src/platform/*.o $(binary)
+	$(RM) src/brogue/*.o src/platform/*.o $(binary) \
+	  seed-catalog.txt README.txt CHANGELOG.txt
 
 common-files := README.txt CHANGELOG.txt LICENSE.txt seed-catalog.txt
 common-bin := bin/assets bin/keymap.txt
 
 %.txt: %.md
 	cp $< $@
+
+seed-catalog.txt: $(binary)
+	$(binary) --print-seed-catalog > $@
 
 windows.zip: $(common-files) $(common-bin)
 	zip -rvl $@ $^ $(binary) bin/*.dll bin/brogue-cmd.bat

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ bin/brogue.exe: $(objects)
 clean:
 	$(RM) src/brogue/*.o src/platform/*.o $(binary) \
 	  seed-catalog.txt README.txt CHANGELOG.txt \
-	  macos.zip linux.tar.gz
+	  windows.zip macos.zip linux.tar.gz
 	$(RM) -r Brogue\ CE.app
 
 common-files := README.txt CHANGELOG.txt LICENSE.txt seed-catalog.txt
@@ -82,7 +82,11 @@ seed-catalog.txt: $(binary)
 	$(binary) --print-seed-catalog > $@
 
 windows.zip: $(common-files) $(common-bin)
-	zip -rvl $@ $^ $(binary) bin/*.dll bin/brogue-cmd.bat
+	cp ./SDL2/x86_64-w64-mingw32/bin/SDL2.dll ./bin/
+	cp ./SDL2_image/x86_64-w64-mingw32/bin/zlib1.dll ./bin/
+	cp ./SDL2_image/x86_64-w64-mingw32/bin/SDL2_image.dll ./bin/
+	cp ./SDL2_image/x86_64-w64-mingw32/bin/libpng16-16.dll ./bin/
+	7z a $@ $^ $(binary) bin/*.dll bin/brogue-cmd.bat
 
 # Filter-out problematic names so we can quote them manually
 macos.zip: $(common-files) Brogue\ CE.app

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,16 @@ ifeq ($(WEBBROGUE),YES)
 	cppflags += -DBROGUE_WEB
 endif
 
+binary := bin/brogue
+objects := $(sources:.c=.o)
+
 ifeq ($(MAC_APP),YES)
 	cppflags += -DSDL_PATHS
+endif
+
+ifeq ($(WINDOWS_APP),YES)
+	binary := bin/brogue.exe
+	objects += windows/icon.o
 endif
 
 ifeq ($(DEBUG),YES)
@@ -42,8 +50,6 @@ ifeq ($(DEBUG),YES)
 else
 	cflags += -O2
 endif
-
-objects := $(sources:.c=.o)
 
 .PHONY: clean
 
@@ -56,13 +62,12 @@ bin/brogue: $(objects)
 windows/icon.o: windows/icon.rc
 	windres $< $@
 
-bin/brogue.exe: $(objects) windows/icon.o
+bin/brogue.exe: $(objects)
 	$(CC) $(cflags) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(libs) $(LDLIBS)
 	mt -manifest windows/brogue.exe.manifest '-outputresource:bin/brogue.exe;1'
 
 clean:
-	$(RM) src/brogue/*.o src/platform/*.o bin/brogue{,.exe}
-
+	$(RM) src/brogue/*.o src/platform/*.o $(binary)
 
 common-files := README.txt CHANGELOG.txt LICENSE.txt seed-catalog.txt
 common-bin := bin/assets bin/keymap.txt
@@ -71,7 +76,7 @@ common-bin := bin/assets bin/keymap.txt
 	cp $< $@
 
 windows.zip: $(common-files) $(common-bin)
-	zip -rvl $@ $^ bin/brogue.exe bin/*.dll bin/brogue-cmd.bat
+	zip -rvl $@ $^ $(binary) bin/*.dll bin/brogue-cmd.bat
 
 macos.zip: $(common-files)
 	chmod +x "Brogue CE.app"/Contents/MacOS/brogue
@@ -80,7 +85,6 @@ macos.zip: $(common-files)
 linux.tar.gz: $(common-files) $(common-bin) brogue
 	chmod +x bin/brogue
 	tar -cavf $@ $^ bin/brogue -C linux make-link-for-desktop.sh
-
 
 # $* is the matched %
 icon_%.png: bin/assets/icon.png

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ bin/brogue.exe: $(objects)
 clean:
 	$(RM) src/brogue/*.o src/platform/*.o $(binary) \
 	  seed-catalog.txt README.txt CHANGELOG.txt \
-	  linux.tar.gz
+	  macos.zip linux.tar.gz
+	$(RM) -r Brogue\ CE.app
 
 common-files := README.txt CHANGELOG.txt LICENSE.txt seed-catalog.txt
 common-bin := bin/assets bin/keymap.txt
@@ -83,9 +84,11 @@ seed-catalog.txt: $(binary)
 windows.zip: $(common-files) $(common-bin)
 	zip -rvl $@ $^ $(binary) bin/*.dll bin/brogue-cmd.bat
 
-macos.zip: $(common-files)
+# Filter-out problematic names so we can quote them manually
+macos.zip: $(common-files) Brogue\ CE.app
 	chmod +x "Brogue CE.app"/Contents/MacOS/brogue
-	zip -rv -ll $@ $^ "Brogue CE.app"
+	cd "Brogue CE.app"/Contents && dylibbundler -cd -b -x MacOS/brogue
+	zip -rv -ll $@ $(filter-out Brogue CE.app,$^) "Brogue CE.app"
 
 linux.tar.gz: $(common-files) $(common-bin) brogue
 	chmod +x bin/brogue
@@ -99,8 +102,9 @@ macos/Brogue.icns: icon_32.png icon_128.png icon_256.png icon_512.png
 	png2icns $@ $^
 	$(RM) $^
 
-Brogue.app: bin/brogue
-	mkdir -p $@/Contents/{MacOS,Resources}
-	cp macos/Info.plist $@/Contents
-	cp bin/brogue $@/Contents/MacOS
-	cp -r macos/Brogue.icns bin/assets $@/Contents/Resources
+Brogue\ CE.app: bin/brogue
+	mkdir -p "$@"/Contents/MacOS
+	mkdir -p "$@"/Contents/Resources
+	cp macos/Info.plist "$@"/Contents
+	cp bin/brogue "$@"/Contents/MacOS
+	cp -r macos/Brogue.icns bin/assets "$@"/Contents/Resources

--- a/config.mk
+++ b/config.mk
@@ -20,3 +20,9 @@ RELEASE := NO
 
 # Configure the executable to run from a macOS .app bundle (only works in graphical mode)
 MAC_APP := NO
+
+# Build for linux
+LINUX_APP := NO
+
+# Build for windows
+WINDOWS_APP := NO


### PR DESCRIPTION
This PR reworks the make file and github actions a bit, to directly produce archives like the ones available on the releases page.  The makefile attempted to build archives that seemed similar, but were missing parts or had slightly different names internally.  Now the archive listings (so, `unzip -l` or `tar tzf`) are identical with the release archives.

The intent is to give testers easy access to ~test/dev~ _unstable_ builds for their OS in a format they might expect to see.  (Apologies if such a means already exists for testers, but after looking I couldn't find it.)  Now, if the github actions script is run for a given commit, a tester can download a release-like archive as an artifact from the github action page.