### PR TITLE
Enable arrow controls for inventory

### DIFF
--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -323,6 +323,7 @@ const color hiliteColor =           {100,   100,    0,      0,      0,          
 const color interfaceBoxColor =     {7,     6,      15,     0,      0,          0,          0,      false};
 const color interfaceButtonColor =  {18,    15,     38,     0,      0,          0,          0,      false};
 const color buttonHoverColor =      {100,   70,     40,     0,      0,          0,          0,      false};
+const color buttonFocusColor =      {100,   70,     40,     0,      0,          0,          0,      false};
 const color titleButtonColor =      {23,    15,     30,     0,      0,          0,          0,      false};
 
 const color playerInvisibleColor =  {20,    20,     30,     0,      0,          80,         0,      true};

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -157,6 +157,7 @@ extern const color inLightMultiplierColor;
 extern const color inDarknessMultiplierColor;
 
 extern const color buttonHoverColor;
+extern const color buttonFocusColor;
 extern color titleButtonColor;
 
 // other colors


### PR DESCRIPTION
#195 suggests reducing the number of keys required to play Brogue, to make devices without a keyboard (e.g. on a controller) more convenient.

Here's an (incomplete) proposed implementation for just the Inventory menu. Pressing `Return` or `Left` or `Right` (or various synonyms) switches the Item Detail view to having one "focused" button (defaulting to an item-type-appropriate choice: equip/apply/remove). Pressing `Left` or `Right` will move to the next button, and pressing `Return` will activate that button.

For consistency in this view, I added a new `buttonFocusColor` to highlight the button that's currently focused, i.e. which button will activate when the player presses `Return`. Since the `confirm` screen also uses `Return` for "Yes", I also recolored that button.

---

Separately, I think it would be best to add non-letter "function" keys to do all common (contextual) tasks like Drop/Throw/Apply/Equip/etc.

That way, it would be possible to bind those keys to a controller without also making them select random items (`t`/`e`/`d`/...) in your inventory or otherwise act like a letter or direction when it's not intended.

