### PR TITLE
Guard again undefined macros

### DIFF
--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -28,6 +28,10 @@
 #include <time.h>
 #include "PlatformDefines.h"
 
+#ifndef BROGUE_EXTRA_VERSION
+#error "The BROGUE_EXTRA_VERSION macro is undefined."
+#endif
+
 // unicode: comment this line to revert to ASCII
 
 #define USE_UNICODE

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -2,6 +2,10 @@
 #include <limits.h>
 #include "platform.h"
 
+#ifndef DATADIR
+#error "The DATADIR macro is undefined."
+#endif
+
 // Expanding a macro as a string constant requires two levels of macros
 #define _str(x)  #x
 #define STRINGIFY(x)  _str(x)


### PR DESCRIPTION
Brogue won't compile if some macros are not defined. This patch makes it compile by defaulting macros to sane values (with warning for one of them).