### PR TITLE
Pass brogue-multiuser.sh params to Brogue itself

### DIFF
--- a/linux/brogue-multiuser.sh
+++ b/linux/brogue-multiuser.sh
@@ -15,4 +15,4 @@ userdir="${XDG_DATA_HOME:-$HOME/.local/share}/Brogue"  # where you want user fil
 
 mkdir -p "$userdir"
 cd "$userdir"
-exec "$broguedir"/brogue
+exec "$broguedir"/brogue "$@"


### PR DESCRIPTION
I know that `linux/brogue-multiuser.sh` is supposed to be an example script but many distros use it as a launcher for BrogueCE in their packages. Thus, users have to create their own scripts if they want to pass command line arguments to Brogue.