### PR TITLE
Press w to hot-swap equipment

### DIFF
--- a/changes/equipment-hot-swap.md
+++ b/changes/equipment-hot-swap.md
@@ -1,0 +1,1 @@
+Pressing "w" will hot-swap between recently equipped gear, enabling weapon/armor/ring juggling.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -448,6 +448,10 @@ void specialHit(creature *attacker, creature *defender, short damage) {
                         itemFromTopOfStack->quantity = stolenQuantity;
                         theItem = itemFromTopOfStack; // Redirect pointer.
                     } else {
+                        if (rogue.swappedIn == theItem || rogue.swappedOut == theItem) {
+                            rogue.swappedIn = NULL;
+                            rogue.swappedOut = NULL;
+                        }
                         removeItemFromChain(theItem, packItems);
                     }
                     theItem->flags &= ~ITEM_PLAYER_AVOIDS; // Explore will seek the item out if it ends up on the floor again.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -390,7 +390,7 @@ void specialHit(creature *attacker, creature *defender, short damage) {
             && (rogue.armor->enchant1 + rogue.armor->armor/10 > -10)) {
 
             rogue.armor->enchant1--;
-            equipItem(rogue.armor, true);
+            equipItem(rogue.armor, true, NULL);
             itemName(rogue.armor, buf2, false, false, NULL);
             sprintf(buf, "your %s weakens!", buf2);
             messageWithColor(buf, &itemMessageColor, 0);
@@ -927,7 +927,7 @@ void applyArmorRunicEffect(char returnString[DCOLS], creature *attacker, short *
             if (rand_percent(10)) {
                 rogue.armor->strengthRequired++;
                 sprintf(returnString, "your %s suddenly feels heavier!", armorName);
-                equipItem(rogue.armor, true);
+                equipItem(rogue.armor, true, NULL);
                 runicDiscovered = true;
             }
             break;
@@ -1214,7 +1214,7 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
             if (rogue.weapon->quiverNumber) {
                 rogue.weapon->quiverNumber = rand_range(1, 60000);
             }
-            equipItem(rogue.weapon, true);
+            equipItem(rogue.weapon, true, NULL);
             itemName(rogue.weapon, buf2, false, false, NULL);
             sprintf(buf, "your %s weakens!", buf2);
             messageWithColor(buf, &itemMessageColor, 0);

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2576,6 +2576,9 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
         case RELABEL_KEY:
             relabel(NULL);
             break;
+        case SWAP_KEY:
+            swapLastEquipment();
+            break;
         case TRUE_COLORS_KEY:
             rogue.trueColorMode = !rogue.trueColorMode;
             displayLevel();
@@ -3994,33 +3997,33 @@ void printHelpScreen() {
         "",
         "          -- Commands --",
         "",
-        "         mouse  ****move cursor (including to examine monsters and terrain)",
-        "         click  ****travel",
-        " control-click  ****advance one space",
-        "      <return>  ****enable keyboard cursor control",
-        "   <space/esc>  ****disable keyboard cursor control",
+        "          mouse  ****move cursor (including to examine monsters and terrain)",
+        "          click  ****travel",
+        "  control-click  ****advance one space",
+        "       <return>  ****enable keyboard cursor control",
+        "    <space/esc>  ****disable keyboard cursor control",
         "hjklyubn, arrow keys, or numpad  ****move or attack (control or shift to run)",
         "",
-        " a/e/r/t/d/c/R  ****apply/equip/remove/throw/drop/call/relabel an item",
-        "             T  ****re-throw last item at last monster",
-        "i, right-click  ****view inventory",
-        "             D  ****list discovered items",
+        "a/e/r/t/d/c/R/w  ****apply/equip/remove/throw/drop/call/relabel/swap an item",
+        "              T  ****re-throw last item at last monster",
+        " i, right-click  ****view inventory",
+        "              D  ****list discovered items",
         "",
-        "             z  ****rest once",
-        "             Z  ****rest for 100 turns or until something happens",
-        "             s  ****search for secrets (control-s: long search)",
-        "          <, >  ****travel to stairs",
-        "             x  ****auto-explore (control-x: fast forward)",
-        "             A  ****autopilot (control-A: fast forward)",
-        "             M  ****display old messages",
-        "             G  ****toggle graphical tiles (when available)",
+        "              z  ****rest once",
+        "              Z  ****rest for 100 turns or until something happens",
+        "              s  ****search for secrets (control-s: long search)",
+        "           <, >  ****travel to stairs",
+        "              x  ****auto-explore (control-x: fast forward)",
+        "              A  ****autopilot (control-A: fast forward)",
+        "              M  ****display old messages",
+        "              G  ****toggle graphical tiles (when available)",
         "",
-        "             S  ****suspend game and quit",
-        "             Q  ****quit to title screen",
+        "              S  ****suspend game and quit",
+        "              Q  ****quit to title screen",
         "",
-        "             \\  ****disable/enable color effects",
-        "             ]  ****display/hide stealth range",
-        "   <space/esc>  ****clear message or cancel command",
+        "              \\  ****disable/enable color effects",
+        "              ]  ****display/hide stealth range",
+        "    <space/esc>  ****clear message or cancel command",
         "",
         "        -- press space or click to continue --"
     };

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3194,8 +3194,6 @@ void equip(item *theItem) {
         confirmMessages();
         messageWithColor(buf1, &itemMessageColor, 0);
 
-        strengthCheck(theItem);
-
         if (theItem->flags & ITEM_CURSED) {
             itemName(theItem, buf2, false, false, NULL);
             switch(theItem->category) {
@@ -7331,13 +7329,13 @@ void equipItem(item *theItem, boolean force) {
     }
     if (theItem->category & WEAPON) {
         rogue.weapon = theItem;
-        recalculateEquipmentBonuses();
+        strengthCheck(theItem);
     } else if (theItem->category & ARMOR) {
         if (!force) {
             player.status[STATUS_DONNING] = player.maxStatus[STATUS_DONNING] = theItem->armor / 10;
         }
         rogue.armor = theItem;
-        recalculateEquipmentBonuses();
+        strengthCheck(theItem);
     } else if (theItem->category & RING) {
         if (rogue.ringLeft && rogue.ringRight) {
             return;
@@ -7356,9 +7354,9 @@ void equipItem(item *theItem, boolean force) {
                    || theItem->kind == RING_STEALTH) {
             identifyItemKind(theItem);
         }
+        updateEncumbrance();
     }
     theItem->flags |= ITEM_EQUIPPED;
-    return;
 }
 
 void unequipItem(item *theItem, boolean force) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -7129,15 +7129,11 @@ void unequip(item *theItem) {
     } else {
         recordKeystrokeSequence(command);
         unequipItem(theItem, false);
-        if (theItem->category & RING) {
-            updateRingBonuses();
-        }
         itemName(theItem, buf2, true, true, NULL);
         if (strLenWithoutEscapes(buf2) > 52) {
             itemName(theItem, buf2, false, true, NULL);
         }
         confirmMessages();
-        updateEncumbrance();
         sprintf(buf, "you are no longer %s %s.", (theItem->category & WEAPON ? "wielding" : "wearing"), buf2);
         messageWithColor(buf, &itemMessageColor, 0);
     }
@@ -7400,7 +7396,6 @@ void unequipItem(item *theItem, boolean force) {
         }
     }
     updateEncumbrance();
-    return;
 }
 
 void updateRingBonuses() {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1126,6 +1126,7 @@ enum tileFlags {
 #define THROW_KEY           't'
 #define RETHROW_KEY         'T'
 #define RELABEL_KEY         'R'
+#define SWAP_KEY            'w'
 #define TRUE_COLORS_KEY     '\\'
 #define AGGRO_DISPLAY_KEY   ']'
 #define DROP_KEY            'd'
@@ -2254,6 +2255,8 @@ typedef struct playerCharacter {
     item *armor;
     item *ringLeft;
     item *ringRight;
+    item *swappedIn;
+    item *swappedOut;
 
     flare **flares;
     short flareCount;
@@ -3101,6 +3104,7 @@ extern "C" {
     void makeMonsterDropItem(creature *monst);
     void throwCommand(item *theItem, boolean autoThrow);
     void relabel(item *theItem);
+    void swapLastEquipment();
     void apply(item *theItem, boolean recordCommands);
     boolean itemCanBeCalled(item *theItem);
     void call(item *theItem);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3045,7 +3045,7 @@ extern "C" {
     short displayedArmorValue();
     void strengthCheck(item *theItem);
     void recalculateEquipmentBonuses();
-    boolean equipItem(item *theItem, boolean force);
+    boolean equipItem(item *theItem, boolean force, item *unequipHint);
     void equip(item *theItem);
     item *keyInPackFor(short x, short y);
     item *keyOnTileAt(short x, short y);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3045,7 +3045,7 @@ extern "C" {
     short displayedArmorValue();
     void strengthCheck(item *theItem);
     void recalculateEquipmentBonuses();
-    void equipItem(item *theItem, boolean force);
+    boolean equipItem(item *theItem, boolean force);
     void equip(item *theItem);
     item *keyInPackFor(short x, short y);
     item *keyOnTileAt(short x, short y);
@@ -3121,7 +3121,7 @@ extern "C" {
                               char *prompt,
                               boolean allowInventoryActions);
     item *itemOfPackLetter(char letter);
-    void unequipItem(item *theItem, boolean force);
+    boolean unequipItem(item *theItem, boolean force);
     short magicCharDiscoverySuffix(short category, short kind);
     int itemMagicPolarity(item *theItem);
     item *itemAtLoc(short x, short y);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -374,7 +374,7 @@ void initializeRogue(uint64_t seed) {
     theItem->flags &= ~(ITEM_CURSED | ITEM_RUNIC);
     identify(theItem);
     theItem = addItemToPack(theItem);
-    equipItem(theItem, false);
+    equipItem(theItem, false, NULL);
 
     theItem = generateItem(WEAPON, DART);
     theItem->enchant1 = theItem->enchant2 = 0;
@@ -388,7 +388,7 @@ void initializeRogue(uint64_t seed) {
     theItem->flags &= ~(ITEM_CURSED | ITEM_RUNIC);
     identify(theItem);
     theItem = addItemToPack(theItem);
-    equipItem(theItem, false);
+    equipItem(theItem, false, NULL);
     player.status[STATUS_DONNING] = 0;
 
     recalculateEquipmentBonuses();

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -349,6 +349,8 @@ void initializeRogue(uint64_t seed) {
     rogue.armor = NULL;
     rogue.ringLeft = NULL;
     rogue.ringRight = NULL;
+    rogue.swappedIn = NULL;
+    rogue.swappedOut = NULL;
     rogue.monsterSpawnFuse = rand_range(125, 175);
     rogue.ticksTillUpdateEnvironment = 100;
     rogue.mapToShore = NULL;


### PR DESCRIPTION
Whenever a piece of equipment displaces another when being equipped, it
is "swapped in" and the other is "swapped out".  Pressing "w" then
exchanges these two as a player action.  In this way players can
"juggle" rings, weapons or armor with a single key stroke.

If either of the swapped in or out items leaves the pack, the swapped
in/out status of both is cleared.  There is no visual feedback (in the
inventory screen or elsewhere) of which items are swapped in or out.

Closes #220