### PR TITLE
Allow falling into deep water

### DIFF
--- a/changes/falling-into-water.md
+++ b/changes/falling-into-water.md
@@ -1,2 +1,3 @@
 It is now possible to fall through chasms into deep water, without damage.
 Falling into shallow water or bog deals half the damage as hitting hard floor.
+Items falling through chasms (except keys and amulet) may now land into deep water, another chasm, or lava.

--- a/changes/falling-into-water.md
+++ b/changes/falling-into-water.md
@@ -1,0 +1,2 @@
+It is now possible to fall through chasms into deep water, without damage.
+Falling into shallow water or bog deals half the damage as hitting hard floor.

--- a/changes/falling-into-water.md
+++ b/changes/falling-into-water.md
@@ -1,3 +1,3 @@
 It is now possible to fall through chasms into deep water, without damage.
 Falling into shallow water or bog deals half the damage as hitting hard floor.
-Items falling through chasms (except keys and amulet) may now land into deep water, another chasm, or lava.
+Items falling through chasms may now land into deep water, another chasm, or lava.

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3541,17 +3541,10 @@ void restoreItem(item *theItem) {
     if (theItem->flags & ITEM_PREPLACED) {
         theItem->flags &= ~ITEM_PREPLACED;
 
-        if (theItem->category == AMULET || theItem->category == KEY) {
-            // keep keys and the amulet as safe as before (but why would anyone throw them down a chasm?!)
-            getQualifyingLocNear(loc, *x, *y, true, 0,
-                                (T_OBSTRUCTS_ITEMS | T_AUTO_DESCENT | T_IS_DEEP_WATER | T_LAVA_INSTA_DEATH),
-                                (HAS_MONSTER | HAS_ITEM | HAS_STAIRS), true, false);
-        } else {
-            // disposable items can fall into deep water, enclaved lakes, another chasm, and even lava!
-            getQualifyingLocNear(loc, *x, *y, true, 0,
-                                (T_OBSTRUCTS_ITEMS),
-                                (HAS_MONSTER | HAS_ITEM | HAS_STAIRS), false, false);
-        }
+        // Items can fall into deep water, enclaved lakes, another chasm, even lava!
+        getQualifyingLocNear(loc, *x, *y, true, 0,
+                            (T_OBSTRUCTS_ITEMS),
+                            (HAS_MONSTER | HAS_ITEM | HAS_STAIRS), false, false);
 
         *x = loc[0];
         *y = loc[1];

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3540,8 +3540,19 @@ void restoreItem(item *theItem) {
 
     if (theItem->flags & ITEM_PREPLACED) {
         theItem->flags &= ~ITEM_PREPLACED;
-        getQualifyingLocNear(loc, *x, *y, true, 0, (T_OBSTRUCTS_ITEMS | T_AUTO_DESCENT | T_IS_DEEP_WATER | T_LAVA_INSTA_DEATH),
-                             (HAS_MONSTER | HAS_ITEM | HAS_STAIRS), true, false);
+
+        if (theItem->category == AMULET || theItem->category == KEY) {
+            // keep keys and the amulet as safe as before (but why would anyone throw them down a chasm?!)
+            getQualifyingLocNear(loc, *x, *y, true, 0,
+                                (T_OBSTRUCTS_ITEMS | T_AUTO_DESCENT | T_IS_DEEP_WATER | T_LAVA_INSTA_DEATH),
+                                (HAS_MONSTER | HAS_ITEM | HAS_STAIRS), true, false);
+        } else {
+            // disposable items can fall into deep water, enclaved lakes, another chasm, and even lava!
+            getQualifyingLocNear(loc, *x, *y, true, 0,
+                                (T_OBSTRUCTS_ITEMS),
+                                (HAS_MONSTER | HAS_ITEM | HAS_STAIRS), false, false);
+        }
+
         *x = loc[0];
         *y = loc[1];
     }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1105,6 +1105,10 @@ void updateFloorItems() {
         nextItem = theItem->nextItem;
         x = theItem->xLoc;
         y = theItem->yLoc;
+        if (rogue.absoluteTurnNumber < theItem->spawnTurnNumber) {
+            // we are simulating an earlier turn than when the item fell into this level... let's not touch it yet
+            continue;
+        }
         if (cellHasTerrainFlag(x, y, T_AUTO_DESCENT)) {
             if (playerCanSeeOrSense(x, y)) {
                 itemName(theItem, buf, false, false, NULL);
@@ -1126,6 +1130,7 @@ void updateFloorItems() {
                 deleteItem(theItem);
             } else {
                 // Add to next level's chain.
+                theItem->spawnTurnNumber = rogue.absoluteTurnNumber;
                 theItem->nextItem = levels[rogue.depthLevel-1 + 1].items;
                 levels[rogue.depthLevel-1 + 1].items = theItem;
             }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1365,6 +1365,7 @@ typedef struct item {
     short yLoc;
     keyLocationProfile keyLoc[KEY_ID_MAXIMUM];
     short originDepth;
+    unsigned long spawnTurnNumber;
     struct item *nextItem;
 } item;
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -765,6 +765,22 @@ void startLevel(short oldLevelNumber, short stairDirection) {
         getQualifyingLocNear(loc, player.xLoc, player.yLoc, true, 0,
                              (T_PATHING_BLOCKER & ~T_IS_DEEP_WATER),
                              (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
+
+        if (cellHasTerrainFlag(loc[0], loc[1], T_IS_DEEP_WATER)) {
+            // Fell into deep water... can we swim out of it?
+            short dryLoc[2];
+            getQualifyingLocNear(dryLoc, player.xLoc, player.yLoc, true, 0,
+                                (T_PATHING_BLOCKER),
+                                (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
+
+            short swimDistance = pathingDistance(loc[0], loc[1], dryLoc[0], dryLoc[1], T_PATHING_BLOCKER & ~T_IS_DEEP_WATER);
+            if (swimDistance == 30000) {
+                // Cannot swim out! This is an enclosed lake.
+                loc[0] = dryLoc[0];
+                loc[1] = dryLoc[1];
+            }
+        }
+
     } else {
         if (stairDirection == 1) { // heading downward
             player.xLoc = rogue.upLoc[0];

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -763,7 +763,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     if (stairDirection == 0) { // fell into the level
 
         getQualifyingLocNear(loc, player.xLoc, player.yLoc, true, 0,
-                             (T_PATHING_BLOCKER),
+                             (T_PATHING_BLOCKER & ~T_IS_DEEP_WATER),
                              (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
     } else {
         if (stairDirection == 1) { // heading downward

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -744,13 +744,13 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     px = player.xLoc;
     py = player.yLoc;
     player.xLoc = player.yLoc = 0;
+    unsigned long currentTurnNumber = rogue.absoluteTurnNumber;
     timeAway = min(timeAway, 100);
     while (timeAway--) {
-        unsigned long turn = rogue.absoluteTurnNumber;
-        rogue.absoluteTurnNumber = (turn > timeAway ? turn - timeAway : 0);
+        rogue.absoluteTurnNumber = max(currentTurnNumber, timeAway) - timeAway;
         updateEnvironment();
-        rogue.absoluteTurnNumber = turn;
     }
+    rogue.absoluteTurnNumber = currentTurnNumber;
     player.xLoc = px;
     player.yLoc = py;
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -744,8 +744,12 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     px = player.xLoc;
     py = player.yLoc;
     player.xLoc = player.yLoc = 0;
-    for (i = 0; i < 100 && i < (short) timeAway; i++) {
+    timeAway = min(timeAway, 100);
+    while (timeAway--) {
+        unsigned long turn = rogue.absoluteTurnNumber;
+        rogue.absoluteTurnNumber = (turn > timeAway ? turn - timeAway : 0);
         updateEnvironment();
+        rogue.absoluteTurnNumber = turn;
     }
     player.xLoc = px;
     player.yLoc = py;

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -754,6 +754,12 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     player.xLoc = px;
     player.yLoc = py;
 
+    // This level is now up-to-date as of the current turn.
+    // Get the ticker ready for the *next* environment update.
+    if (rogue.ticksTillUpdateEnvironment <= 0) {
+        rogue.ticksTillUpdateEnvironment += 100;
+    }
+
     if (!levels[rogue.depthLevel-1].visited) {
         levels[rogue.depthLevel-1].visited = true;
         if (rogue.depthLevel == AMULET_LEVEL) {

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -989,10 +989,20 @@ void playerFalls() {
         rogue.depthLevel++;
         startLevel(rogue.depthLevel - 1, 0);
         damage = randClumpedRange(FALL_DAMAGE_MIN, FALL_DAMAGE_MAX, 2);
-        messageWithColor("You are damaged by the fall.", &badMessageColor, 0);
-        if (inflictDamage(NULL, &player, damage, &red, false)) {
-            gameOver("Killed by a fall", true);
-        } else if (rogue.depthLevel > rogue.deepestLevel) {
+        boolean killed = false;
+        if (terrainFlags(player.xLoc, player.yLoc) & T_IS_DEEP_WATER) {
+            messageWithColor("You fall into deep water, unharmed.", &badMessageColor, 0);
+        } else {
+            if (cellHasTMFlag(player.xLoc, player.yLoc, TM_ALLOWS_SUBMERGING)) {
+                damage /= 2; // falling into liquid (shallow water, bog, etc.) hurts less than hitting hard floor
+            }
+            messageWithColor("You are damaged by the fall.", &badMessageColor, 0);
+            if (inflictDamage(NULL, &player, damage, &red, false)) {
+                gameOver("Killed by a fall", true);
+                killed = true;
+            }
+        }
+        if (!killed && rogue.depthLevel > rogue.deepestLevel) {
             rogue.deepestLevel = rogue.depthLevel;
         }
     } else {

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -991,7 +991,7 @@ void playerFalls() {
         damage = randClumpedRange(FALL_DAMAGE_MIN, FALL_DAMAGE_MAX, 2);
         boolean killed = false;
         if (terrainFlags(player.xLoc, player.yLoc) & T_IS_DEEP_WATER) {
-            messageWithColor("You plunge into deep water, unharmed.", &badMessageColor, 0);
+            messageWithColor("You fall into deep water, unharmed.", &badMessageColor, 0);
         } else {
             if (cellHasTMFlag(player.xLoc, player.yLoc, TM_ALLOWS_SUBMERGING)) {
                 damage /= 2; // falling into liquid (shallow water, bog, etc.) hurts less than hitting hard floor

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -991,12 +991,12 @@ void playerFalls() {
         damage = randClumpedRange(FALL_DAMAGE_MIN, FALL_DAMAGE_MAX, 2);
         boolean killed = false;
         if (terrainFlags(player.xLoc, player.yLoc) & T_IS_DEEP_WATER) {
-            messageWithColor("You fall into deep water, unharmed.", &badMessageColor, 0);
+            messageWithColor("You plunge into deep water, unharmed.", &badMessageColor, 0);
         } else {
             if (cellHasTMFlag(player.xLoc, player.yLoc, TM_ALLOWS_SUBMERGING)) {
                 damage /= 2; // falling into liquid (shallow water, bog, etc.) hurts less than hitting hard floor
             }
-            messageWithColor("You are damaged by the fall.", &badMessageColor, 0);
+            messageWithColor("You are injured by the fall.", &badMessageColor, 0);
             if (inflictDamage(NULL, &player, damage, &red, false)) {
                 gameOver("Killed by a fall", true);
                 killed = true;


### PR DESCRIPTION
Falling into deep water is now possible, without damage.

Damage is reduced when falling into other liquids (shallow water, bog) like in real life.

Closes #268 