### PR TITLE
Better default window size for wide screens

### DIFF
--- a/changes/ultra-wide-monitor-support.md
+++ b/changes/ultra-wide-monitor-support.md
@@ -1,0 +1,1 @@
+Brogue now starts with a reasonable window size on ultra-wide monitors.

--- a/src/platform/tiles.c
+++ b/src/platform/tiles.c
@@ -721,8 +721,9 @@ void resizeWindow(int width, int height) {
     SDL_DisplayMode mode;
     if (SDL_GetCurrentDisplayMode(0, &mode) < 0) sdlfatal(__FILE__, __LINE__);
 
-    // 70% of monitor width by default, with height following 16:10 aspect ratio
-    if (width < 0) width = mode.w * 7/10;
+    // By default the window will have an aspect ratio of 16:10
+    // and either 70% of monitor width or 70% of monitor height, whichever is smaller
+    if (width < 0) width = min(mode.w * 7/10, mode.h * 28/25);
     if (height < 0) height = width * 10/16;
 
     // go to fullscreen mode if the window is as big as the screen

--- a/src/platform/tiles.c
+++ b/src/platform/tiles.c
@@ -722,8 +722,8 @@ void resizeWindow(int width, int height) {
     if (SDL_GetCurrentDisplayMode(0, &mode) < 0) sdlfatal(__FILE__, __LINE__);
 
     // By default the window will have an aspect ratio of 16:10
-    // and either 70% of monitor width or 70% of monitor height, whichever is smaller
-    if (width < 0) width = min(mode.w * 7/10, mode.h * 28/25);
+    // and either 80% of monitor width or 80% of monitor height, whichever is smaller
+    if (width < 0) width = min(mode.w * 8/10, mode.h * 8*16/(10*10));
     if (height < 0) height = width * 10/16;
 
     // go to fullscreen mode if the window is as big as the screen


### PR DESCRIPTION
For lucky owners of ultra-wide monitors (aspect ratio > 2:1) Brogue opens by default with a window that is taller than the monitor. This patch ensures that the default window size does not exceed 70% of monitor's width nor 70% of monitor's height. Initial window aspect ratio is 16:10.