### PR TITLE
Show git commit and branch name in unstable builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@ cppflags := -DDATADIR=$(DATADIR)
 
 sources := $(wildcard src/brogue/*.c) $(addprefix src/platform/,main.c platformdependent.c)
 
+ifeq ($(RELEASE),YES)
+	extra_version :=
+else
+	extra_version := $(shell tools/git-extra-version)
+endif
+cppflags += -DBROGUE_EXTRA_VERSION='"$(extra_version)"'
+
 ifeq ($(TERMINAL),YES)
 	sources += $(addprefix src/platform/,curses-platform.c term.c)
 	cppflags += -DBROGUE_CURSES

--- a/config.mk
+++ b/config.mk
@@ -15,5 +15,8 @@ WEBBROGUE := NO
 # Enable debugging mode. See top of Rogue.h for features
 DEBUG := NO
 
+# Declare this is a release build
+RELEASE := NO
+
 # Configure the executable to run from a macOS .app bundle (only works in graphical mode)
 MAC_APP := NO

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -33,7 +33,7 @@
 #define USE_UNICODE
 
 // Brogue version: what the user sees in the menu and title
-#define BROGUE_VERSION_STRING "CE 1.9.3"
+#define BROGUE_VERSION_STRING "CE 1.9.3" BROGUE_EXTRA_VERSION
 
 // Recording version. Saved into recordings and save files made by this version.
 // Cannot be longer than 16 chars

--- a/tools/git-extra-version
+++ b/tools/git-extra-version
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+# Emit extra version string (if any) to append to BROGUE_VERSION_STRING
+
+# Release builds should write nothing to stdout.  Development builds
+# (everything else) should write something, but what depends on the information
+# available.
+
+# If we're in CI and the ref is the gha-build branch, assume we are a release
+if [[ ${GITHUB_ACTIONS:-false} == true ]] && [[ $GITHUB_REF =~ ^refs/heads/gha-build ]]
+then
+    exit 0
+fi
+
+# Otherwise we must be a development build
+
+if [[ ${GITHUB_ACTIONS:-false} == true ]]
+then
+    # If we're in CI, use what they hand us
+    # If it's a branch, strip refs/heads.  Highlight tags by keeping the prefix
+    EXTRA_VERSION="-dev.${GITHUB_SHA:0:7}.${GITHUB_REF##refs/heads/}"
+elif { which git && git rev-parse --show-toplevel; } >/dev/null 2>&1
+then
+    # Otherwise inspect git if it and a repo are available
+    EXTRA_VERSION="-dev.$(git log -1 --format='%h').$(git rev-parse --abbrev-ref HEAD)"
+else
+    # Finally, if nothing else just call it "development"
+    EXTRA_VERSION=-dev
+fi
+
+# No matter what, limit the extra version to 64 characters
+echo "${EXTRA_VERSION:0:64}"


### PR DESCRIPTION
If a build is made by CI (has $CI defined) and a tag pointed at its git commit, call it a release build.  Call other builds unstable builds.

Put the git commit and branch name on the title screen and --version output of all unstable builds.  If built locally use "unstable" instead of a commit hash or branch, since the work tree might not be clean.

We avoid calling git directly since it may not be available.  Instead only variables supplied by the CI environment are used.
