### PR TITLE
Don't ask to step onto gas traps with respiration

### DIFF
--- a/changes/respiration-gas-trap-warning.md
+++ b/changes/respiration-gas-trap-warning.md
@@ -1,0 +1,1 @@
+When wearing known respiration armor, don't warn when stepping on immune gas traps.

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1058,6 +1058,10 @@ boolean playerMoves(short direction) {
                    && cellHasTerrainFlag(newX, newY, T_IS_DF_TRAP)
                    && !(pmap[newX][newY].flags & PRESSURE_PLATE_DEPRESSED)
                    && !cellHasTMFlag(newX, newY, TM_IS_SECRET)
+                   && (!rogue.armor || !(rogue.armor->flags & ITEM_RUNIC) || !(rogue.armor->flags & ITEM_RUNIC_IDENTIFIED) || rogue.armor->enchant2 != A_RESPIRATION ||
+                        (!cellHasTerrainType(newX, newY, GAS_TRAP_POISON)
+                         && !cellHasTerrainType(newX, newY, GAS_TRAP_PARALYSIS)
+                         && !cellHasTerrainType(newX, newY, GAS_TRAP_CONFUSION)))
                    && !confirm("Step onto the pressure plate?", false)) {
 
             brogueAssert(!committed);


### PR DESCRIPTION
Specifically, don't ask if the player is wearing identified respiration armor and steps on a caustic, paralysis or confusion trigger.  Stepping still shows the "--MORE--" prompt afterwards that must be dismissed.

Closes #149