### PR TITLE
Fix pit bloat gas crashes

### DIFF
--- a/changes/pit-bloat-crashes.md
+++ b/changes/pit-bloat-crashes.md
@@ -1,0 +1,1 @@
+Fixed crashes from pit bloat/gas interactions

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -98,7 +98,7 @@ boolean monsterShouldFall(creature *monst) {
 
 // Called at least every 100 ticks; may be called more frequently.
 void applyInstantTileEffectsToCreature(creature *monst) {
-    char buf[COLS], buf2[COLS];
+    char buf[COLS], buf2[COLS], buf3[COLS];
     short *x = &(monst->xLoc), *y = &(monst->yLoc), damage;
     enum dungeonLayers layer;
     item *theItem;
@@ -315,11 +315,14 @@ void applyInstantTileEffectsToCreature(creature *monst) {
                 monst->creatureState = MONSTER_TRACKING_SCENT;
             }
             monsterName(buf, monst, true);
+
+            // Get explosive layer before damage in case a death DF replaces the explosion
+            strcpy(buf3, tileCatalog[pmap[*x][*y].layers[layerWithFlag(*x, *y, T_CAUSES_EXPLOSIVE_DAMAGE)]].description);
             if (inflictDamage(NULL, monst, damage, &yellow, false)) {
                 // if killed
                 sprintf(buf2, "%s %s %s.", buf,
                         (monst->info.flags & MONST_INANIMATE) ? "is destroyed by" : "dies in",
-                        tileCatalog[pmap[*x][*y].layers[layerWithFlag(*x, *y, T_CAUSES_EXPLOSIVE_DAMAGE)]].description);
+                        buf3);
                 messageWithColor(buf2, messageColorFromVictim(monst), false);
                 refreshDungeonCell(*x, *y);
                 return;


### PR DESCRIPTION
There were 2 types of crashes:
 - memory access when a pit bloat dies in an explosion, and
 - an infinite loop when the player is levitating in burning gas and a pit bloat dies near the player (unclear on exact conditions).

The explosion issue happens because the pit bloat's hole replaces the explosion and the game is unable to find the explosive layer that it assumes exists when printing out the pit bloat's death message.

For the loop: when exposeTileToFire clears gas, it sets the gas volume to 0 but leaves 'layers[GAS]' untouched. Clearing the gas layer makes gas burn [awkwardly](https://cdn.discordapp.com/attachments/647802299783184384/799503542430859294/Screenshot.png) and the layer is cleared when gases are updated anyways, so I left the behavior intact. Instead, I cut off the loop right before exposeTileToFire is called, if the gas layer exists but the volume is 0, which I believe only occurs from the quirk in exposeTileToFire.