### PR TITLE
Added a lighting outline feature to replace turning off color effects

### DIFF
--- a/changes/lighting-outlines.md
+++ b/changes/lighting-outlines.md
@@ -1,0 +1,1 @@
+Added a lighting outline feature to replace turning off color effects

--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -327,6 +327,7 @@ short buttonInputLoop(brogueButton *buttons,
     boolean canceled;
     rogueEvent theEvent;
     buttonState state = {0};
+    short rout[COLS][ROWS];
 
     assureCosmeticRNG;
 
@@ -336,6 +337,7 @@ short buttonInputLoop(brogueButton *buttons,
     do {
         // Update the display.
         overlayDisplayBuffer(state.dbuf, NULL);
+        overlayLightingOutlines(state.dbuf, rout);
 
         // Get input.
         nextBrogueEvent(&theEvent, true, false, false);
@@ -345,6 +347,7 @@ short buttonInputLoop(brogueButton *buttons,
 
         // Revert the display.
         overlayDisplayBuffer(state.rbuf, NULL);
+        restoreLightingOutlines(rout);
 
     } while (button == -1 && !canceled);
 

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -27,6 +27,9 @@ tcell tmap[DCOLS][DROWS];                       // grids with info about the map
 pcell pmap[DCOLS][DROWS];
 short **scentMap;
 cellDisplayBuffer displayBuffer[COLS][ROWS];    // used to optimize plotCharWithColor
+short lightingOutlineGrid[COLS][ROWS] = {{0}};  // Outline flags: bit 1 represents light level, 0: light, 1: dark
+                                                // bits 2-5 store which sides have outlines, in order of nbDirs
+                                                // bits 6-12 represent the opacity of the outline from 1-100
 short terrainRandomValues[DCOLS][DROWS][8];
 short **safetyMap;                              // used to help monsters flee
 short **allySafetyMap;                          // used to help allies flee

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -25,6 +25,7 @@ extern tcell tmap[DCOLS][DROWS];                        // grids with info about
 extern pcell pmap[DCOLS][DROWS];                        // grids with info about the map
 extern short **scentMap;
 extern cellDisplayBuffer displayBuffer[COLS][ROWS];
+extern short lightingOutlineGrid[COLS][ROWS];
 extern short terrainRandomValues[DCOLS][DROWS][8];
 extern short **safetyMap;                                       // used to help monsters flee
 extern short **allySafetyMap;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2660,6 +2660,7 @@ char displayInventory(unsigned short categoryMask,
     short highlightItemLine, itemSpaceRemaining;
     cellDisplayBuffer dbuf[COLS][ROWS];
     cellDisplayBuffer rbuf[COLS][ROWS];
+    short rout[COLS][ROWS];
     brogueButton buttons[50] = {{{0}}};
     short actionKey = -1;
     color darkItemColor;
@@ -2887,6 +2888,7 @@ char displayInventory(unsigned short categoryMask,
     buttons[itemNumber + extraLineCount + 1].hotkey[1] = DOWN_ARROW;
 
     overlayDisplayBuffer(dbuf, rbuf);
+    overlayLightingOutlines(dbuf, rout);
 
     do {
         repeatDisplay = false;
@@ -2944,7 +2946,7 @@ char displayInventory(unsigned short categoryMask,
                     } else {
                         restoreRNG;
                         repeatDisplay = false;
-                        overlayDisplayBuffer(rbuf, NULL); // restore the original screen
+                        restoreLightingOutlines(rout); // screen ready, now prepare outlines
                     }
 
                     switch (actionKey) {
@@ -2999,6 +3001,7 @@ char displayInventory(unsigned short categoryMask,
     } while (repeatDisplay); // so you can get info on multiple items sequentially
 
     overlayDisplayBuffer(rbuf, NULL); // restore the original screen
+    restoreLightingOutlines(rout);
 
     restoreRNG;
     return theKey;

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -417,7 +417,7 @@ void dialogAlert(char *message) {
     strcpy(OKButton.text, "     OK     ");
     OKButton.hotkey[0] = RETURN_KEY;
     OKButton.hotkey[1] = ACKNOWLEDGE_KEY;
-    printTextBox(message, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, rbuf, &OKButton, 1);
+    printTextBox(message, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, rbuf, NULL, &OKButton, 1);
     overlayDisplayBuffer(rbuf, NULL);
 }
 

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -295,6 +295,7 @@ might succeed on the original computer."
 
 void playbackPanic() {
     cellDisplayBuffer rbuf[COLS][ROWS];
+    short rout[COLS][ROWS];
 
     if (!rogue.playbackOOS) {
         rogue.playbackFastForward = false;
@@ -308,13 +309,14 @@ void playbackPanic() {
         confirmMessages();
         message("Playback is out of sync.", false);
 
-        printTextBox(OOS_APOLOGY, 0, 0, 0, &white, &black, rbuf, NULL, 0);
+        printTextBox(OOS_APOLOGY, 0, 0, 0, &white, &black, rbuf, rout, NULL, 0);
 
         rogue.playbackMode = false;
         displayMoreSign();
         rogue.playbackMode = true;
 
         overlayDisplayBuffer(rbuf, 0);
+        restoreLightingOutlines(rout);
 
         printf("Playback panic at location %li! Turn number %li.\n", recordingLocation - 1, rogue.playerTurnNumber);
         overlayDisplayBuffer(rbuf, 0);
@@ -420,6 +422,7 @@ void loadNextAnnotation() {
 
 void displayAnnotation() {
     cellDisplayBuffer rbuf[COLS][ROWS];
+    short rout[COLS][ROWS];
 
     if (rogue.playbackMode
         && rogue.playerTurnNumber == rogue.nextAnnotationTurn) {
@@ -427,13 +430,14 @@ void displayAnnotation() {
         if (!rogue.playbackFastForward) {
             refreshSideBar(-1, -1, false);
 
-            printTextBox(rogue.nextAnnotation, player.xLoc, 0, 0, &black, &white, rbuf, NULL, 0);
+            printTextBox(rogue.nextAnnotation, player.xLoc, 0, 0, &black, &white, rbuf, rout, NULL, 0);
 
             rogue.playbackMode = false;
             displayMoreSign();
             rogue.playbackMode = true;
 
             overlayDisplayBuffer(rbuf, 0);
+            restoreLightingOutlines(rout);
         }
 
         loadNextAnnotation();
@@ -1025,6 +1029,17 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                     }
                 }
                 return true;
+            case LIGHTING_OUTLINE_KEY:
+                rogue.lightingOutlineMode = !rogue.lightingOutlineMode;
+                refreshLightingOutlines();
+                commitDraws();
+                if (rogue.lightingOutlineMode) {
+                    messageWithColor(KEYBOARD_LABELS ? "Lighting outlines displayed. Press \' again to hide." : "Lighting outlines displayed.",
+                                     &teal, false);
+                } else {
+                    messageWithColor(KEYBOARD_LABELS ? "Lighting outlines hidden. Press \' again to display." : "Lighting outlines hidden.",
+                                     &teal, false);
+                }
             case SEED_KEY:
                 //rogue.playbackMode = false;
                 //DEBUG {displayGrid(safetyMap); displayMoreSign(); displayLevel();}

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1120,6 +1120,7 @@ enum tileFlags {
 #define RELABEL_KEY         'R'
 #define TRUE_COLORS_KEY     '\\'
 #define AGGRO_DISPLAY_KEY   ']'
+#define LIGHTING_OUTLINE_KEY '\''
 #define DROP_KEY            'd'
 #define CALL_KEY            'c'
 #define QUIT_KEY            'Q'
@@ -2232,6 +2233,7 @@ typedef struct playerCharacter {
     boolean eligibleToUseStairs;        // so the player uses stairs only when he steps onto them
     boolean trueColorMode;              // whether lighting effects are disabled
     boolean displayAggroRangeMode;      // whether your stealth range is displayed
+    boolean lightingOutlineMode;        // whether light/dark cells are outlined
     boolean quit;                       // to skip the typical end-game theatrics when the player quits
     unsigned long seed;                 // the master seed for generating the entire dungeon
     short RNG;                          // which RNG are we currently using?
@@ -2677,7 +2679,8 @@ extern "C" {
     void plotChar(enum displayGlyph inputChar,
                   short xLoc, short yLoc,
                   short backRed, short backGreen, short backBlue,
-                  short foreRed, short foreGreen, short foreBlue);
+                  short foreRed, short foreGreen, short foreBlue,
+                  short outlineFlags, short outlineRed, short outlineGreen, short outlineBlue);
     boolean pauseForMilliseconds(short milliseconds);
     boolean isApplicationActive();
     void nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance);
@@ -2708,9 +2711,10 @@ extern "C" {
     short printTextBox(char *textBuf, short x, short y, short width,
                        color *foreColor, color *backColor,
                        cellDisplayBuffer rbuf[COLS][ROWS],
+                       short rout[COLS][ROWS],
                        brogueButton *buttons, short buttonCount);
-    void printMonsterDetails(creature *monst, cellDisplayBuffer rbuf[COLS][ROWS]);
-    void printFloorItemDetails(item *theItem, cellDisplayBuffer rbuf[COLS][ROWS]);
+    void printMonsterDetails(creature *monst, cellDisplayBuffer rbuf[COLS][ROWS], short rout[COLS][ROWS]);
+    void printFloorItemDetails(item *theItem, cellDisplayBuffer rbuf[COLS][ROWS], short rout[COLS][ROWS]);
     unsigned long printCarriedItemDetails(item *theItem,
                                           short x, short y, short width,
                                           boolean includeButtons,
@@ -2723,6 +2727,11 @@ extern "C" {
     void waitForKeystrokeOrMouseClick();
     boolean confirm(char *prompt, boolean alsoDuringPlayback);
     void refreshDungeonCell(short x, short y);
+    void refreshLightingOutlines();
+    void multiplyOutlineOpacity(short* outline, short multiplier);
+    void overlayLightingOutlines(cellDisplayBuffer dbuf[COLS][ROWS], short rout[COLS][ROWS]);
+    void restoreLightingOutlines(short rout[COLS][ROWS]);
+    void clearLightingOutlines();
     void applyColorMultiplier(color *baseColor, const color *multiplierColor);
     void applyColorAverage(color *baseColor, const color *newColor, short averageWeight);
     void applyColorAugment(color *baseColor, const color *augmentingColor, short augmentWeight);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1044,6 +1044,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     }
     rogue.highScoreSaved = true;
 
+    clearLightingOutlines();
     if (rogue.quit) {
         blackOutScreen();
     } else {
@@ -1128,6 +1129,7 @@ void victory(boolean superVictory) {
 
     rogue.gameInProgress = false;
     flushBufferToFile();
+    clearLightingOutlines();
 
     //
     // First screen - Congratulations...

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -762,6 +762,9 @@ void updateVision(boolean refreshDisplay) {
     updateTelepathy();
     updateLighting();
     updateFieldOfViewDisplay(true, refreshDisplay);
+    if (rogue.lightingOutlineMode) {
+        refreshLightingOutlines();
+    }
 
     //  for (i=0; i<DCOLS; i++) {
     //      for (j=0; j<DROWS; j++) {
@@ -2540,6 +2543,7 @@ void playerTurnEnded() {
         refreshSideBar(-1, -1, false);
 
         applyInstantTileEffectsToCreature(&player);
+
         if (rogue.gameHasEnded) { // caustic gas, lava, trapdoor, etc.
             return;
         }

--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -64,7 +64,8 @@ static char glyphToAscii(enum displayGlyph glyph) {
 static void curses_plotChar(enum displayGlyph ch,
               short xLoc, short yLoc,
               short foreRed, short foreGreen, short foreBlue,
-              short backRed, short backGreen, short backBlue) {
+              short backRed, short backGreen, short backBlue,
+              short outlineFlags, short outlineRed, short outlineGreen, short outlineBlue) {
 
     fcolor fore;
     fcolor back;

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -57,7 +57,8 @@ struct brogueConsole {
         enum displayGlyph inputChar,
         short x, short y,
         short foreRed, short foreGreen, short foreBlue,
-        short backRed, short backGreen, short backBlue
+        short backRed, short backGreen, short backBlue,
+        short outlineFlags, short outlineRed, short outlineGreen, short outlineBlue
     );
 
     void (*remap)(const char *, const char *);
@@ -112,4 +113,3 @@ extern char dataDirectory[];
 
 // defined in brogue
 extern playerCharacter rogue;
-

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -189,8 +189,10 @@ unsigned int glyphToUnicode(enum displayGlyph glyph) {
 void plotChar(enum displayGlyph inputChar,
               short xLoc, short yLoc,
               short foreRed, short foreGreen, short foreBlue,
-              short backRed, short backGreen, short backBlue) {
-    currentConsole.plotChar(inputChar, xLoc, yLoc, foreRed, foreGreen, foreBlue, backRed, backGreen, backBlue);
+              short backRed, short backGreen, short backBlue,
+              short outlineFlags, short outlineRed, short outlineGreen, short outlineBlue) {
+    currentConsole.plotChar(inputChar, xLoc, yLoc, foreRed, foreGreen, foreBlue, backRed, backGreen, backBlue,
+        outlineFlags, outlineRed, outlineGreen, outlineBlue);
 }
 
 void pausingTimerStartsNow() {
@@ -567,4 +569,3 @@ boolean isApplicationActive(void) {
     // FIXME: finish
     return true;
 }
-

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -377,11 +377,13 @@ static void _plotChar(
     enum displayGlyph inputChar,
     short x, short y,
     short foreRed, short foreGreen, short foreBlue,
-    short backRed, short backGreen, short backBlue
+    short backRed, short backGreen, short backBlue,
+    short outlineFlags, short outlineRed, short outlineGreen, short outlineBlue
 ) {
     updateTile(y, x, fontIndex(inputChar),
         foreRed, foreGreen, foreBlue,
-        backRed, backGreen, backBlue);
+        backRed, backGreen, backBlue,
+        outlineFlags, outlineRed, outlineGreen, outlineBlue);
 }
 
 

--- a/src/platform/tiles.h
+++ b/src/platform/tiles.h
@@ -7,7 +7,8 @@ void initTiles();
 void resizeWindow(int width, int height);
 void updateTile(int row, int column, short charIndex,
     short foreRed, short foreGreen, short foreBlue,
-    short backRed, short backGreen, short backBlue);
+    short backRed, short backGreen, short backBlue,
+    short outlineFlags, short outlineRed, short outlineGreen, short outlineBlue);
 void updateScreen();
 SDL_Surface *captureScreen();
 

--- a/src/platform/web-platform.c
+++ b/src/platform/web-platform.c
@@ -150,7 +150,8 @@ static unsigned int fixUnicode(unsigned int code) {
 static void web_plotChar(enum displayGlyph inputChar,
                          short xLoc, short yLoc,
                          short foreRed, short foreGreen, short foreBlue,
-                         short backRed, short backGreen, short backBlue) {
+                         short backRed, short backGreen, short backBlue,
+                         short outlineFlags, short outlineRed, short outlineGreen, short outlineBlue) {
     unsigned char outputBuffer[OUTPUT_SIZE];
     unsigned char firstCharByte, secondCharByte;
     enum displayGlyph translatedChar;


### PR DESCRIPTION
Added a lighting outline feature activated with the ' key as an alternative to the color effects mode. Tried to make outlines as unintrusive as possible to the game's art except when actively looking for them.

The formulas had some mathematical basis that I don't remember, but the numbers are arbitrary, I just messed with them until I found the nicest colors.

Here are a few (low-quality) screenshots and the windows .exe if you want to play around: https://drive.google.com/drive/folders/1VART4zS4ol1txqk7g6ZWzZuXA9W01MqY?usp=sharing

Most changes in this commit have to do with modifying/reverting outlines appropriately after a displayBuffer appearing in-game. 'rout' acts like rbuf when overlaying a display buffer, but restoring the original outlines instead of tiles. I couldn't find an efficient way to merge the process of overlaying outlines and normal overlaying, so this will have to do.