### PR TITLE
Fix two levelgen door bugs

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -348,8 +348,8 @@ void addLoops(short **grid, short minimumPathingDistance) {
                 oppY = y - dirCoords[d][1];
                 if (coordinatesAreInMap(newX, newY)
                     && coordinatesAreInMap(oppX, oppY)
-                    && grid[newX][newY] > 0
-                    && grid[oppX][oppY] > 0) { // If the tile being inspected has floor on both sides,
+                    && grid[newX][newY] == 1
+                    && grid[oppX][oppY] == 1) { // If the tile being inspected has floor on both sides,
 
                     fillGrid(pathMap, 30000);
                     pathMap[newX][newY] = 0;
@@ -634,9 +634,6 @@ void expandMachineInterior(char interior[DCOLS][DROWS], short minimumInteriorNei
                             }
                         }
                     }
-                } else if (pmap[i][j].layers[DUNGEON] == DOOR
-                           || pmap[i][j].layers[DUNGEON] == SECRET_DOOR) {
-                    pmap[i][j].layers[DUNGEON] = FLOOR;
                 }
             }
         }


### PR DESCRIPTION
Closes #260

Two longstanding bugs fixed here:

- Any machine that calls expandMachineInterior() would eliminate all doors and secret doors on the entire depth (!!!)
- Rarely addLoops() could place a door immediately adjacent to an existing door

This is a new PR that rebases [PR 275](https://github.com/tmewett/BrogueCE/pull/275), which got snarled up by my slow climb up the github learning curve... I will close that PR in favor of this one.