### PR TITLE
Display "negated" in the sidebar and monster details

### DIFF
--- a/changes/negated-status.md
+++ b/changes/negated-status.md
@@ -1,0 +1,1 @@
+The sidebar and monster details now prominently display that a monster has been affected by negation

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -91,6 +91,7 @@ const color darkBlue =              {0,     0,      50,     0,      0,          
 const color darkTurquoise =         {0,     40,     65,     0,      0,          0,          0,      false};
 const color lightBlue =             {40,    40,     100,    0,      0,          0,          0,      false};
 const color pink =                  {100,   60,     66,     0,      0,          0,          0,      false};
+const color darkPink =              {50,    30,     33,     0,      0,          0,          0,      false};
 const color red  =                  {100,   0,      0,      0,      0,          0,          0,      false};
 const color darkRed =               {50,    0,      0,      0,      0,          0,          0,      false};
 const color tanColor =              {80,    67,     15,     0,      0,          0,          0,      false};

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4453,6 +4453,12 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
             || monst->creatureState == MONSTER_ALLY)) {
 
             if (y < ROWS - 1) {
+                if (monst->wasNegated
+                    && monst->newPowerCount == monst->totalPowerCount
+                    && y < ROWS - 1
+                    && (!player.status[STATUS_HALLUCINATING] || rogue.playbackOmniscience )) {
+                    printString("      Negated       ", 0, y++, (dim ? &darkPink : &pink), &black, 0);
+                }
                 if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience && y < ROWS - 1) {
                     printString(hallucinationStrings[rand_range(0, 9)], 0, y++, (dim ? &darkGray : &gray), &black, 0);
                 } else if (monst->bookkeepingFlags & MB_CAPTIVE && y < ROWS - 1) {

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -91,6 +91,7 @@ extern color darkOrange;
 extern color darkBlue;
 extern color lightBlue;
 extern color pink;
+extern color darkPink;
 extern color tanColor;
 extern color sunlight;
 extern color rainbow;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3517,7 +3517,10 @@ boolean tunnelize(short x, short y) {
     }
     return didSomething;
 }
-
+/* Negates the given creature. Returns true if there was an effect for the purpose of identifying a wand of negation.
+ * If the creature was stripped of any traits or abilities, the wasNegated property is set, which is used for display in
+ * sidebar and the creature's description.
+ */
 boolean negate(creature *monst) {
     short i, j;
     enum boltType backupBolts[20];
@@ -3529,6 +3532,7 @@ boolean negate(creature *monst) {
     if (monst->info.abilityFlags & ~MA_NON_NEGATABLE_ABILITIES) {
         monst->info.abilityFlags &= MA_NON_NEGATABLE_ABILITIES; // negated monsters lose all special abilities
         negated = true;
+        monst->wasNegated = true;
     }
 
     if (monst->bookkeepingFlags & MB_SEIZING){
@@ -3616,6 +3620,7 @@ boolean negate(creature *monst) {
         }
         if (monst->info.flags & MONST_IMMUNE_TO_FIRE) {
             monst->info.flags &= ~MONST_IMMUNE_TO_FIRE;
+            monst->wasNegated = true;
             negated = true;
         }
         if (monst->movementSpeed != monst->info.movementSpeed) {
@@ -3632,6 +3637,7 @@ boolean negate(creature *monst) {
 
             monst->mutationIndex = -1;
             negated = true;
+            monst->wasNegated = true;
         }
         if (monst != &player && (monst->info.flags & NEGATABLE_TRAITS)) {
             if ((monst->info.flags & MONST_FIERY) && monst->status[STATUS_BURNING]) {
@@ -3639,6 +3645,7 @@ boolean negate(creature *monst) {
             }
             monst->info.flags &= ~NEGATABLE_TRAITS;
             negated = true;
+            monst->wasNegated = true;
             refreshDungeonCell(monst->xLoc, monst->yLoc);
             refreshSideBar(-1, -1, false);
         }

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -4278,6 +4278,16 @@ void monsterDetails(char buf[], creature *monst) {
         strcat(buf, newText);
     }
 
+    if (monst->wasNegated && monst->newPowerCount == monst->totalPowerCount) {
+        i = strlen(buf);
+        i = encodeMessageColor(buf, i, &pink);
+        sprintf(newText, "%s is stripped of $HISHER special traits.", capMonstName);
+        resolvePronounEscapes(newText, monst);
+        upperCase(newText);
+        strcat(buf, "\n     ");
+        strcat(buf, newText);
+    }
+
     strcat(buf, "\n     ");
 
     i = strlen(buf);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2136,6 +2136,7 @@ typedef struct creature {
     enum creatureModes creatureMode;    // current behavioral mode (higher-level than state)
 
     short mutationIndex;                // what mutation the monster has (or -1 for none)
+    boolean wasNegated;                 // the monster has lost abilities due to negation
 
     // Waypoints:
     short targetWaypointIndex;          // the index number of the waypoint we're pathing toward


### PR DESCRIPTION
Add text to the sidebar and monster details to show that a monster was affected by negation