### PR TITLE
Portable patchVersion checks

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3467,12 +3467,12 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
             theMap = mapToStairs;
         }
 
-        if(COMPARE_TO_VERSION(1,9,3) >= 0) {
+        if(BROGUE_VERSION_ATLEAST(1,9,3)) {
             pmap[*x][*y].flags &= ~HAS_MONSTER;
         }
         if (theMap) {
             // STATUS_ENTERS_LEVEL_IN accounts for monster speed; convert back to map distance and subtract from distance to stairs
-            turnCount = COMPARE_TO_VERSION(1,9,3) < 0 ? ((theMap[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100) - monst->status[STATUS_ENTERS_LEVEL_IN])
+            turnCount = !BROGUE_VERSION_ATLEAST(1,9,3) ? ((theMap[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100) - monst->status[STATUS_ENTERS_LEVEL_IN])
                         : (theMap[monst->xLoc][monst->yLoc] - (monst->status[STATUS_ENTERS_LEVEL_IN] * 100 / monst->movementSpeed));
             for (i=0; i < turnCount; i++) {
                 if ((dir = nextStep(theMap, monst->xLoc, monst->yLoc, NULL, true)) != NO_DIRECTION) {

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3467,12 +3467,12 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
             theMap = mapToStairs;
         }
 
-        if(rogue.patchVersion >= 3) {
+        if(COMPARE_TO_VERSION(1,9,3) >= 0) {
             pmap[*x][*y].flags &= ~HAS_MONSTER;
         }
         if (theMap) {
             // STATUS_ENTERS_LEVEL_IN accounts for monster speed; convert back to map distance and subtract from distance to stairs
-            turnCount = rogue.patchVersion < 3 ? ((theMap[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100) - monst->status[STATUS_ENTERS_LEVEL_IN])
+            turnCount = COMPARE_TO_VERSION(1,9,3) < 0 ? ((theMap[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100) - monst->status[STATUS_ENTERS_LEVEL_IN])
                         : (theMap[monst->xLoc][monst->yLoc] - (monst->status[STATUS_ENTERS_LEVEL_IN] * 100 / monst->movementSpeed));
             for (i=0; i < turnCount; i++) {
                 if ((dir = nextStep(theMap, monst->xLoc, monst->yLoc, NULL, true)) != NO_DIRECTION) {

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1045,7 +1045,7 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
 
     if ((attacker->info.abilityFlags & MA_SEIZES)
         && (!(attacker->bookkeepingFlags & MB_SEIZING) || !(defender->bookkeepingFlags & MB_SEIZED))
-        && (COMPARE_TO_VERSION(1,9,2) < 0 ||
+        && (!BROGUE_VERSION_ATLEAST(1,9,2) ||
             (distanceBetween(attacker->xLoc, attacker->yLoc, defender->xLoc, defender->yLoc) == 1
             && !diagonalBlocked(attacker->xLoc, attacker->yLoc, defender->xLoc, defender->yLoc, false)))) {
 
@@ -1601,7 +1601,7 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
     }
 
     if (!administrativeDeath && (decedent->info.abilityFlags & MA_DF_ON_DEATH)
-        && ((COMPARE_TO_VERSION(1,9,3) < 0) || !(decedent->bookkeepingFlags & MB_IS_FALLING))) {
+        && ((!BROGUE_VERSION_ATLEAST(1,9,3)) || !(decedent->bookkeepingFlags & MB_IS_FALLING))) {
         spawnDungeonFeature(decedent->xLoc, decedent->yLoc, &dungeonFeatureCatalog[decedent->info.DFType], true, false);
 
         if (monsterText[decedent->info.monsterID].DFMessage[0] && canSeeMonster(decedent)) {

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1045,7 +1045,7 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
 
     if ((attacker->info.abilityFlags & MA_SEIZES)
         && (!(attacker->bookkeepingFlags & MB_SEIZING) || !(defender->bookkeepingFlags & MB_SEIZED))
-        && (rogue.patchVersion < 2 ||
+        && (COMPARE_TO_VERSION(1,9,2) < 0 ||
             (distanceBetween(attacker->xLoc, attacker->yLoc, defender->xLoc, defender->yLoc) == 1
             && !diagonalBlocked(attacker->xLoc, attacker->yLoc, defender->xLoc, defender->yLoc, false)))) {
 
@@ -1601,7 +1601,7 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
     }
 
     if (!administrativeDeath && (decedent->info.abilityFlags & MA_DF_ON_DEATH)
-        && ((rogue.patchVersion < 3) || !(decedent->bookkeepingFlags & MB_IS_FALLING))) {
+        && ((COMPARE_TO_VERSION(1,9,3) < 0) || !(decedent->bookkeepingFlags & MB_IS_FALLING))) {
         spawnDungeonFeature(decedent->xLoc, decedent->yLoc, &dungeonFeatureCatalog[decedent->info.DFType], true, false);
 
         if (monsterText[decedent->info.monsterID].DFMessage[0] && canSeeMonster(decedent)) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3633,7 +3633,7 @@ boolean negate(creature *monst) {
         }
 
         if (monst != &player && monst->mutationIndex > -1 && mutationCatalog[monst->mutationIndex].canBeNegated
-            && COMPARE_TO_VERSION(1,9,3) >= 0) {
+            && BROGUE_VERSION_ATLEAST(1,9,3)) {
 
             monst->mutationIndex = -1;
             negated = true;
@@ -4409,7 +4409,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 if (boltCatalog[BOLT_NEGATION].backColor) {
                     flashMonster(monst, boltCatalog[BOLT_NEGATION].backColor, 100);
                 }
-                if (COMPARE_TO_VERSION(1,9,4) >= 0 && negated && autoID && canSeeMonster(monst)) {
+                if (BROGUE_VERSION_ATLEAST(1,9,4) && negated && autoID && canSeeMonster(monst)) {
                     *autoID = true;
                 }
 
@@ -4481,7 +4481,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 if (!(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
                     newMonst = cloneMonster(monst, true, true);
                     if (newMonst) {
-                        if (COMPARE_TO_VERSION(1,9,1) >= 0) {
+                        if (BROGUE_VERSION_ATLEAST(1,9,1)) {
                             monst->info.maxHP = newMonst->info.maxHP = (monst->info.maxHP + 1) / 2;
                             monst->currentHP = newMonst->currentHP = min(monst->currentHP, monst->info.maxHP);
                         } else {
@@ -4649,7 +4649,7 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
             caster->xLoc = x;
             caster->yLoc = y;
             // Always break free on blink
-            if (COMPARE_TO_VERSION(1,9,4) >= 0) {
+            if (BROGUE_VERSION_ATLEAST(1,9,4)) {
                 disentangle(caster);
             }
             applyInstantTileEffectsToCreature(caster);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3633,7 +3633,7 @@ boolean negate(creature *monst) {
         }
 
         if (monst != &player && monst->mutationIndex > -1 && mutationCatalog[monst->mutationIndex].canBeNegated
-            && rogue.patchVersion >= 3) {
+            && COMPARE_TO_VERSION(1,9,3) >= 0) {
 
             monst->mutationIndex = -1;
             negated = true;
@@ -4409,7 +4409,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 if (boltCatalog[BOLT_NEGATION].backColor) {
                     flashMonster(monst, boltCatalog[BOLT_NEGATION].backColor, 100);
                 }
-                if (rogue.patchVersion >= 4 && negated && autoID && canSeeMonster(monst)) {
+                if (COMPARE_TO_VERSION(1,9,4) >= 0 && negated && autoID && canSeeMonster(monst)) {
                     *autoID = true;
                 }
 
@@ -4481,7 +4481,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 if (!(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
                     newMonst = cloneMonster(monst, true, true);
                     if (newMonst) {
-                        if (rogue.patchVersion >= 1) {
+                        if (COMPARE_TO_VERSION(1,9,1) >= 0) {
                             monst->info.maxHP = newMonst->info.maxHP = (monst->info.maxHP + 1) / 2;
                             monst->currentHP = newMonst->currentHP = min(monst->currentHP, monst->info.maxHP);
                         } else {
@@ -4649,7 +4649,7 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
             caster->xLoc = x;
             caster->yLoc = y;
             // Always break free on blink
-            if (rogue.patchVersion >=4) {
+            if (COMPARE_TO_VERSION(1,9,4) >= 0) {
                 disentangle(caster);
             }
             applyInstantTileEffectsToCreature(caster);

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -687,7 +687,7 @@ boolean spawnMinions(short hordeID, creature *leader, boolean summoned, boolean 
         }
 
         for (iMember = 0; iMember < count; iMember++) {
-            if (rogue.patchVersion >=4) {
+            if (COMPARE_TO_VERSION(1,9,4) >= 0) {
                 monst = generateMonster(theHorde->memberType[iSpecies], itemPossible, !summoned);
             } else {
                 monst = generateMonster(theHorde->memberType[iSpecies], true, !summoned);
@@ -855,7 +855,7 @@ creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFla
         leader->info.intrinsicLightType = SACRIFICE_MARK_LIGHT;
     }
 
-    if (rogue.patchVersion >= 3 && (theHorde->flags & HORDE_MACHINE_THIEF)) {
+    if (COMPARE_TO_VERSION(1,9,3) >= 0 && (theHorde->flags & HORDE_MACHINE_THIEF)) {
         leader->safetyMap = allocGrid(); // Keep thieves from fleeing before they see the player
         fillGrid(leader->safetyMap, 0);
     }
@@ -922,7 +922,7 @@ boolean summonMinions(creature *summoner) {
         removeMonsterFromChain(summoner, monsters);
     }
 
-    if (rogue.patchVersion >= 4) {
+    if (COMPARE_TO_VERSION(1,9,4) >= 0) {
         atLeastOneMinion = spawnMinions(hordeID, summoner, true, false);
     } else {
         atLeastOneMinion = spawnMinions(hordeID, summoner, true, true);
@@ -962,7 +962,7 @@ boolean summonMinions(creature *summoner) {
             monst->ticksUntilTurn = 101;
             monst->leader = summoner;
 
-            if (rogue.patchVersion < 4 && monst->carriedItem) {
+            if (COMPARE_TO_VERSION(1,9,4) < 0 && monst->carriedItem) {
                 deleteItem(monst->carriedItem);
                 monst->carriedItem = NULL;
             }
@@ -1124,7 +1124,7 @@ void teleport(creature *monst, short x, short y, boolean respectTerrainAvoidance
         }
     }
     // Always break free on teleport
-    if (rogue.patchVersion >=4) {
+    if (COMPARE_TO_VERSION(1,9,4) >= 0) {
         disentangle(monst);
     }
     setMonsterLocation(monst, x, y);
@@ -2370,7 +2370,7 @@ boolean generallyValidBoltTarget(creature *caster, creature *target) {
         // Can't target yourself; that's the fundamental theorem of Brogue bolts.
         return false;
     }
-    if (rogue.patchVersion >= 3
+    if (COMPARE_TO_VERSION(1,9,3) >= 0
         && caster->status[STATUS_DISCORDANT]
         && caster->creatureState == MONSTER_WANDERING
         && target == &player) {
@@ -3297,7 +3297,7 @@ void monstersTurn(creature *monst) {
             dir = nextStep(safetyMap, monst->xLoc, monst->yLoc, NULL, true);
         } else {
             if (!monst->safetyMap) {
-                if (rogue.patchVersion >= 3 && !rogue.updatedSafetyMapThisTurn) {
+                if (COMPARE_TO_VERSION(1,9,3) >= 0 && !rogue.updatedSafetyMapThisTurn) {
                     updateSafetyMap();
                 }
                 monst->safetyMap = allocGrid();
@@ -3887,7 +3887,7 @@ void demoteMonsterFromLeadership(creature *monst) {
     }
 
     for (int level = 0; level <= DEEPEST_LEVEL; level++) {
-        if (rogue.patchVersion < 1 && level > 0) break; // to play back 1.9.0 recordings, skip other levels
+        if (COMPARE_TO_VERSION(1,9,1) < 0 && level > 0) break;
         // we'll work on this level's monsters first, so that the new leader is preferably on the same level
         creature *firstMonster = (level == 0 ? monsters->nextCreature : levels[level-1].monsters);
         for (follower = firstMonster; follower != NULL; follower = follower->nextCreature) {
@@ -3918,7 +3918,7 @@ void demoteMonsterFromLeadership(creature *monst) {
     }
 
     for (int level = 0; level <= DEEPEST_LEVEL; level++) {
-        if (rogue.patchVersion < 1 && level > 0) break;
+        if (COMPARE_TO_VERSION(1,9,1) < 0 && level > 0) break;
         creature *firstMonster = (level == 0 ? dormantMonsters->nextCreature : levels[level-1].dormantMonsters);
         for (follower = firstMonster; follower != NULL; follower = follower->nextCreature) {
             if (follower == monst || follower->leader != monst) continue;

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -687,7 +687,7 @@ boolean spawnMinions(short hordeID, creature *leader, boolean summoned, boolean 
         }
 
         for (iMember = 0; iMember < count; iMember++) {
-            if (COMPARE_TO_VERSION(1,9,4) >= 0) {
+            if (BROGUE_VERSION_ATLEAST(1,9,4)) {
                 monst = generateMonster(theHorde->memberType[iSpecies], itemPossible, !summoned);
             } else {
                 monst = generateMonster(theHorde->memberType[iSpecies], true, !summoned);
@@ -855,7 +855,7 @@ creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFla
         leader->info.intrinsicLightType = SACRIFICE_MARK_LIGHT;
     }
 
-    if (COMPARE_TO_VERSION(1,9,3) >= 0 && (theHorde->flags & HORDE_MACHINE_THIEF)) {
+    if (BROGUE_VERSION_ATLEAST(1,9,3) && (theHorde->flags & HORDE_MACHINE_THIEF)) {
         leader->safetyMap = allocGrid(); // Keep thieves from fleeing before they see the player
         fillGrid(leader->safetyMap, 0);
     }
@@ -922,7 +922,7 @@ boolean summonMinions(creature *summoner) {
         removeMonsterFromChain(summoner, monsters);
     }
 
-    if (COMPARE_TO_VERSION(1,9,4) >= 0) {
+    if (BROGUE_VERSION_ATLEAST(1,9,4)) {
         atLeastOneMinion = spawnMinions(hordeID, summoner, true, false);
     } else {
         atLeastOneMinion = spawnMinions(hordeID, summoner, true, true);
@@ -962,7 +962,7 @@ boolean summonMinions(creature *summoner) {
             monst->ticksUntilTurn = 101;
             monst->leader = summoner;
 
-            if (COMPARE_TO_VERSION(1,9,4) < 0 && monst->carriedItem) {
+            if (!BROGUE_VERSION_ATLEAST(1,9,4) && monst->carriedItem) {
                 deleteItem(monst->carriedItem);
                 monst->carriedItem = NULL;
             }
@@ -1124,7 +1124,7 @@ void teleport(creature *monst, short x, short y, boolean respectTerrainAvoidance
         }
     }
     // Always break free on teleport
-    if (COMPARE_TO_VERSION(1,9,4) >= 0) {
+    if (BROGUE_VERSION_ATLEAST(1,9,4)) {
         disentangle(monst);
     }
     setMonsterLocation(monst, x, y);
@@ -2370,7 +2370,7 @@ boolean generallyValidBoltTarget(creature *caster, creature *target) {
         // Can't target yourself; that's the fundamental theorem of Brogue bolts.
         return false;
     }
-    if (COMPARE_TO_VERSION(1,9,3) >= 0
+    if (BROGUE_VERSION_ATLEAST(1,9,3)
         && caster->status[STATUS_DISCORDANT]
         && caster->creatureState == MONSTER_WANDERING
         && target == &player) {
@@ -3297,7 +3297,7 @@ void monstersTurn(creature *monst) {
             dir = nextStep(safetyMap, monst->xLoc, monst->yLoc, NULL, true);
         } else {
             if (!monst->safetyMap) {
-                if (COMPARE_TO_VERSION(1,9,3) >= 0 && !rogue.updatedSafetyMapThisTurn) {
+                if (BROGUE_VERSION_ATLEAST(1,9,3) && !rogue.updatedSafetyMapThisTurn) {
                     updateSafetyMap();
                 }
                 monst->safetyMap = allocGrid();
@@ -3887,7 +3887,7 @@ void demoteMonsterFromLeadership(creature *monst) {
     }
 
     for (int level = 0; level <= DEEPEST_LEVEL; level++) {
-        if (COMPARE_TO_VERSION(1,9,1) < 0 && level > 0) break;
+        if (!BROGUE_VERSION_ATLEAST(1,9,1) && level > 0) break;
         // we'll work on this level's monsters first, so that the new leader is preferably on the same level
         creature *firstMonster = (level == 0 ? monsters->nextCreature : levels[level-1].monsters);
         for (follower = firstMonster; follower != NULL; follower = follower->nextCreature) {
@@ -3918,7 +3918,7 @@ void demoteMonsterFromLeadership(creature *monst) {
     }
 
     for (int level = 0; level <= DEEPEST_LEVEL; level++) {
-        if (COMPARE_TO_VERSION(1,9,1) < 0 && level > 0) break;
+        if (!BROGUE_VERSION_ATLEAST(1,9,1) && level > 0) break;
         creature *firstMonster = (level == 0 ? dormantMonsters->nextCreature : levels[level-1].dormantMonsters);
         for (follower = firstMonster; follower != NULL; follower = follower->nextCreature) {
             if (follower == monst || follower->leader != monst) continue;

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -481,7 +481,7 @@ void moveEntrancedMonsters(enum directions dir) {
 
     dir = oppositeDirection(dir);
 
-    if (COMPARE_TO_VERSION(1,9,3) >= 0) {
+    if (BROGUE_VERSION_ATLEAST(1,9,3)) {
         for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
             monst->bookkeepingFlags &= ~MB_HAS_ENTRANCED_MOVED;
         }
@@ -864,7 +864,7 @@ boolean playerMoves(short direction) {
             }
         }
 
-        if (COMPARE_TO_VERSION(1,9,1) < 0 && player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
+        if (!BROGUE_VERSION_ATLEAST(1,9,1) && player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
                 // Don't interrupt exploration with this message.
             if (--player.status[STATUS_STUCK]) {
                 if (!rogue.automationActive) {
@@ -1090,7 +1090,7 @@ boolean playerMoves(short direction) {
             }
         }
 
-        if (COMPARE_TO_VERSION(1,9,1) >= 0 && player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
+        if (BROGUE_VERSION_ATLEAST(1,9,1) && player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
                 // Don't interrupt exploration with this message.
             if (--player.status[STATUS_STUCK]) {
                 if (!rogue.automationActive) {

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -481,7 +481,7 @@ void moveEntrancedMonsters(enum directions dir) {
 
     dir = oppositeDirection(dir);
 
-    if (rogue.patchVersion >= 3) {
+    if (COMPARE_TO_VERSION(1,9,3) >= 0) {
         for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
             monst->bookkeepingFlags &= ~MB_HAS_ENTRANCED_MOVED;
         }
@@ -864,7 +864,7 @@ boolean playerMoves(short direction) {
             }
         }
 
-        if (rogue.patchVersion < 1 && player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
+        if (COMPARE_TO_VERSION(1,9,1) < 0 && player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
                 // Don't interrupt exploration with this message.
             if (--player.status[STATUS_STUCK]) {
                 if (!rogue.automationActive) {
@@ -1090,7 +1090,7 @@ boolean playerMoves(short direction) {
             }
         }
 
-        if (rogue.patchVersion >= 1 && player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
+        if (COMPARE_TO_VERSION(1,9,1) >= 0 && player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
                 // Don't interrupt exploration with this message.
             if (--player.status[STATUS_STUCK]) {
                 if (!rogue.automationActive) {

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -441,10 +441,15 @@ void displayAnnotation() {
 }
 
 // Attempts to extract the patch version of versionString into patchVersion,
-// according to the global pattern. Returns 0 if successful.
+// according to the global pattern. The Major and Minor versions must match ours.
+// Returns true if successful.
 static boolean getPatchVersion(char *versionString, unsigned short *patchVersion) {
-    int n = sscanf(versionString, BROGUE_PATCH_VERSION_PATTERN, patchVersion);
-    return n == 1;
+    if (strcmp(versionString, "CE 1.9") == 0) {
+        // this older version string didn't show the patch number
+        *patchVersion = 0;
+        return BROGUE_MAJOR == 1 && BROGUE_MINOR == 9;
+    }
+    return sscanf(versionString, BROGUE_PATCH_VERSION_PATTERN, patchVersion) == 1;
 }
 
 // creates a game recording file, or if in playback mode,
@@ -452,7 +457,7 @@ static boolean getPatchVersion(char *versionString, unsigned short *patchVersion
 void initRecording() {
     short i;
     boolean wizardMode;
-    unsigned short gamePatch, recPatch;
+    unsigned short recPatch;
     char buf[100], *versionString = rogue.versionString;
     FILE *recordFile;
 
@@ -487,16 +492,11 @@ void initRecording() {
         }
         wizardMode = recallChar();
 
-        if (getPatchVersion(versionString, &recPatch)
-                && getPatchVersion(BROGUE_RECORDING_VERSION_STRING, &gamePatch)
-                && recPatch <= gamePatch) {
+        if (getPatchVersion(versionString, &recPatch) && recPatch <= BROGUE_PATCH) {
+            // Major and Minor match ours, Patch is less than or equal to ours: we are compatible.
             rogue.patchVersion = recPatch;
-        } else if (strcmp(versionString, "CE 1.9") == 0) {
-            // Temporary measure until next release, as "CE 1.9" recording string
-            // doesn't have a patch version (".0"), but we can load it.
-            rogue.patchVersion = 0;
         } else if (strcmp(versionString, BROGUE_RECORDING_VERSION_STRING) != 0) {
-            // If we have neither a patch pattern match nor an exact match, we can't load.
+            // We have neither a compatible pattern match nor an exact match: we cannot load it.
             rogue.playbackMode = false;
             rogue.playbackFastForward = false;
             sprintf(buf, "This file is from version %s and cannot be opened in version %s.", versionString, BROGUE_VERSION_STRING);
@@ -508,7 +508,7 @@ void initRecording() {
             rogue.gameHasEnded = true;
         }
 
-        if (wizardMode != rogue.wizard && rogue.patchVersion > 1) { // (don't perform the check for version 1.9.1 or earlier)
+        if (wizardMode != rogue.wizard && COMPARE_TO_VERSION(1,9,2) >= 0) {
             // wizard game cannot be played in normal mode and vice versa
             rogue.playbackMode = false;
             rogue.playbackFastForward = false;
@@ -539,7 +539,7 @@ void initRecording() {
         }
     } else {
         // If present, set the patch version for playing the game.
-        getPatchVersion(BROGUE_RECORDING_VERSION_STRING, &rogue.patchVersion);
+        rogue.patchVersion = BROGUE_PATCH;
         strcpy(versionString, BROGUE_RECORDING_VERSION_STRING);
 
         lengthOfPlaybackFile = 1;

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -508,7 +508,7 @@ void initRecording() {
             rogue.gameHasEnded = true;
         }
 
-        if (wizardMode != rogue.wizard && COMPARE_TO_VERSION(1,9,2) >= 0) {
+        if (wizardMode != rogue.wizard && BROGUE_VERSION_ATLEAST(1,9,2)) {
             // wizard game cannot be played in normal mode and vice versa
             rogue.playbackMode = false;
             rogue.playbackFastForward = false;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -33,15 +33,23 @@
 #endif
 
 // unicode: comment this line to revert to ASCII
-
 #define USE_UNICODE
 
+// Brogue version number
+#define BROGUE_MAJOR 1
+#define BROGUE_MINOR 9
+#define BROGUE_PATCH 4
+
+// Expanding a macro as a string constant requires two levels of macros
+#define _str(x) #x
+#define STRINGIFY(x) _str(x)
+
 // Brogue version: what the user sees in the menu and title
-#define BROGUE_VERSION_STRING "CE 1.9.4" BROGUE_EXTRA_VERSION
+#define BROGUE_VERSION_STRING "CE " STRINGIFY(BROGUE_MAJOR) "." STRINGIFY(BROGUE_MINOR) "." STRINGIFY(BROGUE_PATCH) BROGUE_EXTRA_VERSION
 
 // Recording version. Saved into recordings and save files made by this version.
 // Cannot be longer than 16 chars
-#define BROGUE_RECORDING_VERSION_STRING "CE 1.9.4"
+#define BROGUE_RECORDING_VERSION_STRING "CE " STRINGIFY(BROGUE_MAJOR) "." STRINGIFY(BROGUE_MINOR) "." STRINGIFY(BROGUE_PATCH)
 
 /* Patch pattern. A scanf format string which matches an unsigned short. If this
 matches against a recording version string, it defines a "patch version." During
@@ -53,10 +61,13 @@ which is equal or less than the patch version of the current game
 (rogue.patchLevel is set to the recording's); or b) it doesn't match the version
 strings, but they are equal (rogue.patchLevel is set to 0).
 */
-#define BROGUE_PATCH_VERSION_PATTERN "CE 1.9.%hu"
+#define BROGUE_PATCH_VERSION_PATTERN "CE " STRINGIFY(BROGUE_MAJOR) "." STRINGIFY(BROGUE_MINOR) ".%hu"
 
 // Dungeon version. Used in seed catalog output.
 #define BROGUE_DUNGEON_VERSION_STRING "CE 1.9"
+
+// Macro to compare BROGUE_MAJOR.BROGUE_MINOR.patchVersion to a.b.c
+#define COMPARE_TO_VERSION(a,b,c) (BROGUE_MAJOR != (a) ? BROGUE_MAJOR - (a) : BROGUE_MINOR != (b) ? BROGUE_MINOR - (b) : rogue.patchVersion - (c))
 
 #define DEBUG                           if (rogue.wizard)
 #define MONSTERS_ENABLED                (!rogue.wizard || 1) // Quest room monsters can be generated regardless.

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -67,7 +67,7 @@ strings, but they are equal (rogue.patchLevel is set to 0).
 #define BROGUE_DUNGEON_VERSION_STRING "CE 1.9"
 
 // Macro to compare BROGUE_MAJOR.BROGUE_MINOR.patchVersion to a.b.c
-#define COMPARE_TO_VERSION(a,b,c) (BROGUE_MAJOR != (a) ? BROGUE_MAJOR - (a) : BROGUE_MINOR != (b) ? BROGUE_MINOR - (b) : rogue.patchVersion - (c))
+#define BROGUE_VERSION_ATLEAST(a,b,c) (BROGUE_MAJOR != (a) ? BROGUE_MAJOR > (a) : BROGUE_MINOR != (b) ? BROGUE_MINOR > (b) : rogue.patchVersion >= (c))
 
 #define DEBUG                           if (rogue.wizard)
 #define MONSTERS_ENABLED                (!rogue.wizard || 1) // Quest room monsters can be generated regardless.

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -574,7 +574,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             freeGrid(monst->mapToMe);
             monst->mapToMe = NULL;
         }
-        if (rogue.patchVersion < 3 && monst->safetyMap) {
+        if (COMPARE_TO_VERSION(1,9,3) < 0 && monst->safetyMap) {
             freeGrid(monst->safetyMap);
             monst->safetyMap = NULL;
         }
@@ -585,7 +585,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (pmap[i][j].flags & (rogue.patchVersion >= 3 ? ANY_KIND_OF_VISIBLE : VISIBLE)) {
+            if (pmap[i][j].flags & (COMPARE_TO_VERSION(1,9,3) >= 0 ? ANY_KIND_OF_VISIBLE : VISIBLE)) {
                 // Remember visible cells upon exiting.
                 storeMemories(i, j);
             }
@@ -593,7 +593,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                 levels[oldLevelNumber - 1].mapStorage[i][j].layers[layer] = pmap[i][j].layers[layer];
             }
             levels[oldLevelNumber - 1].mapStorage[i][j].volume = pmap[i][j].volume;
-            levels[oldLevelNumber - 1].mapStorage[i][j].flags = (pmap[i][j].flags & (rogue.patchVersion < 3 ? (PERMANENT_TILE_FLAGS & ~HAS_MONSTER) : PERMANENT_TILE_FLAGS));
+            levels[oldLevelNumber - 1].mapStorage[i][j].flags = (pmap[i][j].flags & (COMPARE_TO_VERSION(1,9,3) < 0 ? (PERMANENT_TILE_FLAGS & ~HAS_MONSTER) : PERMANENT_TILE_FLAGS));
             levels[oldLevelNumber - 1].mapStorage[i][j].machineNumber = pmap[i][j].machineNumber;
             levels[oldLevelNumber - 1].mapStorage[i][j].rememberedAppearance = pmap[i][j].rememberedAppearance;
             levels[oldLevelNumber - 1].mapStorage[i][j].rememberedItemCategory = pmap[i][j].rememberedItemCategory;
@@ -685,7 +685,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                     pmap[i][j].layers[layer] = levels[rogue.depthLevel - 1].mapStorage[i][j].layers[layer];
                 }
                 pmap[i][j].volume = levels[rogue.depthLevel - 1].mapStorage[i][j].volume;
-                pmap[i][j].flags = (levels[rogue.depthLevel - 1].mapStorage[i][j].flags & (rogue.patchVersion < 3 ? (PERMANENT_TILE_FLAGS & ~HAS_MONSTER) : PERMANENT_TILE_FLAGS));
+                pmap[i][j].flags = (levels[rogue.depthLevel - 1].mapStorage[i][j].flags & (COMPARE_TO_VERSION(1,9,3) < 0 ? (PERMANENT_TILE_FLAGS & ~HAS_MONSTER) : PERMANENT_TILE_FLAGS));
                 pmap[i][j].machineNumber = levels[rogue.depthLevel - 1].mapStorage[i][j].machineNumber;
                 pmap[i][j].rememberedAppearance = levels[rogue.depthLevel - 1].mapStorage[i][j].rememberedAppearance;
                 pmap[i][j].rememberedItemCategory = levels[rogue.depthLevel - 1].mapStorage[i][j].rememberedItemCategory;
@@ -718,7 +718,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             restoreItem(theItem);
         }
 
-        if (rogue.patchVersion < 3) {
+        if (COMPARE_TO_VERSION(1,9,3) < 0) {
             mapToStairs = allocGrid();
             mapToPit = allocGrid();
             fillGrid(mapToStairs, 0);
@@ -807,7 +807,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
         rogue.inWater = true;
     }
 
-    if (levels[rogue.depthLevel - 1].visited && rogue.patchVersion >= 3) {
+    if (levels[rogue.depthLevel - 1].visited && COMPARE_TO_VERSION(1,9,3) >= 0) {
         mapToStairs = allocGrid();
         mapToPit = allocGrid();
         fillGrid(mapToStairs, 0);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -574,7 +574,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             freeGrid(monst->mapToMe);
             monst->mapToMe = NULL;
         }
-        if (COMPARE_TO_VERSION(1,9,3) < 0 && monst->safetyMap) {
+        if (!BROGUE_VERSION_ATLEAST(1,9,3) && monst->safetyMap) {
             freeGrid(monst->safetyMap);
             monst->safetyMap = NULL;
         }
@@ -585,7 +585,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (pmap[i][j].flags & (COMPARE_TO_VERSION(1,9,3) >= 0 ? ANY_KIND_OF_VISIBLE : VISIBLE)) {
+            if (pmap[i][j].flags & (BROGUE_VERSION_ATLEAST(1,9,3) ? ANY_KIND_OF_VISIBLE : VISIBLE)) {
                 // Remember visible cells upon exiting.
                 storeMemories(i, j);
             }
@@ -593,7 +593,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                 levels[oldLevelNumber - 1].mapStorage[i][j].layers[layer] = pmap[i][j].layers[layer];
             }
             levels[oldLevelNumber - 1].mapStorage[i][j].volume = pmap[i][j].volume;
-            levels[oldLevelNumber - 1].mapStorage[i][j].flags = (pmap[i][j].flags & (COMPARE_TO_VERSION(1,9,3) < 0 ? (PERMANENT_TILE_FLAGS & ~HAS_MONSTER) : PERMANENT_TILE_FLAGS));
+            levels[oldLevelNumber - 1].mapStorage[i][j].flags = (pmap[i][j].flags & (!BROGUE_VERSION_ATLEAST(1,9,3) ? (PERMANENT_TILE_FLAGS & ~HAS_MONSTER) : PERMANENT_TILE_FLAGS));
             levels[oldLevelNumber - 1].mapStorage[i][j].machineNumber = pmap[i][j].machineNumber;
             levels[oldLevelNumber - 1].mapStorage[i][j].rememberedAppearance = pmap[i][j].rememberedAppearance;
             levels[oldLevelNumber - 1].mapStorage[i][j].rememberedItemCategory = pmap[i][j].rememberedItemCategory;
@@ -685,7 +685,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                     pmap[i][j].layers[layer] = levels[rogue.depthLevel - 1].mapStorage[i][j].layers[layer];
                 }
                 pmap[i][j].volume = levels[rogue.depthLevel - 1].mapStorage[i][j].volume;
-                pmap[i][j].flags = (levels[rogue.depthLevel - 1].mapStorage[i][j].flags & (COMPARE_TO_VERSION(1,9,3) < 0 ? (PERMANENT_TILE_FLAGS & ~HAS_MONSTER) : PERMANENT_TILE_FLAGS));
+                pmap[i][j].flags = (levels[rogue.depthLevel - 1].mapStorage[i][j].flags & (!BROGUE_VERSION_ATLEAST(1,9,3) ? (PERMANENT_TILE_FLAGS & ~HAS_MONSTER) : PERMANENT_TILE_FLAGS));
                 pmap[i][j].machineNumber = levels[rogue.depthLevel - 1].mapStorage[i][j].machineNumber;
                 pmap[i][j].rememberedAppearance = levels[rogue.depthLevel - 1].mapStorage[i][j].rememberedAppearance;
                 pmap[i][j].rememberedItemCategory = levels[rogue.depthLevel - 1].mapStorage[i][j].rememberedItemCategory;
@@ -718,7 +718,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             restoreItem(theItem);
         }
 
-        if (COMPARE_TO_VERSION(1,9,3) < 0) {
+        if (!BROGUE_VERSION_ATLEAST(1,9,3)) {
             mapToStairs = allocGrid();
             mapToPit = allocGrid();
             fillGrid(mapToStairs, 0);
@@ -807,7 +807,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
         rogue.inWater = true;
     }
 
-    if (levels[rogue.depthLevel - 1].visited && COMPARE_TO_VERSION(1,9,3) >= 0) {
+    if (levels[rogue.depthLevel - 1].visited && BROGUE_VERSION_ATLEAST(1,9,3)) {
         mapToStairs = allocGrid();
         mapToPit = allocGrid();
         fillGrid(mapToStairs, 0);

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1342,7 +1342,7 @@ void monstersFall() {
     for (monst = monsters->nextCreature; monst != NULL; monst = nextCreature) {
         nextCreature = monst->nextCreature;
         if ((monst->bookkeepingFlags & MB_IS_FALLING) || monsterShouldFall(monst)) {
-            if (COMPARE_TO_VERSION(1,9,3) >= 0) monst->bookkeepingFlags |= MB_IS_FALLING;
+            if (BROGUE_VERSION_ATLEAST(1,9,3)) monst->bookkeepingFlags |= MB_IS_FALLING;
 
             x = monst->xLoc;
             y = monst->yLoc;
@@ -1353,7 +1353,7 @@ void monstersFall() {
                 messageWithColor(buf2, messageColorFromVictim(monst), false);
             }
 
-            if (COMPARE_TO_VERSION(1,9,3) < 0) {
+            if (!BROGUE_VERSION_ATLEAST(1,9,3)) {
                 monst->status[STATUS_ENTRANCED] = 0;
                 monst->bookkeepingFlags |= MB_PREPLACED;
                 monst->bookkeepingFlags &= ~(MB_IS_FALLING | MB_SEIZED | MB_SEIZING);
@@ -1366,7 +1366,7 @@ void monstersFall() {
             } else if (!inflictDamage(NULL, monst, randClumpedRange(6, 12, 2), &red, false)) {
                 demoteMonsterFromLeadership(monst);
 
-                if (COMPARE_TO_VERSION(1,9,3) >= 0) {
+                if (BROGUE_VERSION_ATLEAST(1,9,3)) {
                     monst->status[STATUS_ENTRANCED] = 0;
                     monst->bookkeepingFlags |= MB_PREPLACED;
                     monst->bookkeepingFlags &= ~(MB_IS_FALLING | MB_SEIZED | MB_SEIZING);
@@ -1853,7 +1853,7 @@ void monsterEntersLevel(creature *monst, short n) {
     char monstName[COLS], buf[COLS];
     boolean pit = false;
 
-    if (COMPARE_TO_VERSION(1,9,3) >= 0) {
+    if (BROGUE_VERSION_ATLEAST(1,9,3)) {
         levels[n].mapStorage[monst->xLoc][monst->yLoc].flags &= ~HAS_MONSTER;
     }
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1342,7 +1342,7 @@ void monstersFall() {
     for (monst = monsters->nextCreature; monst != NULL; monst = nextCreature) {
         nextCreature = monst->nextCreature;
         if ((monst->bookkeepingFlags & MB_IS_FALLING) || monsterShouldFall(monst)) {
-            if (rogue.patchVersion >= 3) monst->bookkeepingFlags |= MB_IS_FALLING;
+            if (COMPARE_TO_VERSION(1,9,3) >= 0) monst->bookkeepingFlags |= MB_IS_FALLING;
 
             x = monst->xLoc;
             y = monst->yLoc;
@@ -1353,7 +1353,7 @@ void monstersFall() {
                 messageWithColor(buf2, messageColorFromVictim(monst), false);
             }
 
-            if (rogue.patchVersion < 3) {
+            if (COMPARE_TO_VERSION(1,9,3) < 0) {
                 monst->status[STATUS_ENTRANCED] = 0;
                 monst->bookkeepingFlags |= MB_PREPLACED;
                 monst->bookkeepingFlags &= ~(MB_IS_FALLING | MB_SEIZED | MB_SEIZING);
@@ -1366,7 +1366,7 @@ void monstersFall() {
             } else if (!inflictDamage(NULL, monst, randClumpedRange(6, 12, 2), &red, false)) {
                 demoteMonsterFromLeadership(monst);
 
-                if (rogue.patchVersion >= 3) {
+                if (COMPARE_TO_VERSION(1,9,3) >= 0) {
                     monst->status[STATUS_ENTRANCED] = 0;
                     monst->bookkeepingFlags |= MB_PREPLACED;
                     monst->bookkeepingFlags &= ~(MB_IS_FALLING | MB_SEIZED | MB_SEIZING);
@@ -1853,7 +1853,7 @@ void monsterEntersLevel(creature *monst, short n) {
     char monstName[COLS], buf[COLS];
     boolean pit = false;
 
-    if (rogue.patchVersion >= 3) {
+    if (COMPARE_TO_VERSION(1,9,3) >= 0) {
         levels[n].mapStorage[monst->xLoc][monst->yLoc].flags &= ~HAS_MONSTER;
     }
 

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -6,10 +6,6 @@
 #error "The DATADIR macro is undefined."
 #endif
 
-// Expanding a macro as a string constant requires two levels of macros
-#define _str(x)  #x
-#define STRINGIFY(x)  _str(x)
-
 struct brogueConsole currentConsole;
 
 char dataDirectory[BROGUE_FILENAME_MAX] = STRINGIFY(DATADIR);


### PR DESCRIPTION
Right now, the `master` branch still carries the version number `1.9.4`. This is problematic because any build made off `master` will show "1.9.4" in the main menu, which is misleading, as recordings made with `master` builds are not backward compatible with 1.9.4 builds. We cannot safely change it to `1.10.0` though, because doing so will disable features introduced since 1.9.1, and restore bugs fixed since 1.9.1, due to the dozens of `patchVersion` checks which have not yet been removed from the code merged into `master`.

Removing the `patchVersion` checks in master is simple (turn the comparisons into either `true` or `false`, then simplify the code) but it causes annoying merge conflicts which we would rather not deal with on an ongoing basis.

This patch offers a solution, so that we can happily merge `release` into `master` without having to worry about refactoring the version checks or dealing with the regressions that leaving them in would cause. If we want to remove the checks for the 1.10 release, we can do it all the same, but there are no consequences if we don't (apart from some dead code).

Instead of writing

    rogue.patchVersion >= 4

you would write

    BROGUE_VERSION_ATLEAST(1,9,4)

and instead of

    rogue.patchVersion < 4

this

    !BROGUE_VERSION_ATLEAST(1,9,4)

The new `BROGUE_VERSION_ATLEAST` macro takes the Major and Minor versions into consideration, not just the Patch version.

Major and Minor are tracked with new defines, `BROGUE_MAJOR` and `BROGUE_MINOR` which will be `1` and `9` in `release` branch, `1` and `10` in `master`. There is also `BROGUE_PATCH` now (but the `BROGUE_VERSION_ATLEAST` macro uses `patchVersion`, of course).