### PR TITLE
Don't print equip messages when throwing

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1188,7 +1188,7 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
             if (armorRunicString[0]) {
                 message(armorRunicString, 0);
                 if (rogue.armor && (rogue.armor->flags & ITEM_RUNIC) && rogue.armor->enchant2 == A_BURDEN) {
-                    strengthCheck(rogue.armor);
+                    strengthCheck(rogue.armor, true);
                 }
             }
         }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3065,7 +3065,7 @@ extern "C" {
     item *makeItemInto(item *theItem, unsigned long itemCategory, short itemKind);
     void updateEncumbrance();
     short displayedArmorValue();
-    void strengthCheck(item *theItem);
+    void strengthCheck(item *theItem, boolean noisy);
     void recalculateEquipmentBonuses();
     boolean equipItem(item *theItem, boolean force, item *unequipHint);
     void equip(item *theItem);


### PR DESCRIPTION
Throwing (and enchanting, falling victim to acid mounds, or armor of burden..) implicitly equips an item as part of its implementation. These calls can now produce undesired messages.

Add a message flag as a boolean argument, to indicate if equip/unequip messages should be emitted.  Messages concerning cursed equipment are always produced.

Issue #220