### PR TITLE
Explicitly sign char used as cost intermediate

### DIFF
--- a/changes/dungeon-generation-on-arm.md
+++ b/changes/dungeon-generation-on-arm.md
@@ -1,0 +1,1 @@
+Make dungeon generation on ARM processors agree with x86

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -258,7 +258,7 @@ void calculateDistances(short **distanceMap,
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            char cost;
+            signed char cost;
             monst = monsterAtLoc(i, j);
             if (monst
                 && (monst->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))


### PR DESCRIPTION
Unlike other numeric types, `char` apparently is not implicitly `signed char`, but rather has an unspecified signed-ness (see [0]).  Since negative guards are used, and since it is the default on my x86 gcc, use a signed char.

[0]: https://stackoverflow.com/a/2054941/580412

Closes #68