### PR TITLE
Auto-ID wand of negation if monster description changes (#233)

### DIFF
--- a/changes/negation-wand-auto-id.md
+++ b/changes/negation-wand-auto-id.md
@@ -1,0 +1,1 @@
+Wands of negation auto-ID if the bolt has an effect. A combat message is shown for any monster affected by negation. 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4400,7 +4400,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 if (boltCatalog[BOLT_NEGATION].backColor) {
                     flashMonster(monst, boltCatalog[BOLT_NEGATION].backColor, 100);
                 }
-                if (rogue.patchVersion >= 4 && negated && autoID) {
+                if (rogue.patchVersion >= 4 && negated && autoID && canSeeMonster(monst)) {
                     *autoID = true;
                 }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3518,15 +3518,25 @@ boolean tunnelize(short x, short y) {
     return didSomething;
 }
 
-void negate(creature *monst) {
+boolean negate(creature *monst) {
     short i, j;
     enum boltType backupBolts[20];
-    monst->info.abilityFlags &= MA_NON_NEGATABLE_ABILITIES; // negated monsters lose all special abilities
-    monst->bookkeepingFlags &= ~MB_SEIZING;
+    char buf[DCOLS * 3], monstName[DCOLS];
+    boolean negated = false;
+
+    monsterName(monstName, monst, true);
+
+    if (monst->info.abilityFlags & ~MA_NON_NEGATABLE_ABILITIES) {
+        monst->info.abilityFlags &= MA_NON_NEGATABLE_ABILITIES; // negated monsters lose all special abilities
+        negated = true;
+    }
+
+    if (monst->bookkeepingFlags & MB_SEIZING){
+        monst->bookkeepingFlags &= ~MB_SEIZING;
+        negated = true;
+    }
 
     if (monst->info.flags & MONST_DIES_IF_NEGATED) {
-        char buf[DCOLS * 3], monstName[DCOLS];
-        monsterName(monstName, monst, true);
         if (monst->status[STATUS_LEVITATING]) {
             sprintf(buf, "%s dissipates into thin air", monstName);
         } else if (monst->info.flags & MONST_INANIMATE) {
@@ -3536,49 +3546,108 @@ void negate(creature *monst) {
         }
         killCreature(monst, false);
         combatMessage(buf, messageColorFromVictim(monst));
+        negated = true;
     } else if (!(monst->info.flags & MONST_INVULNERABLE)) {
         // works on inanimates
-        monst->status[STATUS_IMMUNE_TO_FIRE] = 0;
-        monst->status[STATUS_SLOWED] = 0;
-        monst->status[STATUS_HASTED] = 0;
-        monst->status[STATUS_CONFUSED] = 0;
-        monst->status[STATUS_ENTRANCED] = 0;
-        monst->status[STATUS_DISCORDANT] = 0;
-        monst->status[STATUS_SHIELDED] = 0;
-        monst->status[STATUS_INVISIBLE] = 0;
+        if (monst->status[STATUS_IMMUNE_TO_FIRE]) {
+            monst->status[STATUS_IMMUNE_TO_FIRE] = 0;
+            negated = true;
+        }
+        if (monst->status[STATUS_SLOWED]) {
+            monst->status[STATUS_SLOWED] = 0;
+            negated = true;
+        }
+        if (monst->status[STATUS_HASTED]) {
+            monst->status[STATUS_HASTED] = 0;
+            negated = true;
+        }
+        if (monst->status[STATUS_CONFUSED]) {
+            monst->status[STATUS_CONFUSED] = 0;
+            negated = true;
+        }
+        if (monst->status[STATUS_ENTRANCED]) {
+            monst->status[STATUS_ENTRANCED] = 0;
+            negated = true;
+        }
+        if (monst->status[STATUS_DISCORDANT]) {
+            monst->status[STATUS_DISCORDANT] = 0;
+            negated = true;
+        }
+        if (monst->status[STATUS_SHIELDED]) {
+            monst->status[STATUS_SHIELDED] = 0;
+            negated = true;
+        }
+        if (monst->status[STATUS_INVISIBLE]) {
+            monst->status[STATUS_INVISIBLE] = 0;
+            negated = true;
+        }
         if (monst == &player) {
-            monst->status[STATUS_TELEPATHIC] = min(monst->status[STATUS_TELEPATHIC], 1);
-            monst->status[STATUS_MAGICAL_FEAR] = min(monst->status[STATUS_MAGICAL_FEAR], 1);
-            monst->status[STATUS_LEVITATING] = min(monst->status[STATUS_LEVITATING], 1);
+            if (monst->status[STATUS_TELEPATHIC] > 1 ) {
+                monst->status[STATUS_TELEPATHIC] = 1;
+                negated = true;
+            }
+            if (monst->status[STATUS_MAGICAL_FEAR] > 1 ) {
+                monst->status[STATUS_MAGICAL_FEAR] = 1;
+                negated = true;
+            }
+            if (monst->status[STATUS_LEVITATING] > 1 ) {
+                monst->status[STATUS_LEVITATING] = 1;
+                negated = true;
+            }
             if (monst->status[STATUS_DARKNESS]) {
                 monst->status[STATUS_DARKNESS] = 0;
                 updateMinersLightRadius();
                 updateVision(true);
+                negated = true;
             }
         } else {
-            monst->status[STATUS_TELEPATHIC] = 0;
-            monst->status[STATUS_MAGICAL_FEAR] = 0;
-            monst->status[STATUS_LEVITATING] = 0;
+            if (monst->status[STATUS_TELEPATHIC] > 0 ) {
+                monst->status[STATUS_TELEPATHIC] = 0;
+                negated = true;
+            }
+            if (monst->status[STATUS_MAGICAL_FEAR] > 0 ) {
+                monst->status[STATUS_MAGICAL_FEAR] = 0;
+                negated = true;
+            }
+            if (monst->status[STATUS_LEVITATING] > 0 ) {
+                monst->status[STATUS_LEVITATING] = 0;
+                negated = true;
+            }
         }
-        monst->info.flags &= ~MONST_IMMUNE_TO_FIRE;
-        monst->movementSpeed = monst->info.movementSpeed;
-        monst->attackSpeed = monst->info.attackSpeed;
+        if (monst->info.flags & MONST_IMMUNE_TO_FIRE) {
+            monst->info.flags &= ~MONST_IMMUNE_TO_FIRE;
+            negated = true;
+        }
+        if (monst->movementSpeed != monst->info.movementSpeed) {
+            monst->movementSpeed = monst->info.movementSpeed;
+            negated = true;
+        }
+        if (monst->attackSpeed != monst->info.attackSpeed) {
+            monst->attackSpeed = monst->info.attackSpeed;
+            negated = true;
+        }
+
         if (monst != &player && monst->mutationIndex > -1 && mutationCatalog[monst->mutationIndex].canBeNegated
             && rogue.patchVersion >= 3) {
 
             monst->mutationIndex = -1;
+            negated = true;
         }
         if (monst != &player && (monst->info.flags & NEGATABLE_TRAITS)) {
             if ((monst->info.flags & MONST_FIERY) && monst->status[STATUS_BURNING]) {
                 extinguishFireOnCreature(monst);
             }
             monst->info.flags &= ~NEGATABLE_TRAITS;
+            negated = true;
             refreshDungeonCell(monst->xLoc, monst->yLoc);
             refreshSideBar(-1, -1, false);
         }
         for (i = 0; i < 20; i++) {
             backupBolts[i] = monst->info.bolts[i];
             monst->info.bolts[i] = BOLT_NONE;
+            if (monst->info.bolts[i] && !(boltCatalog[monst->info.bolts[i]].flags & BF_NOT_NEGATABLE)) {
+                negated = true;
+            }
         }
         for (i = 0, j = 0; i < 20 && backupBolts[i]; i++) {
             if (boltCatalog[backupBolts[i]].flags & BF_NOT_NEGATABLE) {
@@ -3589,6 +3658,14 @@ void negate(creature *monst) {
         monst->newPowerCount = monst->totalPowerCount; // Allies can re-learn lost ability slots.
         applyInstantTileEffectsToCreature(monst); // in case it should immediately die or fall into a chasm
     }
+
+    if (negated && monst != &player && !(monst->info.flags & MONST_DIES_IF_NEGATED)) {
+        sprintf(buf, "%s is stripped of $HISHER special traits", monstName);
+        resolvePronounEscapes(buf, monst);
+        combatMessage(buf, messageColorFromVictim(monst));
+    }
+
+    return negated;
 }
 
 // Adds one to the creature's weakness, sets the weakness status duration to maxDuration.
@@ -4150,6 +4227,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
     creature *monst; // Creature being hit by the bolt, if any.
     creature *newMonst; // Utility variable for plenty
     boolean terminateBolt = false;
+    boolean negated = false;
 
     if (lightingChanged) {
         *lightingChanged = false;
@@ -4318,10 +4396,14 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 }
                 break;
             case BE_NEGATION:
-                negate(monst);
+                negated = negate(monst);
                 if (boltCatalog[BOLT_NEGATION].backColor) {
                     flashMonster(monst, boltCatalog[BOLT_NEGATION].backColor, 100);
                 }
+                if (rogue.patchVersion >= 4 && negated && autoID) {
+                    *autoID = true;
+                }
+
                 break;
             case BE_EMPOWERMENT:
                 if (monst != &player

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2959,7 +2959,7 @@ extern "C" {
     short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2], const short targetLoc[2]);
     void getImpactLoc(short returnLoc[2], const short originLoc[2], const short targetLoc[2],
                       const short maxDistance, const boolean returnLastEmptySpace);
-    void negate(creature *monst);
+    boolean negate(creature *monst);
     short monsterAccuracyAdjusted(const creature *monst);
     fixpt monsterDamageAdjustmentAmount(const creature *monst);
     short monsterDefenseAdjusted(const creature *monst);


### PR DESCRIPTION
Wands of negation auto-ID if the bolt has an effect. A combat message is shown for any monster affected by negation.