### PR TITLE
Allow seeking to the last turn of a recording

### DIFF
--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -793,15 +793,13 @@ void promptToAdvanceToLocation(short keystroke) {
         if (enteredText && entryText[0] != '\0') {
             sscanf(entryText, "%lu", &destinationFrame);
 
-            if (destinationFrame >= rogue.howManyTurns) {
-                flashTemporaryAlert(" Past end of recording ", 3000);
-            } else if (rogue.playbackOOS && destinationFrame > rogue.playerTurnNumber) {
+            if (rogue.playbackOOS && destinationFrame > rogue.playerTurnNumber) {
                 flashTemporaryAlert(" Out of sync ", 3000);
             } else if (destinationFrame == rogue.playerTurnNumber) {
                 sprintf(buf, " Already at turn %li ", destinationFrame);
                 flashTemporaryAlert(buf, 1000);
             } else {
-                seek(destinationFrame, RECORDING_SEEK_MODE_TURN);
+                seek(min(destinationFrame, rogue.howManyTurns), RECORDING_SEEK_MODE_TURN);
             }
             rogue.playbackPaused = true;
         }
@@ -916,7 +914,7 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                         destinationFrame = rogue.playerTurnNumber + frameCount;
                     }
                 } else {
-                    destinationFrame = min(rogue.playerTurnNumber + frameCount, rogue.howManyTurns - 1);
+                    destinationFrame = min(rogue.playerTurnNumber + frameCount, rogue.howManyTurns);
                 }
 
                 if (destinationFrame == rogue.playerTurnNumber) {

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -980,6 +980,11 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     rogue.gameInProgress = false;
     flushBufferToFile();
 
+    if (rogue.playbackFastForward) {
+        rogue.playbackFastForward = false;
+        displayLevel();
+    }
+
     if (rogue.quit) {
         if (rogue.playbackMode) {
             playback = rogue.playbackMode;
@@ -1128,6 +1133,11 @@ void victory(boolean superVictory) {
 
     rogue.gameInProgress = false;
     flushBufferToFile();
+
+    if (rogue.playbackFastForward) {
+        rogue.playbackFastForward = false;
+        displayLevel();
+    }
 
     //
     // First screen - Congratulations...


### PR DESCRIPTION
Until now, Brogue wouldn't let you navigate to the last turn of a recording, either with arrow keys or entering the turn number, because the `gameOver()` / `victory()` functions could not display it while in fast-forward mode. Fixing the latter now allows seeking to the last turn without any issue.

For convenience, we now also allow entering a large turn number, e.g "99999" (easy to type!) and it is treated the same as seeking the end of the recording (i.e last turn).

Closes #309.