### PR TITLE
Exit Logic (For A Game): Fix hanging and truncated saves

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2400,7 +2400,12 @@ void nextBrogueEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsD
 
     returnEvent->eventType = EVENT_ERROR;
 
-    if (rogue.playbackMode && !realInputEvenInPlayback) {
+    if (rogue.gameHasEnded && !(rogue.playbackMode && !realInputEvenInPlayback)) {
+        // If game has ended and we're asked for user input, return Escape to
+        // cancel out of any prompts or input loops
+        returnEvent->eventType = KEYSTROKE;
+        returnEvent->param1 = ESCAPE_KEY;
+    } else if (rogue.playbackMode && !realInputEvenInPlayback) {
         do {
             repeatAgain = false;
             if ((!rogue.playbackFastForward && rogue.playbackBetweenTurns)

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1130,17 +1130,6 @@ void saveGame() {
     deleteMessages();
 }
 
-void saveRecordingNoPrompt(char *filePath)
-{
-    if (rogue.playbackMode) {
-        return;
-    }
-    getAvailableFilePath(filePath, "Recording", RECORDING_SUFFIX);
-    strcat(filePath, RECORDING_SUFFIX);
-    remove(filePath);
-    rename(currentFilePath, filePath);
-}
-
 void saveRecording(char *filePath) {
     char defaultPath[BROGUE_FILENAME_MAX];
     boolean askAgain;
@@ -1153,6 +1142,7 @@ void saveRecording(char *filePath) {
 
     deleteMessages();
     do {
+        if (serverMode) break;  // Just save as the suggested name.
         askAgain = false;
         if (getInputTextString(filePath, "Save recording as (<esc> to cancel): ",
                                BROGUE_FILENAME_MAX - strlen(RECORDING_SUFFIX), defaultPath, RECORDING_SUFFIX, TEXT_INPUT_FILENAME, false)) {
@@ -1160,7 +1150,6 @@ void saveRecording(char *filePath) {
             strcat(filePath, RECORDING_SUFFIX);
             if (!fileExists(filePath) || confirm("File of that name already exists. Overwrite?", true)) {
                 remove(filePath);
-                rename(currentFilePath, filePath);
             } else {
                 askAgain = true;
             }
@@ -1170,10 +1159,11 @@ void saveRecording(char *filePath) {
             if (fileExists(filePath)) {
                 remove(filePath);
             }
-            rename(currentFilePath, filePath);
         }
     } while (askAgain);
     deleteMessages();
+
+    rename(currentFilePath, filePath);
 }
 
 void copyFile(char *fromFilePath, char *toFilePath, unsigned long fromFileLength) {

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1069,16 +1069,11 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
         displayMoreSign();
     }
 
-    if (serverMode) {
-        blackOutScreen();
-        saveRecordingNoPrompt(recordingFilename);
-    } else {
-        if (!rogue.playbackMode && saveHighScore(theEntry)) {
-            printHighScores(true);
-        }
-        blackOutScreen();
-        saveRecording(recordingFilename);
+    if (!serverMode && !rogue.playbackMode && saveHighScore(theEntry)) {
+        printHighScores(true);
     }
+    blackOutScreen();
+    saveRecording(recordingFilename);
 
     if (!rogue.playbackMode) {
         if (!rogue.quit) {
@@ -1099,7 +1094,7 @@ void victory(boolean superVictory) {
     short i, j, gemCount = 0;
     unsigned long totalValue = 0;
     rogueHighScoresEntry theEntry;
-    boolean qualified, isPlayback;
+    boolean isPlayback;
     cellDisplayBuffer dbuf[COLS][ROWS];
     char recordingFilename[BROGUE_FILENAME_MAX] = {0};
 
@@ -1210,12 +1205,6 @@ void victory(boolean superVictory) {
         theEntry.score /= 10;
     }
 
-    if (!rogue.wizard && !rogue.playbackMode) {
-        qualified = saveHighScore(theEntry);
-    } else {
-        qualified = false;
-    }
-
     isPlayback = rogue.playbackMode;
     rogue.playbackMode = false;
     rogue.playbackMode = isPlayback;
@@ -1223,10 +1212,11 @@ void victory(boolean superVictory) {
     if (serverMode) {
         // There's no save recording prompt, so let the player see achievements.
         displayMoreSign();
-        saveRecordingNoPrompt(recordingFilename);
-    } else {
-        saveRecording(recordingFilename);
-        printHighScores(qualified);
+    }
+    saveRecording(recordingFilename);
+
+    if (!serverMode && !rogue.playbackMode && saveHighScore(theEntry)) {
+        printHighScores(true);
     }
 
     if (!rogue.playbackMode) {


### PR DESCRIPTION
I think I've fixed hanging, but in the case of closing on the "You die..." prompt, there is a several second delay. I don't know why yet...

Truncated saves are also a difficult problem, I don't know where to put the flush call. I tried at the end of mainInputLoop but it then gave me out-of-sync when I opened the left-behind LastRecording (I think it corrupted the buffer or something?)