### PR TITLE
Auto-kink throw trajectories

### DIFF
--- a/changes/assisted-aiming.md
+++ b/changes/assisted-aiming.md
@@ -1,0 +1,1 @@
+Aiming at a target now picks up or avoids as many enemies/allies/walls as possible without the need to aim for a cell beyond your intended target.

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1907,7 +1907,8 @@ boolean traversiblePathBetween(creature *monst, short x2, short y2) {
     short originLoc[2] = {monst->xLoc, monst->yLoc};
     short targetLoc[2] = {x2, y2};
 
-    n = getLineCoordinates(coords, originLoc, targetLoc);
+    // Using BOLT_NONE here to favor a path that avoids obstacles to one that hits them
+    n = getLineCoordinates(coords, originLoc, targetLoc, &boltCatalog[BOLT_NONE]);
 
     for (i=0; i<n; i++) {
         x = coords[i][0];
@@ -1928,7 +1929,7 @@ boolean specifiedPathBetween(short x1, short y1, short x2, short y2,
     short coords[DCOLS][2], i, x, y, n;
     short originLoc[2] = {x1, y1};
     short targetLoc[2] = {x2, y2};
-    n = getLineCoordinates(coords, originLoc, targetLoc);
+    n = getLineCoordinates(coords, originLoc, targetLoc, &boltCatalog[BOLT_NONE]);
 
     for (i=0; i<n; i++) {
         x = coords[i][0];
@@ -1947,7 +1948,7 @@ boolean specifiedPathBetween(short x1, short y1, short x2, short y2,
 boolean openPathBetween(short x1, short y1, short x2, short y2) {
     short returnLoc[2], startLoc[2] = {x1, y1}, targetLoc[2] = {x2, y2};
 
-    getImpactLoc(returnLoc, startLoc, targetLoc, DCOLS, false);
+    getImpactLoc(returnLoc, startLoc, targetLoc, DCOLS, false, &boltCatalog[BOLT_NONE]);
     if (returnLoc[0] == targetLoc[0] && returnLoc[1] == targetLoc[1]) {
         return true;
     }
@@ -2219,7 +2220,7 @@ boolean monsterBlinkToPreferenceMap(creature *monst, short **preferenceMap, bool
         target[0] += monst->xLoc;
         target[1] += monst->yLoc;
 
-        getImpactLoc(impact, origin, target, maxDistance, true);
+        getImpactLoc(impact, origin, target, maxDistance, true, &boltCatalog[BOLT_BLINKING]);
         nowPreference = preferenceMap[impact[0]][impact[1]];
 
         if (((blinkUphill && (nowPreference > bestPreference))

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -615,7 +615,7 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
     originLoc[1] = attacker->yLoc;
     targetLoc[0] = attacker->xLoc + nbDirs[dir][0];
     targetLoc[1] = attacker->yLoc + nbDirs[dir][1];
-    getImpactLoc(strikeLoc, originLoc, targetLoc, 5, false);
+    getImpactLoc(strikeLoc, originLoc, targetLoc, 5, false, &boltCatalog[BOLT_WHIP]);
 
     defender = monsterAtLoc(strikeLoc[0], strikeLoc[1]);
     if (defender

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2965,9 +2965,9 @@ extern "C" {
     void pickUpItemAt(short x, short y);
     item *addItemToPack(item *theItem);
     void aggravateMonsters(short distance, short x, short y, const color *flashColor);
-    short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2], const short targetLoc[2]);
+    short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2], const short targetLoc[2], const bolt *theBolt);
     void getImpactLoc(short returnLoc[2], const short originLoc[2], const short targetLoc[2],
-                      const short maxDistance, const boolean returnLastEmptySpace);
+                      const short maxDistance, const boolean returnLastEmptySpace, const bolt *theBolt);
     void negate(creature *monst);
     short monsterAccuracyAdjusted(const creature *monst);
     fixpt monsterDamageAdjustmentAmount(const creature *monst);


### PR DESCRIPTION
Casting bolts and throwing items happen in a straight line as always, but now the pathing algorithm can aim for a point that is not the exact center of the target cell, to improve the outcome. Tunneling will try to hit as many walls as possible, throwing objects will try to avoid them. Bolts will try to hit many enemies and few allies, or vice versa depending on the type of bolt. If a bolt can only hit 1 creature, Brogue will favor hitting the targeted one over any other. If firebolt can hit as many enemies with or without setting terrain on fire, it will prefer not to.

This makes it unnecessary to aim for a cell beyond your intended target, trying to trick the Bresenham algorithm into passing through the cells you want.

The projectile is still thrown from the exact center of the origin (player). I tested offsetting the origin too, but it significantly changed gameplay: you could then shoot arrows along walls from behind a corner (a la CornerShot), way outside the field of view, which is already a problem as it is (see #265).

Solves Pender's first bullet point.