### PR TITLE
Refactor monster generation

### DIFF
--- a/changes/monster-spawn.md
+++ b/changes/monster-spawn.md
@@ -1,0 +1,3 @@
+Wisps no longer spawn on grass.
+
+Turrets will no longer spawn behind the stairs, or behind statues so that they cannot fire.

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -1551,7 +1551,8 @@ boolean buildAMachine(enum machineTypes bp,
                                                featX,
                                                featY,
                                                ((HORDE_IS_SUMMONED | HORDE_LEADER_CAPTIVE) & ~(feature->hordeFlags)),
-                                               feature->hordeFlags);
+                                               feature->hordeFlags,
+                                               false);
                             if (monst) {
                                 monst->bookkeepingFlags |= MB_JUST_SUMMONED;
                             }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -6697,7 +6697,7 @@ void readScroll(item *theItem) {
                     y = player.yLoc + nbDirs[i][1];
                     if (!cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY) && !(pmap[x][y].flags & HAS_MONSTER)
                         && rand_percent(10) && (numberOfMonsters < 3)) {
-                        monst = spawnHorde(0, x, y, (HORDE_LEADER_CAPTIVE | HORDE_NO_PERIODIC_SPAWN | HORDE_IS_SUMMONED | HORDE_MACHINE_ONLY), 0);
+                        monst = spawnHorde(0, x, y, (HORDE_LEADER_CAPTIVE | HORDE_NO_PERIODIC_SPAWN | HORDE_IS_SUMMONED | HORDE_MACHINE_ONLY), 0, false);
                         if (monst) {
                             // refreshDungeonCell(x, y);
                             // monst->creatureState = MONSTER_TRACKING_SCENT;

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -612,9 +612,11 @@ creature *cloneMonster(creature *monst, boolean announce, boolean placeClone) {
 }
 
 unsigned long forbiddenFlagsForMonster(creatureType *monsterType) {
-    unsigned long flags;
+    unsigned long flags = 0;
 
-    flags = T_PATHING_BLOCKER;
+    if (!(monsterType->flags & MONST_ATTACKABLE_THRU_WALLS)) {
+        flags = T_PATHING_BLOCKER;
+    }
     if (monsterType->flags & MONST_INVULNERABLE) {
         flags &= ~(T_LAVA_INSTA_DEATH | T_SPONTANEOUSLY_IGNITES | T_IS_FIRE);
     }

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -685,6 +685,9 @@ boolean spawnMinions(short hordeID, creature *leader, boolean summoned) {
         if (hordeCatalog[hordeID].spawnsIn) {
             forbiddenTerrainFlags &= ~(tileCatalog[hordeCatalog[hordeID].spawnsIn].flags);
         }
+        if (monsterCatalog[theHorde->memberType[iSpecies]].flags & MONST_FIERY) {
+            forbiddenTerrainFlags |= T_IS_FLAMMABLE;
+        }
 
         for (iMember = 0; iMember < count; iMember++) {
             monst = generateMonster(theHorde->memberType[iSpecies], true, !summoned);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2882,7 +2882,7 @@ extern "C" {
 
     creature *generateMonster(short monsterID, boolean itemPossible, boolean mutationPossible);
     short chooseMonster(short forLevel);
-    creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFlags, unsigned long requiredFlags);
+    creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFlags, unsigned long requiredFlags, boolean periodic);
     void fadeInMonster(creature *monst);
     boolean removeMonsterFromChain(creature *monst, creature *theChain);
     boolean monsterWillAttackTarget(const creature *attacker, const creature *defender);


### PR DESCRIPTION
Created getRandomHordeSpawnLocation to determine horde spawn location, which brings all the checks from spawnHorde, getRandomMonsterSpawnLocation, and randomMatchingLocation into one place. There are a few more checks in spawnHorde that affect scroll of summon monsters, but other than that everything has been moved. A byproduct of this is that during periodic horde spawn, the horde type can be chosen before location, which makes changing monster spawn behavior easier.

Includes commits for preventing turrets from spawning behind statues/stairs and preventing wisps from spawning on grass.

Should I patchVersion this? I think this would come down to creating separate spawnHorde_193 and spawnHorde_194 functions because of the extra argument.
