### PR TITLE
Fix secret door OOS

### DIFF
--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -2467,7 +2467,6 @@ void playerTurnEnded() {
 
         for(monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
             if (canSeeMonster(monst) && !(monst->bookkeepingFlags & (MB_WAS_VISIBLE | MB_ALREADY_SEEN))) {
-                monst->bookkeepingFlags |= MB_WAS_VISIBLE;
                 if (monst->creatureState != MONSTER_ALLY) {
                     rogue.disturbed = true;
                     if (rogue.cautiousMode || rogue.automationActive) {
@@ -2488,6 +2487,10 @@ void playerTurnEnded() {
                         restoreRNG;
                     }
                 }
+            }
+
+            if (canSeeMonster(monst) && (BROGUE_VERSION_ATLEAST(1,9,4) || !(monst->bookkeepingFlags & (MB_WAS_VISIBLE | MB_ALREADY_SEEN)))) {
+                monst->bookkeepingFlags |= MB_WAS_VISIBLE;
                 if (cellHasTerrainFlag(monst->xLoc, monst->yLoc, T_OBSTRUCTS_PASSABILITY)
                     && cellHasTMFlag(monst->xLoc, monst->yLoc, TM_IS_SECRET)) {
 
@@ -2515,9 +2518,14 @@ void playerTurnEnded() {
                         messageWithColor(buf, &itemMessageColor, true);
                     }
                 }
-            } else if (!canSeeMonster(monst)
-                       && (monst->bookkeepingFlags & MB_WAS_VISIBLE)
-                       && !(monst->bookkeepingFlags & MB_CAPTIVE)) {
+            }
+
+            if (!canSeeMonster(monst)
+                && (monst->bookkeepingFlags & MB_WAS_VISIBLE)
+                && !(monst->bookkeepingFlags & MB_CAPTIVE)) {
+                // For captives we never unset MB_WAS_VISIBLE because captives are not moving,
+                // so we don't want to get "You see a ..." every time they come back into view.
+
                 monst->bookkeepingFlags &= ~MB_WAS_VISIBLE;
             }
         }


### PR DESCRIPTION
The purpose of the `MB_ALREADY_SEEN` monster flag is to interrupt compound movements (exploration). It does not get set during recording playback, so internal game state should not depend on it, lest we get OOS errors during playback.

Yet this was happening when a monster that _was_ seen while exploring/auto-playing showed up through a hidden door: the door was not getting revealed then (because `MB_ALREADY_SEEN` was set), but it was revealed during playback (`MB_ALREADY_SEEN` not set). The OOS occurred soon after, as the `rand_percent()` call in `search()` function depends on door secrecy.

This patch fixes the erroneous dependency in Brogue 1.9.4 and above. The dependency also affected runic weapon/armor's flags, although much less frequently than secret doors.