### PR TITLE
Summon minions without items (#251)

### DIFF
--- a/changes/summon-minions-without-items.md
+++ b/changes/summon-minions-without-items.md
@@ -1,0 +1,2 @@
+Fixed a bug where summoned minions could spawn with a carried item which was then deleted, making it unavailable for 
+future monster drops and leading to differences in available items for players playing the same seed 


### PR DESCRIPTION
Partial resolution of issue #251.

This fixes a bug where summoned minions could spawn with a carried item which was then deleted, making it unavailable for 
future monster drops and leading to differences in available items for players playing the same seed.