### PR TITLE
Fix game crash when polymorphing a lich or phoenix (#238)

### DIFF
--- a/changes/fix-lich-polymorph-crash.md
+++ b/changes/fix-lich-polymorph-crash.md
@@ -1,0 +1,1 @@
+Fixed a bug causing the game to crash when polymorphing a lich or phoenix

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3625,7 +3625,6 @@ boolean polymorph(creature *monst) {
 
     // After polymorphing, don't "drop" any creature on death (e.g. phylactery, phoenix egg)
     if (monst->carriedMonster) {
-        killCreature(monst->carriedMonster, true);
         freeCreature(monst->carriedMonster);
         monst->carriedMonster = NULL;
     }


### PR DESCRIPTION
Game was crashing in `freeCreature` after call to `emptyGraveyard`. It seems the polymorph code handling the special case of liches/phoenixes was needlessly calling `kill ` for the phylactery/egg (carriedMonster), which adds the creature to the graveyard.
