### PR TITLE
Add truecolor terminal output

### DIFF
--- a/changes/truecolor-terminal.md
+++ b/changes/truecolor-terminal.md
@@ -1,0 +1,1 @@
+Use 24-bit colors when the terminal supports it (curses build).

--- a/src/platform/term.c
+++ b/src/platform/term.c
@@ -544,10 +544,10 @@ static void buffer_render_256() {
 static void buffer_render_24bit() {
     int i = 0;
     for (int y = 0; y < minsize.height; y++) {
+        printf("\033[%d;1f", y+1);
         for (int x = 0; x < minsize.width; x++) {
             pairmode_cell c = cell_buffer[i++];
-            printf("\033[%d;%df\033[38;2;%d;%d;%d;48;2;%d;%d;%dm%c",
-                y+1, x+1,
+            printf("\033[38;2;%d;%d;%d;48;2;%d;%d;%dm%c",
                 c.fore.r, c.fore.g, c.fore.b,
                 c.back.r, c.back.g, c.back.b,
                 c.ch);


### PR DESCRIPTION
Many terminals now accept 24-bit colors for foreground and background, removing the 256-color palette constraint.

Truecolor terminal support is detected more or less reliably (there is no standard method yet) by reading the $COLORTERM environment variable, which is conventionally set to 'truecolor' or '24bit' by those terminals.

Ncurses started supporting truecolor mode in version 6.1 (January 2018) but to make it work with older versions, this patch rolls out its own implementation with a couple of ANSI escape sequences.

To learn more see [color escape sequences](https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences) and [true color terminals](https://gist.github.com/XVilka/8346728).