### PR TITLE
Link Releases page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ lucky few to return alive?
 Playing
 -------
 
-If you downloaded a release, you can open the game as follows:
+If you downloaded a [release][releases], you can open the game as follows:
 
 ### Windows
 
@@ -116,3 +116,6 @@ necessary.
 We don't know for sure whether Brian is still working on Brogue, or plans to
 release another version. However, he has implied that he considers the game
 complete, so we are working on the assumption that 1.7.5 is the final version.
+
+
+[releases]: https://github.com/tmewett/BrogueCE/releases


### PR DESCRIPTION
It took me an embarrassingly long time to find the releases so that I could download the latest executables. Adding a direct link to the Playing section, as I think it would be helpful for folks like me who jump straight down to the documentation for instructions.