### PR TITLE
Monster pathing fix with patch version

### DIFF
--- a/changes/fix-offlevel-monster-pathing.md
+++ b/changes/fix-offlevel-monster-pathing.md
@@ -1,0 +1,4 @@
+Fixed issues with off-level monster pathing that could get two monsters stuck on one another,
+causing one of them to go into a corrupted state that cannot be attacked.
+
+Made monsters move the correct distance and to the correct spot when reloading a level

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3466,8 +3466,14 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
         } else {
             theMap = mapToStairs;
         }
+
+        if(rogue.patchVersion >= 3) {
+            pmap[*x][*y].flags &= ~HAS_MONSTER;
+        }
         if (theMap) {
-            turnCount = ((theMap[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100) - monst->status[STATUS_ENTERS_LEVEL_IN]);
+            // STATUS_ENTERS_LEVEL_IN accounts for monster speed; convert back to map distance and subtract from distance to stairs
+            turnCount = rogue.patchVersion < 3 ? ((theMap[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100) - monst->status[STATUS_ENTERS_LEVEL_IN])
+                        : (theMap[monst->xLoc][monst->yLoc] - (monst->status[STATUS_ENTERS_LEVEL_IN] * 100 / monst->movementSpeed));
             for (i=0; i < turnCount; i++) {
                 if ((dir = nextStep(theMap, monst->xLoc, monst->yLoc, NULL, true)) != NO_DIRECTION) {
                     monst->xLoc += nbDirs[dir][0];

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1048,7 +1048,7 @@ enum tileFlags {
     IS_IN_MACHINE               = (IS_IN_ROOM_MACHINE | IS_IN_AREA_MACHINE),    // sacred ground; don't generate items here, or teleport randomly to it
 
     PERMANENT_TILE_FLAGS = (DISCOVERED | MAGIC_MAPPED | ITEM_DETECTED | HAS_ITEM | HAS_DORMANT_MONSTER
-                            | HAS_STAIRS | SEARCHED_FROM_HERE | PRESSURE_PLATE_DEPRESSED
+                            | HAS_MONSTER | HAS_STAIRS | SEARCHED_FROM_HERE | PRESSURE_PLATE_DEPRESSED
                             | STABLE_MEMORY | KNOWN_TO_BE_TRAP_FREE | IN_LOOP
                             | IS_CHOKEPOINT | IS_GATE_SITE | IS_IN_MACHINE | IMPREGNABLE),
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1844,6 +1844,10 @@ void monsterEntersLevel(creature *monst, short n) {
     char monstName[COLS], buf[COLS];
     boolean pit = false;
 
+    if (rogue.patchVersion >= 3) {
+        levels[n].mapStorage[monst->xLoc][monst->yLoc].flags &= ~HAS_MONSTER;
+    }
+
     // place traversing monster near the stairs on this level
     if (monst->bookkeepingFlags & MB_APPROACHING_DOWNSTAIRS) {
         monst->xLoc = rogue.upLoc[0];


### PR DESCRIPTION
Patch versioned fix of the monster pathing bug. Who knows when 1.10 will come out, but this works for now.

As a side note, unfortunately you can't use patch version on an enum, so I had to change the 2 instances of PERMANENT_TILE_FLAGS instead, and it has to be referenced this way if it's ever added again between now and 1.10.

