### PR TITLE
Discordant wandering monsters now respect stealth range (#217)

### DIFF
--- a/changes/fix-discordant-snipers.md
+++ b/changes/fix-discordant-snipers.md
@@ -1,0 +1,1 @@
+Discordant wandering monsters no longer target the player with bolts/spells from beyond stealth range

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -2381,6 +2381,15 @@ boolean targetEligibleForCombatBuff(creature *caster, creature *target) {
 // Assumes that the conditions in generallyValidBoltTarget have already been satisfied.
 boolean specificallyValidBoltTarget(creature *caster, creature *target, enum boltType theBoltType) {
 
+    if (rogue.patchVersion >= 3
+        && caster->status[STATUS_DISCORDANT]
+        && caster->creatureState == MONSTER_WANDERING
+        && target == &player
+        ) {
+
+        return false;
+    }
+
     if ((boltCatalog[theBoltType].flags & BF_TARGET_ALLIES)
         && (!monstersAreTeammates(caster, target) || monstersAreEnemies(caster, target))) {
 

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -2384,9 +2384,12 @@ boolean specificallyValidBoltTarget(creature *caster, creature *target, enum bol
     if (rogue.patchVersion >= 3
         && caster->status[STATUS_DISCORDANT]
         && caster->creatureState == MONSTER_WANDERING
-        && target == &player
-        ) {
-
+        && target == &player) {
+        // Discordant monsters always try to cast spells regardless of whether
+        // they're hunting the player, so that they cast at other monsters. This
+        // by bypasses the usual awareness checks, so the player and any allies
+        // can be hit when far away. Hence, we don't target the player with
+        // bolts if we're discordant and wandering.
         return false;
     }
 

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -2349,6 +2349,17 @@ boolean generallyValidBoltTarget(creature *caster, creature *target) {
         // Can't target yourself; that's the fundamental theorem of Brogue bolts.
         return false;
     }
+    if (rogue.patchVersion >= 3
+        && caster->status[STATUS_DISCORDANT]
+        && caster->creatureState == MONSTER_WANDERING
+        && target == &player) {
+        // Discordant monsters always try to cast spells regardless of whether
+        // they're hunting the player, so that they cast at other monsters. This
+        // by bypasses the usual awareness checks, so the player and any allies
+        // can be hit when far away. Hence, we don't target the player with
+        // bolts if we're discordant and wandering.
+        return false;
+    }
     if (monsterIsHidden(target, caster)
         || (target->bookkeepingFlags & MB_SUBMERGED)) {
         // No bolt will affect a submerged creature. Can't shoot at invisible creatures unless it's in gas.
@@ -2380,18 +2391,6 @@ boolean targetEligibleForCombatBuff(creature *caster, creature *target) {
 // Make a decision as to whether the given caster should fire the given bolt at the given target.
 // Assumes that the conditions in generallyValidBoltTarget have already been satisfied.
 boolean specificallyValidBoltTarget(creature *caster, creature *target, enum boltType theBoltType) {
-
-    if (rogue.patchVersion >= 3
-        && caster->status[STATUS_DISCORDANT]
-        && caster->creatureState == MONSTER_WANDERING
-        && target == &player) {
-        // Discordant monsters always try to cast spells regardless of whether
-        // they're hunting the player, so that they cast at other monsters. This
-        // by bypasses the usual awareness checks, so the player and any allies
-        // can be hit when far away. Hence, we don't target the player with
-        // bolts if we're discordant and wandering.
-        return false;
-    }
 
     if ((boltCatalog[theBoltType].flags & BF_TARGET_ALLIES)
         && (!monstersAreTeammates(caster, target) || monstersAreEnemies(caster, target))) {


### PR DESCRIPTION
This applies to all ranged casters, including dragons.