### PR TITLE
Enable High DPI awareness on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ windows/icon.o: windows/icon.rc
 
 bin/brogue.exe: $(objects) windows/icon.o
 	$(CC) $(cflags) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(libs) $(LDLIBS)
+	mt -manifest windows/brogue.exe.manifest -outputresource:bin/brogue.exe;1
 
 clean:
 	$(RM) src/brogue/*.o src/platform/*.o bin/brogue{,.exe}

--- a/windows/brogue.exe.manifest
+++ b/windows/brogue.exe.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">system</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
This is Windows' equivalent to Mac's `Info.plist`. Without it, SDL is not informed when the desktop is configured for high DPI.