### PR TITLE
Remaining levelgen door bugfix

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -638,6 +638,17 @@ void expandMachineInterior(char interior[DCOLS][DROWS], short minimumInteriorNei
             }
         }
     } while (madeChange);
+    
+    // Clear doors and secret doors out of the interior of the machine.
+    for(i=1; i<DCOLS-1; i++) {
+        for(j=1; j < DROWS-1; j++) {
+            if (interior[i][j]
+                && (pmap[i][j].layers[DUNGEON] == DOOR || pmap[i][j].layers[DUNGEON] == SECRET_DOOR)) {
+                
+                pmap[i][j].layers[DUNGEON] = FLOOR;
+            }
+        }
+    }
 }
 
 boolean fillInteriorForVestibuleMachine(char interior[DCOLS][DROWS], short bp, short originX, short originY) {

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -348,8 +348,8 @@ void addLoops(short **grid, short minimumPathingDistance) {
                 oppY = y - dirCoords[d][1];
                 if (coordinatesAreInMap(newX, newY)
                     && coordinatesAreInMap(oppX, oppY)
-                    && grid[newX][newY] > 0
-                    && grid[oppX][oppY] > 0) { // If the tile being inspected has floor on both sides,
+                    && grid[newX][newY] == 1
+                    && grid[oppX][oppY] == 1) { // If the tile being inspected has floor on both sides,
 
                     fillGrid(pathMap, 30000);
                     pathMap[newX][newY] = 0;
@@ -634,9 +634,6 @@ void expandMachineInterior(char interior[DCOLS][DROWS], short minimumInteriorNei
                             }
                         }
                     }
-                } else if (pmap[i][j].layers[DUNGEON] == DOOR
-                           || pmap[i][j].layers[DUNGEON] == SECRET_DOOR) {
-                    pmap[i][j].layers[DUNGEON] = FLOOR;
                 }
             }
         }


### PR DESCRIPTION
Fixes a remaining issue [spotted](https://github.com/tmewett/BrogueCE/pull/289#issuecomment-812806171) by @withinwheels caused by [this prior levelgen door bugfix PR](https://github.com/tmewett/BrogueCE/pull/289).

After expanding the interior of a machine, we take one last pass through the depth and delete any doors or secret doors that remain in the machine's interior.

In hindsight, this is what the original code was intended to do, but it was situated in the wrong place in the loop, so it inadvertently applied to the entire depth rather than just the machine's interior.

Screenshot of fixed level generation (compare to screenshots in @withinwheels 's comment linked above):

<img width="1009" alt="fixed-levelgen-door" src="https://user-images.githubusercontent.com/1160207/113468722-d173c900-93fc-11eb-95ab-354149efa2e4.png">
