### PR TITLE
Fix player damage for un-ID'd weapons in monster infobox

### DIFF
--- a/changes/monst-detail.md
+++ b/changes/monst-detail.md
@@ -1,0 +1,1 @@
+Made un-ID'd weapons display the correct damage in monster info boxes

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -4185,19 +4185,12 @@ void monsterDetails(char buf[], creature *monst) {
         playerKnownAverageDamage = (player.info.damage.upperBound + player.info.damage.lowerBound) / 2;
         playerKnownMaxDamage = player.info.damage.upperBound;
     } else {
-        short tempEnchant = rogue.weapon->enchant1;
-        rogue.weapon->enchant1 = 0;
-        short tempLow = rogue.weapon->damage.lowerBound * damageFraction(netEnchant(rogue.weapon)) / FP_FACTOR;
-        short tempHigh = rogue.weapon->damage.upperBound * damageFraction(netEnchant(rogue.weapon)) / FP_FACTOR;
-        rogue.weapon->enchant1 = tempEnchant;
-        if (tempLow < 1) {
-            tempLow = 1;
-        }
-        if (tempHigh < 1) {
-            tempHigh = 1;
-        }
-        playerKnownAverageDamage = (tempLow + tempHigh) / 2;
-        playerKnownMaxDamage = tempHigh;
+        fixpt strengthFactor = damageFraction(strengthModifier(rogue.weapon));
+        short tempLow = rogue.weapon->damage.lowerBound * strengthFactor / FP_FACTOR;
+        short tempHigh = rogue.weapon->damage.upperBound * strengthFactor / FP_FACTOR;
+
+        playerKnownAverageDamage = max(1, (tempLow + tempHigh) / 2);
+        playerKnownMaxDamage = max(1, tempHigh);
     }
 
     // Combat info for the player attacking the monster (or whether it's captive)

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -4185,8 +4185,19 @@ void monsterDetails(char buf[], creature *monst) {
         playerKnownAverageDamage = (player.info.damage.upperBound + player.info.damage.lowerBound) / 2;
         playerKnownMaxDamage = player.info.damage.upperBound;
     } else {
-        playerKnownAverageDamage = (rogue.weapon->damage.upperBound + rogue.weapon->damage.lowerBound) / 2;
-        playerKnownMaxDamage = rogue.weapon->damage.upperBound;
+        short tempEnchant = rogue.weapon->enchant1;
+        rogue.weapon->enchant1 = 0;
+        short tempLow = rogue.weapon->damage.lowerBound * damageFraction(netEnchant(rogue.weapon)) / FP_FACTOR;
+        short tempHigh = rogue.weapon->damage.upperBound * damageFraction(netEnchant(rogue.weapon)) / FP_FACTOR;
+        rogue.weapon->enchant1 = tempEnchant;
+        if (tempLow < 1) {
+            tempLow = 1;
+        }
+        if (tempHigh < 1) {
+            tempHigh = 1;
+        }
+        playerKnownAverageDamage = (tempLow + tempHigh) / 2;
+        playerKnownMaxDamage = tempHigh;
     }
 
     // Combat info for the player attacking the monster (or whether it's captive)


### PR DESCRIPTION
Originally, if your weapon was un-ID'd, the combat info from hovering over a monster wouldn't account for strength in your average damage. An un-ID'd broadsword would be displayed as doing 100% average to a vampire bat regardless of strength.

The new code is written the same way as in recalculateEquipmentBonuses from Items.c