### PR TITLE
Ww/fix GitHub actions build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
     - name: "Install dependencies"
       run: |
+        # We need SDL 2.0.5+
+        sudo tee /etc/apt/sources.list.d/bionic.list <<<'deb http://azure.archive.ubuntu.com/ubuntu bionic main restricted universe multiverse'
         sudo apt update -y
-        sudo apt install -y libsdl2-dev libsdl2-image-dev
+        sudo apt install -y libsdl2-dev/bionic libsdl2-image-dev/bionic
 
     - name: "Checkout sources"
       uses: actions/checkout@v2


### PR DESCRIPTION
#207 introduced a little build instability in the github actions environment.  Here's a small fix to get them working again.