### PR TITLE
Clear the message archive before welcome()

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -3033,6 +3033,11 @@ void dequeueEvent() {
     nextBrogueEvent(&returnEvent, false, false, true);
 }
 
+// Empty the message archive
+void clearMessageArchive() {
+    messageArchivePosition = 0;
+}
+
 // Get a pointer to the archivedMessage the given number of entries back in history.
 // Pass zero to get the entry under messageArchivePosition.
 archivedMessage *getArchivedMessage(short back) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2877,6 +2877,7 @@ extern "C" {
     void playerTurnEnded();
     void resetScentTurnNumber();
     void displayMonsterFlashes(boolean flashingEnabled);
+    void clearMessageArchive();
     void formatRecentMessages(char buf[][COLS*2], size_t height, short *linesFormatted, short *latestMessageLines);
     void displayRecentMessages();
     void displayMessageArchive();

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -481,6 +481,7 @@ void initializeRogue(uint64_t seed) {
 //          theItem = addItemToPack(theItem);
 //      }
     }
+    clearMessageArchive();
     blackOutScreen();
     welcome();
 }


### PR DESCRIPTION
Equipping the initial equipment now writes messages to the archive, which are visible if the player looks after starting a game.

Clear these and any other possible message cruft by clearing the archive just before Hello and Welcome.

Issue #220