### PR TITLE
Remove 'needsUpdate' from struct cellDisplayBuffer

### DIFF
--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -87,7 +87,6 @@ void hiliteGrid(short **grid, color *hiliteColor, short hiliteStrength) {
                 x = mapToWindowX(i);
                 y = mapToWindowY(j);
 
-                displayBuffer[x][y].needsUpdate = true;
                 displayBuffer[x][y].backColorComponents[0] = clamp(displayBuffer[x][y].backColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
                 displayBuffer[x][y].backColorComponents[1] = clamp(displayBuffer[x][y].backColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
                 displayBuffer[x][y].backColorComponents[2] = clamp(displayBuffer[x][y].backColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -871,17 +871,62 @@ void considerCautiousMode() {
     }*/
 }
 
+// previouslyPlottedCells is only accessed by commitDraws and refreshScreen,
+// as below.
+static cellDisplayBuffer previouslyPlottedCells[COLS][ROWS];
+
+// Only cells which have changed since the previous commitDraws are actually
+// drawn.
+void commitDraws() {
+    for (int j = 0; j < ROWS; j++) {
+        for (int i = 0; i < COLS; i++) {
+            cellDisplayBuffer *lastPlotted = &previouslyPlottedCells[i][j];
+            cellDisplayBuffer *curr = &displayBuffer[i][j];
+            boolean needsUpdate =
+                lastPlotted->character != curr->character
+                || lastPlotted->foreColorComponents[0] != curr->foreColorComponents[0]
+                || lastPlotted->foreColorComponents[1] != curr->foreColorComponents[1]
+                || lastPlotted->foreColorComponents[2] != curr->foreColorComponents[2]
+                || lastPlotted->backColorComponents[0] != curr->backColorComponents[0]
+                || lastPlotted->backColorComponents[1] != curr->backColorComponents[1]
+                || lastPlotted->backColorComponents[2] != curr->backColorComponents[2];
+
+            if (!needsUpdate) {
+                continue;
+            }
+
+            plotChar(curr->character, i, j,
+                     curr->foreColorComponents[0],
+                     curr->foreColorComponents[1],
+                     curr->foreColorComponents[2],
+                     curr->backColorComponents[0],
+                     curr->backColorComponents[1],
+                     curr->backColorComponents[2]
+            );
+            *lastPlotted = *curr;
+        }
+    }
+}
+
 // flags the entire window as needing to be redrawn at next flush.
 // very low level -- does not interface with the guts of the game.
 void refreshScreen() {
-    short i, j;
-
-    for( i=0; i<COLS; i++ ) {
-        for( j=0; j<ROWS; j++ ) {
-            displayBuffer[i][j].needsUpdate = true;
+    for (int i = 0; i < COLS; i++) {
+        for (int j = 0; j < ROWS; j++) {
+            cellDisplayBuffer *curr = &displayBuffer[i][j];
+            plotChar(curr->character, i, j,
+                     curr->foreColorComponents[0],
+                     curr->foreColorComponents[1],
+                     curr->foreColorComponents[2],
+                     curr->backColorComponents[0],
+                     curr->backColorComponents[1],
+                     curr->backColorComponents[2]
+            );
+            // Remember that it was previously plotted, so that
+            // commitDraws still knows when it needs updates.
+            previouslyPlottedCells[i][j] = *curr;
         }
     }
-    commitDraws();
 }
 
 // higher-level redraw
@@ -1778,24 +1823,14 @@ void plotCharWithColor(enum displayGlyph inputChar, short xLoc, short yLoc, cons
         inputChar = ' ';
     }
 
-    if (inputChar       != displayBuffer[xLoc][yLoc].character
-        || foreRed      != displayBuffer[xLoc][yLoc].foreColorComponents[0]
-        || foreGreen    != displayBuffer[xLoc][yLoc].foreColorComponents[1]
-        || foreBlue     != displayBuffer[xLoc][yLoc].foreColorComponents[2]
-        || backRed      != displayBuffer[xLoc][yLoc].backColorComponents[0]
-        || backGreen    != displayBuffer[xLoc][yLoc].backColorComponents[1]
-        || backBlue     != displayBuffer[xLoc][yLoc].backColorComponents[2]) {
-
-        displayBuffer[xLoc][yLoc].needsUpdate = true;
-
-        displayBuffer[xLoc][yLoc].character = inputChar;
-        displayBuffer[xLoc][yLoc].foreColorComponents[0] = foreRed;
-        displayBuffer[xLoc][yLoc].foreColorComponents[1] = foreGreen;
-        displayBuffer[xLoc][yLoc].foreColorComponents[2] = foreBlue;
-        displayBuffer[xLoc][yLoc].backColorComponents[0] = backRed;
-        displayBuffer[xLoc][yLoc].backColorComponents[1] = backGreen;
-        displayBuffer[xLoc][yLoc].backColorComponents[2] = backBlue;
-    }
+    cellDisplayBuffer *target = &displayBuffer[xLoc][yLoc];
+    target->character = inputChar;
+    target->foreColorComponents[0] = foreRed;
+    target->foreColorComponents[1] = foreGreen;
+    target->foreColorComponents[2] = foreBlue;
+    target->backColorComponents[0] = backRed;
+    target->backColorComponents[1] = backGreen;
+    target->backColorComponents[2] = backBlue;
 
     restoreRNG;
 }
@@ -1835,27 +1870,6 @@ void plotForegroundChar(enum displayGlyph inputChar, short x, short y, color *fo
         applyColorMultiplier(&myColor, &multColor);
     }
     plotCharWithColor(inputChar, mapToWindowX(x), mapToWindowY(y), &myColor, &backColor);
-}
-
-// Set to false and draws don't take effect, they simply queue up. Set to true and all of the
-// queued up draws take effect.
-void commitDraws() {
-    short i, j;
-
-    for (j=0; j<ROWS; j++) {
-        for (i=0; i<COLS; i++) {
-            if (displayBuffer[i][j].needsUpdate) {
-                plotChar(displayBuffer[i][j].character, i, j,
-                         displayBuffer[i][j].foreColorComponents[0],
-                         displayBuffer[i][j].foreColorComponents[1],
-                         displayBuffer[i][j].foreColorComponents[2],
-                         displayBuffer[i][j].backColorComponents[0],
-                         displayBuffer[i][j].backColorComponents[1],
-                         displayBuffer[i][j].backColorComponents[2]);
-                displayBuffer[i][j].needsUpdate = false;
-            }
-        }
-    }
 }
 
 // Debug feature: display the level to the screen without regard to lighting, field of view, etc.
@@ -1911,7 +1925,6 @@ void hiliteCharGrid(char hiliteCharGrid[DCOLS][DROWS], color *hiliteColor, short
                 x = mapToWindowX(i);
                 y = mapToWindowY(j);
 
-                displayBuffer[x][y].needsUpdate = true;
                 displayBuffer[x][y].backColorComponents[0] = clamp(displayBuffer[x][y].backColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
                 displayBuffer[x][y].backColorComponents[1] = clamp(displayBuffer[x][y].backColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
                 displayBuffer[x][y].backColorComponents[2] = clamp(displayBuffer[x][y].backColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
@@ -4220,8 +4233,6 @@ void highlightScreenCell(short x, short y, color *highlightColor, short strength
     tempColor = colorFromComponents(displayBuffer[x][y].backColorComponents);
     applyColorAugment(&tempColor, highlightColor, strength);
     storeColorComponents(displayBuffer[x][y].backColorComponents, &tempColor);
-
-    displayBuffer[x][y].needsUpdate = true;
 }
 
 short estimatedArmorValue() {

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -654,7 +654,6 @@ void mainBrogueJunction() {
     for (i=0; i<COLS; i++) {
         for (j=0; j<ROWS; j++) {
             displayBuffer[i][j].character = 0;
-            displayBuffer[i][j].needsUpdate = false;
             displayBuffer[i][j].opacity = 100;
             for (k=0; k<3; k++) {
                 displayBuffer[i][j].foreColorComponents[k] = 0;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1246,7 +1246,6 @@ typedef struct cellDisplayBuffer {
     char foreColorComponents[3];
     char backColorComponents[3];
     char opacity;
-    boolean needsUpdate;
 } cellDisplayBuffer;
 
 typedef struct pcell {                              // permanent cell; have to remember this stuff to save levels


### PR DESCRIPTION
Formerly, `needsUpdate` was stored inside the `struct cellDisplayBuffer` to track which cells should actually be drawn to the screen with `plotChar` inside of `commitDraws`.

Now, `commitDraws` just remembers what it drew to the screen last (inside a new static global called `previouslyPlottedCells`). So the optimization is now applied fully automatically, with no support needed from the rest of IO.

This makes it much harder to accidentally forget to update a cell that's changed.

Also, in my brief tests where I did both at once and highlighted changes, I saw that there were even a few places where cells used to be updated redundantly which no longer occur!

The biggest benefit is that it's now obvious that `needsUpdate` is never used inside the various screen buffers passed around for transparency etc.

---

Separately, I think it should be possible to eliminate `refreshScreen`. However, some platform-specific code relies on calling it (so that every character ends up re-plotted). I _think_ that these can be made redundant, since the platforms do store all of the current characters on their sides anyway, but I was also worried about breaking something while trying to tackle that right here.