### PR TITLE
Add all unusable IDE/compiler files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@ bin/brogue*
 BrogueCE-*
 
 .vscode
+.gdb_history
 
 *.su
 *.gcda
 *.gcno
 *.gcov
+*.desktop
 gmon.out


### PR DESCRIPTION
Use two asterisks to ignore them regardless of the subdirectory they are in.

Also add **.desktop files to .gitignore.

Closes #303.