### PR TITLE
Ww/issue 253 scrollable message buffer

### DIFF
--- a/changes/scrollable-message-archive.md
+++ b/changes/scrollable-message-archive.md
@@ -1,0 +1,2 @@
+The message archive is now larger, and can be navigated by moving up and down.
+Holding shift scrolls one line at a time, holding control jumps to the end.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -3241,58 +3241,59 @@ void displayMessageArchive() {
 
     formatRecentMessages(messageBuffer, MESSAGE_ARCHIVE_LINES, &totalMessageCount, 0);
 
-    if (totalMessageCount > MESSAGE_LINES) {
+    if (totalMessageCount <= MESSAGE_LINES) {
+        return;
+    }
 
-        copyDisplayBuffer(rbuf, displayBuffer);
+    copyDisplayBuffer(rbuf, displayBuffer);
 
-        // Pull-down/pull-up animation:
-        for (reverse = 0; reverse <= 1; reverse++) {
-            fastForward = false;
-            for (currentMessageCount = (reverse ? totalMessageCount : MESSAGE_LINES);
-                 (reverse ? currentMessageCount >= MESSAGE_LINES : currentMessageCount <= totalMessageCount);
-                 currentMessageCount += (reverse ? -1 : 1)) {
+    // Pull-down/pull-up animation:
+    for (reverse = 0; reverse <= 1; reverse++) {
+        fastForward = false;
+        for (currentMessageCount = (reverse ? totalMessageCount : MESSAGE_LINES);
+             (reverse ? currentMessageCount >= MESSAGE_LINES : currentMessageCount <= totalMessageCount);
+             currentMessageCount += (reverse ? -1 : 1)) {
 
-                clearDisplayBuffer(dbuf);
+            clearDisplayBuffer(dbuf);
 
-                // Print the message archive text to the dbuf.
-                for (j=0; j < currentMessageCount && j < ROWS; j++) {
-                    k = MESSAGE_ARCHIVE_LINES - currentMessageCount + j;
-                    printString(messageBuffer[k], mapToWindowX(0), j, &white, &black, dbuf);
-                }
+            // Print the message archive text to the dbuf.
+            for (j=0; j < currentMessageCount && j < ROWS; j++) {
+                k = MESSAGE_ARCHIVE_LINES - currentMessageCount + j;
+                printString(messageBuffer[k], mapToWindowX(0), j, &white, &black, dbuf);
+            }
 
-                // Set the dbuf opacity, and do a fade from bottom to top to make it clear that the bottom messages are the most recent.
-                for (j=0; j < currentMessageCount && j<ROWS; j++) {
-                    fadePercent = 50 * (j + totalMessageCount - currentMessageCount) / totalMessageCount + 50;
-                    for (i=0; i<DCOLS; i++) {
-                        dbuf[mapToWindowX(i)][j].opacity = INTERFACE_OPACITY;
-                        if (dbuf[mapToWindowX(i)][j].character != ' ') {
-                            for (k=0; k<3; k++) {
-                                dbuf[mapToWindowX(i)][j].foreColorComponents[k] = dbuf[mapToWindowX(i)][j].foreColorComponents[k] * fadePercent / 100;
-                            }
+            // Set the dbuf opacity, and do a fade from bottom to top to make it clear that the bottom messages are the most recent.
+            for (j=0; j < currentMessageCount && j<ROWS; j++) {
+                fadePercent = 50 * (j + totalMessageCount - currentMessageCount) / totalMessageCount + 50;
+                for (i=0; i<DCOLS; i++) {
+                    dbuf[mapToWindowX(i)][j].opacity = INTERFACE_OPACITY;
+                    if (dbuf[mapToWindowX(i)][j].character != ' ') {
+                        for (k=0; k<3; k++) {
+                            dbuf[mapToWindowX(i)][j].foreColorComponents[k] = dbuf[mapToWindowX(i)][j].foreColorComponents[k] * fadePercent / 100;
                         }
                     }
                 }
-
-                // Display.
-                overlayDisplayBuffer(rbuf, 0);
-                overlayDisplayBuffer(dbuf, 0);
-
-                if (!fastForward && pauseBrogue(reverse ? 1 : 2)) {
-                    fastForward = true;
-                    dequeueEvent();
-                    currentMessageCount = (reverse ? MESSAGE_LINES + 1 : totalMessageCount - 1); // skip to the end
-                }
             }
 
-            if (!reverse) {
-                displayMoreSign();
+            // Display.
+            overlayDisplayBuffer(rbuf, 0);
+            overlayDisplayBuffer(dbuf, 0);
+
+            if (!fastForward && pauseBrogue(reverse ? 1 : 2)) {
+                fastForward = true;
+                dequeueEvent();
+                currentMessageCount = (reverse ? MESSAGE_LINES + 1 : totalMessageCount - 1); // skip to the end
             }
         }
-        overlayDisplayBuffer(rbuf, 0);
-        updateFlavorText();
-        confirmMessages();
-        updateMessageDisplay();
+
+        if (!reverse) {
+            displayMoreSign();
+        }
     }
+    overlayDisplayBuffer(rbuf, 0);
+    updateFlavorText();
+    confirmMessages();
+    updateMessageDisplay();
 }
 
 // Clears the message area and prints the given message in the area.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -3302,7 +3302,7 @@ void displayMessageArchive() {
         return;
     }
 
-    height = min(length, MESSAGE_ARCHIVE_LINES);
+    height = min(length, MESSAGE_ARCHIVE_VIEW_LINES);
     offset = height;
 
     copyDisplayBuffer(rbuf, displayBuffer);

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -3234,14 +3234,14 @@ void displayRecentMessages() {
 }
 
 void displayMessageArchive() {
-    short i, j, k, reverse, fadePercent, totalMessageCount, currentMessageCount;
+    short i, j, k, reverse, fadePercent, length, currentMessageCount;
     boolean fastForward;
     cellDisplayBuffer dbuf[COLS][ROWS], rbuf[COLS][ROWS];
     char messageBuffer[MESSAGE_ARCHIVE_LINES][COLS*2];
 
-    formatRecentMessages(messageBuffer, MESSAGE_ARCHIVE_LINES, &totalMessageCount, 0);
+    formatRecentMessages(messageBuffer, MESSAGE_ARCHIVE_LINES, &length, 0);
 
-    if (totalMessageCount <= MESSAGE_LINES) {
+    if (length <= MESSAGE_LINES) {
         return;
     }
 
@@ -3250,8 +3250,8 @@ void displayMessageArchive() {
     // Pull-down/pull-up animation:
     for (reverse = 0; reverse <= 1; reverse++) {
         fastForward = false;
-        for (currentMessageCount = (reverse ? totalMessageCount : MESSAGE_LINES);
-             (reverse ? currentMessageCount >= MESSAGE_LINES : currentMessageCount <= totalMessageCount);
+        for (currentMessageCount = (reverse ? length : MESSAGE_LINES);
+             (reverse ? currentMessageCount >= MESSAGE_LINES : currentMessageCount <= length);
              currentMessageCount += (reverse ? -1 : 1)) {
 
             clearDisplayBuffer(dbuf);
@@ -3264,7 +3264,7 @@ void displayMessageArchive() {
 
             // Set the dbuf opacity, and do a fade from bottom to top to make it clear that the bottom messages are the most recent.
             for (j=0; j < currentMessageCount && j<ROWS; j++) {
-                fadePercent = 50 * (j + totalMessageCount - currentMessageCount) / totalMessageCount + 50;
+                fadePercent = 50 * (j + length - currentMessageCount) / length + 50;
                 for (i=0; i<DCOLS; i++) {
                     dbuf[mapToWindowX(i)][j].opacity = INTERFACE_OPACITY;
                     if (dbuf[mapToWindowX(i)][j].character != ' ') {
@@ -3282,7 +3282,7 @@ void displayMessageArchive() {
             if (!fastForward && pauseBrogue(reverse ? 1 : 2)) {
                 fastForward = true;
                 dequeueEvent();
-                currentMessageCount = (reverse ? MESSAGE_LINES + 1 : totalMessageCount - 1); // skip to the end
+                currentMessageCount = (reverse ? MESSAGE_LINES + 1 : length - 1); // skip to the end
             }
         }
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -118,7 +118,8 @@ typedef long long fixpt;
 #define DATE_FORMAT             "%Y-%m-%d" // see strftime() documentation
 
 #define MESSAGE_LINES           3
-#define MESSAGE_ARCHIVE_LINES   ROWS
+#define MESSAGE_ARCHIVE_VIEW_LINES ROWS
+#define MESSAGE_ARCHIVE_LINES   (MESSAGE_ARCHIVE_VIEW_LINES*10)
 #define MESSAGE_ARCHIVE_ENTRIES (MESSAGE_ARCHIVE_LINES*4)
 #define MAX_MESSAGE_REPEATS     100
 


### PR DESCRIPTION
While the archive is open, use any legal up & down movement keys to scroll up and down.  Holding shift scrolls by a third of the visible area at a time, while control jumps to either end.

The message archive has now grown to about 10 screens-worth, but things will continue to fall off the end when that is exhausted.