### PR TITLE
Fully revert Brogue 1.7.5 changes to captives and allies

### DIFF
--- a/changes/restore_ally_logic.md
+++ b/changes/restore_ally_logic.md
@@ -1,0 +1,1 @@
+Fully reverted the changes that Brogue 1.7.5 made to captives and allies.

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -1189,7 +1189,7 @@ const blueprint blueprintCatalog[NUMBER_BLUEPRINTS] = {
         {DF_VOMIT,  0,          0,              {2,3},      1,          0,          -1,         0,              1,              0,          0,          0},
         {0,         0,          0,              {1,1},      1,          0,          0,          0,              2,              0,          0,          (MF_BUILD_AT_ORIGIN | MF_PERMIT_BLOCKING | MF_BUILD_VESTIBULE)}}},
     // Kennel -- allies locked in cages in an open room; choose one or two to unlock and take with you.
-    {{5, AMULET_LEVEL}, {30, 80},   12,     4,          0,                  (BP_ROOM | BP_REWARD),  {
+    {{5, AMULET_LEVEL}, {30, 80},   15,     4,          0,                  (BP_ROOM | BP_REWARD),  {
         {0,         MONSTER_CAGE_CLOSED,DUNGEON,{3,5},      3,          0,          -1,         0,              2,              (HORDE_MACHINE_KENNEL | HORDE_LEADER_CAPTIVE), 0, (MF_GENERATE_HORDE | MF_TREAT_AS_BLOCKING | MF_IMPREGNABLE)},
         {0,         0,          0,              {1,2},      1,          KEY,        KEY_CAGE,   0,              1,              0,          (ITEM_IS_KEY | ITEM_PLAYER_AVOIDS),(MF_PERMIT_BLOCKING | MF_GENERATE_ITEM | MF_OUTSOURCE_ITEM_TO_MACHINE | MF_SKELETON_KEY | MF_KEY_DISPOSABLE)},
         {DF_AMBIENT_BLOOD, 0,   0,              {3,5},      3,          0,          -1,         0,              1,              0,          0,          0},
@@ -1701,7 +1701,7 @@ creatureType monsterCatalog[NUMBER_MONSTER_KINDS] = {
         (MONST_IMMUNE_TO_FIRE | MONST_FLIES | MONST_MALE), (0)},
     {0, "phoenix",      G_PHOENIX,    &phoenixColor,  30,     70,     175,    {4, 10, 2},     0,  50,     100,    DF_ASH_BLOOD,   PHOENIX_LIGHT,    true, 0,0,              {0},
         (MONST_IMMUNE_TO_FIRE| MONST_FLIES | MONST_NO_POLYMORPH)},
-    {0, "phoenix egg",  G_EGG,&phoenixColor, 50,     0,      0,      {0, 0, 0},      0,  100,    150,    DF_ASH_BLOOD,   PHOENIX_EGG_LIGHT,    false,  0,  0,      {0},
+    {0, "phoenix egg",  G_EGG,&phoenixColor, 150,    0,      0,      {0, 0, 0},      0,  100,    150,    DF_ASH_BLOOD,   PHOENIX_EGG_LIGHT,    false,  0,  0,      {0},
         (MONST_IMMUNE_TO_FIRE| MONST_IMMUNE_TO_WEBS | MONST_NEVER_SLEEPS | MONST_IMMOBILE | MONST_INANIMATE | MONST_WILL_NOT_USE_STAIRS | MONST_NO_POLYMORPH | MONST_ALWAYS_HUNTING | MONST_IMMUNE_TO_WEAPONS), (MA_CAST_SUMMON | MA_ENTER_SUMMONS)},
     {0, "mangrove dryad",G_ANCIENT_SPIRIT,   &tanColor,      70,     60,     175,    {2, 8, 2},      6,  100,    100,    DF_ASH_BLOOD,   0,    true,       0,      0,              {BOLT_ANCIENT_SPIRIT_VINES},
         (MONST_IMMUNE_TO_WEBS | MONST_ALWAYS_USE_ABILITY | MONST_MAINTAINS_DISTANCE | MONST_NO_POLYMORPH | MONST_MALE | MONST_FEMALE), (0)},

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -506,11 +506,12 @@ short pickHordeType(short depth, enum monsterTypes summonerType, unsigned long f
 
 void empowerMonster(creature *monst) {
     char theMonsterName[100], buf[200];
-    monst->info.maxHP += 12;
-    monst->info.defense += 10;
-    monst->info.accuracy += 10;
-    monst->info.damage.lowerBound += max(1, monst->info.damage.lowerBound / 10);
-    monst->info.damage.upperBound += max(1, monst->info.damage.upperBound / 10);
+    monst->info.maxHP += 15;
+    monst->currentHP += (15 * monst->currentHP / (monst->info.maxHP - 15));
+    monst->info.defense += 15;
+    monst->info.accuracy += 15;
+    monst->info.damage.lowerBound += max(1, monst->info.damage.lowerBound / 7);
+    monst->info.damage.upperBound += max(1, monst->info.damage.upperBound / 7);
     monst->newPowerCount++;
     monst->totalPowerCount++;
     heal(monst, 100, true);


### PR DESCRIPTION
Brogue 1.7.5 made some controversial changes to captives' frequency (3 times less likely) and to allies' empowerment (3 times less empowered, although they regenerate faster).

Brogue CE 1.8+ partially reverted those changes, but still not enough, as some players still prefer the original logic and continue to play 1.7.4 instead of CE mostly because of it.

I am submitting this PR to the `master` branch, because the two changes to `Globals.c` cannot be cleanly controlled with `patchVersion`. But maybe they don't matter to the 1.7.4 players? If that is the case, we can discard them, use `patchVersion` in `empowerMonster()` and merge into `release` instead, so that these players don't have to wait indefinitely for CE 1.10.