### PR TITLE
Start game with fixed aspect ratio

### DIFF
--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
                 int size = atoi(argv[i + 1]);
                 if (size > 0 && size <= 20) {
                     windowWidth = round(pow(1.1, size) * 620.);
-                    windowHeight = windowWidth * 9/16;
+                    // Height set automatically
                 };
 
                 i++;

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -175,7 +175,7 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
             } else if (key == SDLK_F11 || key == SDLK_F12
                     || key == SDLK_RETURN && (SDL_GetModState() & KMOD_ALT)) {
                 fullScreen = !fullScreen;
-                resizeWindow(windowWidth * 7/10, windowHeight * 7/10);
+                resizeWindow(-1, -1);  // Reset to starting resolution
                 continue;
             }
 

--- a/src/platform/tiles.c
+++ b/src/platform/tiles.c
@@ -721,9 +721,9 @@ void resizeWindow(int width, int height) {
     SDL_DisplayMode mode;
     if (SDL_GetCurrentDisplayMode(0, &mode) < 0) sdlfatal(__FILE__, __LINE__);
 
-    // 70% of monitor size by default
+    // 70% of monitor width by default, with height following 16:10 aspect ratio
     if (width < 0) width = mode.w * 7/10;
-    if (height < 0) height = mode.h * 7/10;
+    if (height < 0) height = width * 10/16;
 
     // go to fullscreen mode if the window is as big as the screen
     if (width >= mode.w && height >= mode.h) fullScreen = true;


### PR DESCRIPTION
Previously it used a 70% screen fit on both width and height, or 16:9 aspect
when using `--size`, however these lead to a slightly wider window than in the
past.

cc @AntonyBoucher for review