### PR TITLE
refactoring: dungeongrid type; (mostly) stop allocating grids on the heap

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -2896,22 +2896,20 @@ void updateMapToShore() {
     dungeongrid costMap = filledGrid(0);
 
     // Calculate the map to shore for this level
-    if (!rogue.mapToShore) {
-        rogue.mapToShore = allocGrid(0);
-    }
+    rogue.mapToShore = filledGrid(0);
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)) {
                 costMap.cells[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
-                rogue.mapToShore->cells[i][j] = 30000;
+                rogue.mapToShore.cells[i][j] = 30000;
             } else {
                 costMap.cells[i][j] = 1;
-                rogue.mapToShore->cells[i][j] = (cellHasTerrainFlag(i, j, T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT)
+                rogue.mapToShore.cells[i][j] = (cellHasTerrainFlag(i, j, T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT)
                                           && !cellHasTMFlag(i, j, TM_IS_SECRET)) ? 30000 : 0;
             }
         }
     }
-    dijkstraScan(rogue.mapToShore, &costMap, true);
+    dijkstraScan(&rogue.mapToShore, &costMap, true);
 }
 
 // Calculates the distance map for the given waypoint.

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -350,7 +350,7 @@ void addLoops(dungeongrid *grid, short minimumPathingDistance) {
                     && grid->cells[newX][newY] == 1
                     && grid->cells[oppX][oppY] == 1) { // If the tile being inspected has floor on both sides,
 
-                    fillGrid(pathMap, 30000);
+                    *pathMap = filledGrid(30000);
                     pathMap->cells[newX][newY] = 0;
                     dijkstraScan(pathMap, costMap, false);
                     if (pathMap->cells[oppX][oppY] > minimumPathingDistance) { // and if the pathing distance between the two flanking floor tiles exceeds minimumPathingDistance,
@@ -1143,7 +1143,7 @@ boolean buildAMachine(enum machineTypes bp,
                 if (!distanceMap) {
                     distanceMap = allocGrid(0);
                 }
-                fillGrid(distanceMap, 0);
+                *distanceMap = filledGrid(0);
                 calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, false);
                 qualifyingTileCount = 0; // Keeps track of how many interior cells we've added.
                 totalFreq = rand_range(blueprintCatalog[bp].roomSize[0], blueprintCatalog[bp].roomSize[1]); // Keeps track of the goal size.
@@ -1231,7 +1231,7 @@ boolean buildAMachine(enum machineTypes bp,
     if (!distanceMap) {
         distanceMap = allocGrid(0);
     }
-    fillGrid(distanceMap, 0);
+    *distanceMap = filledGrid(0);
     calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, true);
     qualifyingTileCount = 0;
     for (i=0; i<100; i++) {
@@ -1944,7 +1944,7 @@ void designCavern(dungeongrid *grid, short minWidth, short maxWidth, short minHe
     boolean foundFillPoint = false;
     
     dungeongrid *blobGrid = allocGrid(0);
-    fillGrid(grid, 0);
+    *grid = filledGrid(0);
     createBlobOnGrid(blobGrid,
                      &caveX, &caveY, &caveWidth, &caveHeight,
                      5, minWidth, minHeight, maxWidth, maxHeight, 55, "ffffffttt", "ffffttttt");
@@ -1973,7 +1973,7 @@ void designCavern(dungeongrid *grid, short minWidth, short maxWidth, short minHe
 void designEntranceRoom(dungeongrid *grid) {
     short roomWidth, roomHeight, roomWidth2, roomHeight2, roomX, roomY, roomX2, roomY2;
 
-    fillGrid(grid, 0);
+    *grid = filledGrid(0);
 
     roomWidth = 8;
     roomHeight = 10;
@@ -1991,7 +1991,7 @@ void designEntranceRoom(dungeongrid *grid) {
 void designCrossRoom(dungeongrid *grid) {
     short roomWidth, roomHeight, roomWidth2, roomHeight2, roomX, roomY, roomX2, roomY2;
 
-    fillGrid(grid, 0);
+    *grid = filledGrid(0);
 
     roomWidth = rand_range(3, 12);
     roomX = rand_range(max(0, DCOLS/2 - (roomWidth - 1)), min(DCOLS, DCOLS/2));
@@ -2011,7 +2011,7 @@ void designCrossRoom(dungeongrid *grid) {
 void designSymmetricalCrossRoom(dungeongrid *grid) {
     short majorWidth, majorHeight, minorWidth, minorHeight;
 
-    fillGrid(grid, 0);
+    *grid = filledGrid(0);
 
     majorWidth = rand_range(4, 8);
     majorHeight = rand_range(4, 5);
@@ -2032,7 +2032,7 @@ void designSymmetricalCrossRoom(dungeongrid *grid) {
 void designSmallRoom(dungeongrid *grid) {
     short width, height;
 
-    fillGrid(grid, 0);
+    *grid = filledGrid(0);
     width = rand_range(3, 6);
     height = rand_range(2, 4);
     drawRectangleOnGrid(grid, (DCOLS - width) / 2, (DROWS - height) / 2, width, height, 1);
@@ -2047,7 +2047,7 @@ void designCircularRoom(dungeongrid *grid) {
         radius = rand_range(2, 4);
     }
 
-    fillGrid(grid, 0);
+    *grid = filledGrid(0);
     drawCircleOnGrid(grid, DCOLS/2, DROWS/2, radius, 1);
 
     if (radius > 6
@@ -2061,7 +2061,7 @@ void designChunkyRoom(dungeongrid *grid) {
     short minX, maxX, minY, maxY;
     short chunkCount = rand_range(2, 8);
 
-    fillGrid(grid, 0);
+    *grid = filledGrid(0);
     drawCircleOnGrid(grid, DCOLS/2, DROWS/2, 2, 1);
     minX = DCOLS/2 - 3;
     maxX = DCOLS/2 + 3;
@@ -2346,7 +2346,7 @@ void attachRooms(dungeongrid *grid, const dungeonProfile *theDP, short attempts,
     roomMap = allocGrid(0);
     for (roomsBuilt = roomsAttempted = 0; roomsBuilt < maxRoomCount && roomsAttempted < attempts; roomsAttempted++) {
         // Build a room in hyperspace.
-        fillGrid(roomMap, 0);
+        *roomMap = filledGrid(0);
         designRandomRoom(roomMap, roomsAttempted <= attempts - 5 && rand_percent(theDP->corridorChance),
                          doorSites, theDP->roomFrequencies);
 
@@ -2610,10 +2610,10 @@ void designLakes(dungeongrid *lakeMap) {
     short lakeX, lakeY, lakeWidth, lakeHeight;
 
     dungeongrid *grid = allocGrid(0); // Holds the current lake.
-    fillGrid(lakeMap, 0);
+    *lakeMap = filledGrid(0);
     for (lakeMaxHeight = 15, lakeMaxWidth = 30; lakeMaxHeight >=10; lakeMaxHeight--, lakeMaxWidth -= 2) { // lake generations
 
-        fillGrid(grid, 0);
+        *grid = filledGrid(0);
         createBlobOnGrid(grid, &lakeX, &lakeY, &lakeWidth, &lakeHeight, 5, 4, 4, lakeMaxWidth, lakeMaxHeight, 55, "ffffftttt", "ffffttttt");
 
 //        if (D_INSPECT_LEVELGEN) {
@@ -2989,7 +2989,7 @@ void refreshWaypoint(short wpIndex) {
             costMap->cells[monst->xLoc][monst->yLoc] = PDS_FORBIDDEN;
         }
     }
-    fillGrid(rogue.wpDistance[wpIndex], 30000);
+    *rogue.wpDistance[wpIndex] = filledGrid(30000);
     rogue.wpDistance[wpIndex]->cells[rogue.wpCoordinates[wpIndex][0]][rogue.wpCoordinates[wpIndex][1]] = 0;
     dijkstraScan(rogue.wpDistance[wpIndex], costMap, true);
     freeGrid(costMap);

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -330,8 +330,8 @@ void addLoops(dungeongrid *grid, short minimumPathingDistance) {
         hiliteGrid(grid, &white, 100);
     }
 
-    dungeongrid *pathMap = allocGrid();
-    dungeongrid *costMap = allocGrid();
+    dungeongrid *pathMap = allocGrid(0);
+    dungeongrid *costMap = allocGrid(0);
     *costMap = *grid;
     findReplaceGrid(costMap, 0, 0, PDS_OBSTRUCTION);
     findReplaceGrid(costMap, 1, 30000, 1);
@@ -657,11 +657,10 @@ boolean fillInteriorForVestibuleMachine(char interior[DCOLS][DROWS], short bp, s
 
     zeroOutGrid(interior);
 
-    distanceMap = allocGrid();
-    fillGrid(distanceMap, 30000);
+    distanceMap = allocGrid(30000);
     distanceMap->cells[originX][originY] = 0;
 
-    costMap = allocGrid();
+    costMap = allocGrid(0);
     populateGenericCostMap(costMap);
     for(i=0; i<DCOLS; i++) {
         for(j=0; j<DROWS; j++) {
@@ -719,7 +718,7 @@ void redesignInterior(char interior[DCOLS][DROWS], short originX, short originY,
     dungeongrid *grid;
     dungeongrid *pathingGrid;
     dungeongrid *costGrid;
-    grid = allocGrid();
+    grid = allocGrid(0);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
@@ -755,8 +754,8 @@ void redesignInterior(char interior[DCOLS][DROWS], short originX, short originY,
 
     // Connect to preexisting rooms that were orphaned (mostly preexisting machine rooms).
     if (orphanCount > 0) {
-        pathingGrid = allocGrid();
-        costGrid = allocGrid();
+        pathingGrid = allocGrid(0);
+        costGrid = allocGrid(0);
         for (n = 0; n < orphanCount; n++) {
 
             if (D_INSPECT_MACHINES) {
@@ -1142,7 +1141,7 @@ boolean buildAMachine(enum machineTypes bp,
                 }
 
                 if (!distanceMap) {
-                    distanceMap = allocGrid();
+                    distanceMap = allocGrid(0);
                 }
                 fillGrid(distanceMap, 0);
                 calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, false);
@@ -1230,7 +1229,7 @@ boolean buildAMachine(enum machineTypes bp,
     // Calculate the distance map (so that features that want to be close to or far from the origin can be placed accordingly)
     // and figure out the 33rd and 67th percentiles for features that want to be near or far from the origin.
     if (!distanceMap) {
-        distanceMap = allocGrid();
+        distanceMap = allocGrid(0);
     }
     fillGrid(distanceMap, 0);
     calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, true);
@@ -1944,7 +1943,7 @@ void designCavern(dungeongrid *grid, short minWidth, short maxWidth, short minHe
     short fillX = 0, fillY = 0;
     boolean foundFillPoint = false;
     
-    dungeongrid *blobGrid = allocGrid();
+    dungeongrid *blobGrid = allocGrid(0);
     fillGrid(grid, 0);
     createBlobOnGrid(blobGrid,
                      &caveX, &caveY, &caveWidth, &caveHeight,
@@ -2126,7 +2125,7 @@ void chooseRandomDoorSites(dungeongrid *roomMap, short doorSites[4][2]) {
     enum directions dir;
     boolean doorSiteFailed;
 
-    dungeongrid *grid = allocGrid();
+    dungeongrid *grid = allocGrid(0);
     *grid = *roomMap;
 
 //    colorOverDungeon(&darkGray);
@@ -2344,7 +2343,7 @@ void attachRooms(dungeongrid *grid, const dungeonProfile *theDP, short attempts,
     fillSequentialList(sCoord, DCOLS*DROWS);
     shuffleList(sCoord, DCOLS*DROWS);
 
-    roomMap = allocGrid();
+    roomMap = allocGrid(0);
     for (roomsBuilt = roomsAttempted = 0; roomsBuilt < maxRoomCount && roomsAttempted < attempts; roomsAttempted++) {
         // Build a room in hyperspace.
         fillGrid(roomMap, 0);
@@ -2560,8 +2559,7 @@ boolean lakeDisruptsPassability(dungeongrid *grid, dungeongrid *lakeMap, short d
     short i, j, x, y;
     dungeongrid *floodMap;
 
-    floodMap = allocGrid();
-    fillGrid(floodMap, 0);
+    floodMap = allocGrid(0);
     x = y = -1;
     // Get starting location for the fill.
     for (i=0; i<DCOLS && x == -1; i++) {
@@ -2611,9 +2609,7 @@ void designLakes(dungeongrid *lakeMap) {
     short lakeMaxHeight, lakeMaxWidth;
     short lakeX, lakeY, lakeWidth, lakeHeight;
 
-    dungeongrid *grid; // Holds the current lake.
-
-    grid = allocGrid();
+    dungeongrid *grid = allocGrid(0); // Holds the current lake.
     fillGrid(lakeMap, 0);
     for (lakeMaxHeight = 15, lakeMaxWidth = 30; lakeMaxHeight >=10; lakeMaxHeight--, lakeMaxWidth -= 2) { // lake generations
 
@@ -2862,7 +2858,7 @@ void digDungeon() {
     // Clear level and fill with granite
     clearLevel();
 
-    grid = allocGrid();
+    grid = allocGrid(0);
     carveDungeon(grid);
     addLoops(grid, 20);
     for (i=0; i<DCOLS; i++) {
@@ -2894,7 +2890,7 @@ void digDungeon() {
     // DEBUG logLevel();
 
     // Now design the lakes and then fill them with various liquids (lava, water, chasm, brimstone).
-    dungeongrid *lakeMap = allocGrid();
+    dungeongrid *lakeMap = allocGrid(0);
     designLakes(lakeMap);
     fillLakes(lakeMap);
     freeGrid(lakeMap);
@@ -2955,12 +2951,11 @@ void updateMapToShore() {
 
     rogue.updatedMapToShoreThisTurn = true;
 
-    costMap = allocGrid();
+    costMap = allocGrid(0);
 
     // Calculate the map to shore for this level
     if (!rogue.mapToShore) {
-        rogue.mapToShore = allocGrid();
-        fillGrid(rogue.mapToShore, 0);
+        rogue.mapToShore = allocGrid(0);
     }
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
@@ -2985,7 +2980,7 @@ void refreshWaypoint(short wpIndex) {
     dungeongrid *costMap;
     creature *monst;
 
-    costMap = allocGrid();
+    costMap = allocGrid(0);
     populateGenericCostMap(costMap);
     for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
         if ((monst->creatureState == MONSTER_SLEEPING || (monst->info.flags & MONST_IMMOBILE) || (monst->bookkeepingFlags & MB_CAPTIVE))
@@ -3748,10 +3743,8 @@ void initializeLevel() {
     }
 
     // Restore creatures that fell from the previous depth or that have been pathing toward the stairs.
-    dungeongrid *mapToStairs = allocGrid();
-    fillGrid(mapToStairs, 0);
-    dungeongrid *mapToPit = allocGrid();
-    fillGrid(mapToPit, 0);
+    dungeongrid *mapToStairs = allocGrid(0);
+    dungeongrid *mapToPit = allocGrid(0);
     calculateDistances(mapToStairs, player.xLoc, player.yLoc, T_PATHING_BLOCKER, NULL, true, true);
     calculateDistances(mapToPit,
                        levels[rogue.depthLevel - 1].playerExitedVia[0],

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1369,7 +1369,6 @@ boolean canAbsorb(creature *ally, boolean ourBolts[NUMBER_BOLT_KINDS], creature 
 
 boolean anyoneWantABite(creature *decedent) {
     short candidates, randIndex, i;
-    dungeongrid *grid;
     creature *ally;
     boolean success = false;
     boolean ourBolts[NUMBER_BOLT_KINDS] = {false};
@@ -1385,10 +1384,10 @@ boolean anyoneWantABite(creature *decedent) {
         return false;
     }
 
-    grid = allocGrid(0);
-    calculateDistances(grid, decedent->xLoc, decedent->yLoc, T_PATHING_BLOCKER, NULL, true, true);
+    dungeongrid grid = filledGrid(0);
+    calculateDistances(&grid, decedent->xLoc, decedent->yLoc, T_PATHING_BLOCKER, NULL, true, true);
     for (ally = monsters->nextCreature; ally != NULL; ally = ally->nextCreature) {
-        if (canAbsorb(ally, ourBolts, decedent, grid)) {
+        if (canAbsorb(ally, ourBolts, decedent, &grid)) {
             candidates++;
         }
     }
@@ -1396,7 +1395,7 @@ boolean anyoneWantABite(creature *decedent) {
         randIndex = rand_range(1, candidates);
         for (ally = monsters->nextCreature; ally != NULL; ally = ally->nextCreature) {
             // CanAbsorb() populates ourBolts if it returns true and there are no learnable behaviors or flags:
-            if (canAbsorb(ally, ourBolts, decedent, grid) && !--randIndex) {
+            if (canAbsorb(ally, ourBolts, decedent, &grid) && !--randIndex) {
                 break;
             }
         }
@@ -1467,7 +1466,6 @@ boolean anyoneWantABite(creature *decedent) {
             }
         }
     }
-    freeGrid(grid);
     return success;
 }
 

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1333,7 +1333,7 @@ void flashMonster(creature *monst, const color *theColor, short strength) {
     }
 }
 
-boolean canAbsorb(creature *ally, boolean ourBolts[NUMBER_BOLT_KINDS], creature *prey, short **grid) {
+boolean canAbsorb(creature *ally, boolean ourBolts[NUMBER_BOLT_KINDS], creature *prey, dungeongrid *grid) {
     short i;
 
     if (ally->creatureState == MONSTER_ALLY
@@ -1341,7 +1341,7 @@ boolean canAbsorb(creature *ally, boolean ourBolts[NUMBER_BOLT_KINDS], creature 
         && (ally->targetCorpseLoc[0] <= 0)
         && !((ally->info.flags | prey->info.flags) & (MONST_INANIMATE | MONST_IMMOBILE))
         && !monsterAvoids(ally, prey->xLoc, prey->yLoc)
-        && grid[ally->xLoc][ally->yLoc] <= 10) {
+        && grid->cells[ally->xLoc][ally->yLoc] <= 10) {
 
         if (~(ally->info.abilityFlags) & prey->info.abilityFlags & LEARNABLE_ABILITIES) {
             return true;
@@ -1369,7 +1369,7 @@ boolean canAbsorb(creature *ally, boolean ourBolts[NUMBER_BOLT_KINDS], creature 
 
 boolean anyoneWantABite(creature *decedent) {
     short candidates, randIndex, i;
-    short **grid;
+    dungeongrid *grid;
     creature *ally;
     boolean success = false;
     boolean ourBolts[NUMBER_BOLT_KINDS] = {false};

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1385,8 +1385,7 @@ boolean anyoneWantABite(creature *decedent) {
         return false;
     }
 
-    grid = allocGrid();
-    fillGrid(grid, 0);
+    grid = allocGrid(0);
     calculateDistances(grid, decedent->xLoc, decedent->yLoc, T_PATHING_BLOCKER, NULL, true, true);
     for (ally = monsters->nextCreature; ally != NULL; ally = ally->nextCreature) {
         if (canAbsorb(ally, ourBolts, decedent, grid)) {

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -138,13 +138,13 @@ void pdsSetDistance(pdsMap *map, short x, short y, short distance) {
     }
 }
 
-void pdsSetCosts(pdsMap *map, short **costMap) {
+void pdsSetCosts(pdsMap *map, dungeongrid *costMap) {
     short i, j;
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             if (i != 0 && j != 0 && i < DCOLS - 1 && j < DROWS - 1) {
-                PDS_CELL(map, i, j)->cost = costMap[i][j];
+                PDS_CELL(map, i, j)->cost = costMap->cells[i][j];
             } else {
                 PDS_CELL(map, i, j)->cost = PDS_FORBIDDEN;
             }
@@ -152,7 +152,7 @@ void pdsSetCosts(pdsMap *map, short **costMap) {
     }
 }
 
-void pdsBatchInput(pdsMap *map, short **distanceMap, short **costMap, short maxDistance, boolean eightWays) {
+void pdsBatchInput(pdsMap *map, dungeongrid *distanceMap, dungeongrid *costMap, short maxDistance, boolean eightWays) {
     short i, j;
     pdsLink *left, *right;
 
@@ -167,7 +167,7 @@ void pdsBatchInput(pdsMap *map, short **distanceMap, short **costMap, short maxD
             pdsLink *link = PDS_CELL(map, i, j);
 
             if (distanceMap != NULL) {
-                link->distance = distanceMap[i][j];
+                link->distance = distanceMap->cells[i][j];
             } else {
                 if (costMap != NULL) {
                     // totally hackish; refactor
@@ -183,7 +183,7 @@ void pdsBatchInput(pdsMap *map, short **distanceMap, short **costMap, short maxD
                 if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY) && cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT)) cost = PDS_OBSTRUCTION;
                 else cost = PDS_FORBIDDEN;
             } else {
-                cost = costMap[i][j];
+                cost = costMap->cells[i][j];
             }
 
             link->cost = cost;
@@ -222,14 +222,14 @@ void pdsBatchInput(pdsMap *map, short **distanceMap, short **costMap, short maxD
     }
 }
 
-void pdsBatchOutput(pdsMap *map, short **distanceMap) {
+void pdsBatchOutput(pdsMap *map, dungeongrid *distanceMap) {
     short i, j;
 
     pdsUpdate(map);
     // transfer results to the distanceMap
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            distanceMap[i][j] = PDS_CELL(map, i, j)->distance;
+            distanceMap->cells[i][j] = PDS_CELL(map, i, j)->distance;
         }
     }
 }
@@ -238,14 +238,14 @@ void pdsInvalidate(pdsMap *map, short maxDistance) {
     pdsBatchInput(map, NULL, NULL, maxDistance, map->eightWays);
 }
 
-void dijkstraScan(short **distanceMap, short **costMap, boolean useDiagonals) {
+void dijkstraScan(dungeongrid *distanceMap, dungeongrid *costMap, boolean useDiagonals) {
     static pdsMap map;
 
     pdsBatchInput(&map, distanceMap, costMap, 30000, useDiagonals);
     pdsBatchOutput(&map, distanceMap);
 }
 
-void calculateDistances(short **distanceMap,
+void calculateDistances(dungeongrid *distanceMap,
                         short destinationX, short destinationY,
                         unsigned long blockingTerrainFlags,
                         creature *traveler,
@@ -292,9 +292,9 @@ void calculateDistances(short **distanceMap,
 }
 
 short pathingDistance(short x1, short y1, short x2, short y2, unsigned long blockingTerrainFlags) {
-    short retval, **distanceMap = allocGrid();
+    dungeongrid *distanceMap = allocGrid();
     calculateDistances(distanceMap, x2, y2, blockingTerrainFlags, NULL, true, true);
-    retval = distanceMap[x1][y1];
+    short retval = distanceMap->cells[x1][y1];
     freeGrid(distanceMap);
     return retval;
 }

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -292,7 +292,7 @@ void calculateDistances(dungeongrid *distanceMap,
 }
 
 short pathingDistance(short x1, short y1, short x2, short y2, unsigned long blockingTerrainFlags) {
-    dungeongrid *distanceMap = allocGrid();
+    dungeongrid *distanceMap = allocGrid(0);
     calculateDistances(distanceMap, x2, y2, blockingTerrainFlags, NULL, true, true);
     short retval = distanceMap->cells[x1][y1];
     freeGrid(distanceMap);

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -292,10 +292,8 @@ void calculateDistances(dungeongrid *distanceMap,
 }
 
 short pathingDistance(short x1, short y1, short x2, short y2, unsigned long blockingTerrainFlags) {
-    dungeongrid *distanceMap = allocGrid(0);
-    calculateDistances(distanceMap, x2, y2, blockingTerrainFlags, NULL, true, true);
-    short retval = distanceMap->cells[x1][y1];
-    freeGrid(distanceMap);
-    return retval;
+    dungeongrid distanceMap = filledGrid(0);
+    calculateDistances(&distanceMap, x2, y2, blockingTerrainFlags, NULL, true, true);
+    return distanceMap.cells[x1][y1];
 }
 

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -25,12 +25,12 @@
 
 tcell tmap[DCOLS][DROWS];                       // grids with info about the map
 pcell pmap[DCOLS][DROWS];
-short **scentMap;
+dungeongrid *scentMap;
 cellDisplayBuffer displayBuffer[COLS][ROWS];    // used to optimize plotCharWithColor
 short terrainRandomValues[DCOLS][DROWS][8];
-short **safetyMap;                              // used to help monsters flee
-short **allySafetyMap;                          // used to help allies flee
-short **chokeMap;                               // used to assess the importance of the map's various chokepoints
+dungeongrid *safetyMap;                              // used to help monsters flee
+dungeongrid *allySafetyMap;                          // used to help allies flee
+dungeongrid *chokeMap;                               // used to assess the importance of the map's various chokepoints
 const short nbDirs[8][2] = {{0,-1}, {0,1}, {-1,0}, {1,0}, {-1,-1}, {-1,1}, {1,-1}, {1,1}};
 const short cDirs[8][2] = {{0, 1}, {1, 1}, {1, 0}, {1, -1}, {0, -1}, {-1, -1}, {-1, 0}, {-1, 1}};
 short numberOfWaypoints;

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -26,8 +26,14 @@
 
 
 // mallocing two-dimensional arrays! dun dun DUN!
-dungeongrid *allocGrid() {
-    return (dungeongrid *)calloc(1, sizeof(dungeongrid));
+dungeongrid *allocGrid(short initial) {
+    dungeongrid *grid = (dungeongrid *)calloc(1, sizeof(dungeongrid));
+    for (int i = 0; i < DCOLS; i++) {
+        for (int j = 0; j < DROWS; j++) {
+            grid->cells[i][j] = initial;
+        }
+    }
+    return grid;
 }
 
 void freeGrid(dungeongrid *array) {
@@ -319,12 +325,9 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
     }
 
     // Allocate the grids.
-    dungeongrid *grid = allocGrid();
-    dungeongrid *costMap = allocGrid();
-
+    dungeongrid *grid = allocGrid(30000);
     // Start with a base of a high number everywhere.
-    fillGrid(grid, 30000);
-    fillGrid(costMap, 1);
+    dungeongrid *costMap = allocGrid(1);
 
     // Block off the pathing blockers.
     getTerrainGrid(costMap, PDS_FORBIDDEN, blockingTerrainFlags, blockingMapFlags);
@@ -379,7 +382,7 @@ void cellularAutomataRound(dungeongrid *grid, char birthParameters[9], char surv
     enum directions dir;
     dungeongrid *buffer2;
 
-    buffer2 = allocGrid();
+    buffer2 = allocGrid(0);
     *buffer2 = *grid; // Make a backup of grid in buffer2, so that each generation is isolated.
 
     for(i=0; i<DCOLS; i++) {

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -40,13 +40,14 @@ void freeGrid(dungeongrid *array) {
     free(array);
 }
 
-
-void fillGrid(dungeongrid *grid, short fillValue) {
+dungeongrid filledGrid(short fillValue) {
+    dungeongrid grid;
     for(int i = 0; i < DCOLS; i++) {
         for(int j = 0; j < DROWS; j++) {
-            grid->cells[i][j] = fillValue;
+            grid.cells[i][j] = fillValue;
         }
     }
+    return grid;
 }
 
 // Highlight the portion indicated by hiliteCharGrid with the hiliteColor at the hiliteStrength -- both latter arguments are optional.
@@ -449,7 +450,7 @@ void createBlobOnGrid(dungeongrid *grid,
     // Generate blobs until they satisfy the minBlobWidth and minBlobHeight restraints
     do {
         // Clear buffer.
-        fillGrid(grid, 0);
+        *grid = filledGrid(0);
 
         // Fill relevant portion with noise based on the percentSeeded argument.
         for(i=0; i<maxBlobWidth; i++) {

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -151,7 +151,7 @@ void processSnapMap(dungeongrid *map) {
     dungeongrid *costMap = allocGrid(0);
 
     populateCreatureCostMap(costMap, &player);
-    fillGrid(map, 30000);
+    *map = filledGrid(30000);
     map->cells[player.xLoc][player.yLoc] = 0;
     dijkstraScan(map, costMap, true);
     for (i = 0; i < DCOLS; i++) {
@@ -615,7 +615,7 @@ void mainInputLoop() {
 
         populateCreatureCostMap(costMap, &player);
 
-        fillGrid(playerPathingMap, 30000);
+        *playerPathingMap = filledGrid(30000);
         playerPathingMap->cells[player.xLoc][player.yLoc] = 0;
         dijkstraScan(playerPathingMap, costMap, true);
         processSnapMap(cursorSnapMap);
@@ -642,7 +642,7 @@ void mainInputLoop() {
                         getClosestValidLocationOnMap(pathDestination, cursorSnapMap, cursor[0], cursor[1]);
                     }
 
-                    fillGrid(playerPathingMap, 30000);
+                    *playerPathingMap = filledGrid(30000);
                     playerPathingMap->cells[pathDestination[0]][pathDestination[1]] = 0;
                     backupCost = costMap->cells[pathDestination[0]][pathDestination[1]];
                     costMap->cells[pathDestination[0]][pathDestination[1]] = 1;

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -145,11 +145,10 @@ void getClosestValidLocationOnMap(short loc[2], dungeongrid *map, short x, short
 }
 
 void processSnapMap(dungeongrid *map) {
-    dungeongrid *costMap;
     enum directions dir;
     short i, j, newX, newY;
 
-    costMap = allocGrid();
+    dungeongrid *costMap = allocGrid(0);
 
     populateCreatureCostMap(costMap, &player);
     fillGrid(map, 30000);
@@ -576,9 +575,9 @@ void mainInputLoop() {
 
     playingBack = rogue.playbackMode;
     rogue.playbackMode = false;
-    dungeongrid *costMap = allocGrid();
-    dungeongrid *playerPathingMap = allocGrid();
-    dungeongrid *cursorSnapMap = allocGrid();
+    dungeongrid *costMap = allocGrid(0);
+    dungeongrid *playerPathingMap = allocGrid(0);
+    dungeongrid *cursorSnapMap = allocGrid(0);
 
     cursor[0] = cursor[1] = -1;
 
@@ -2137,8 +2136,7 @@ void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart
     assureCosmeticRNG;
 
     fastForward = false;
-    distanceMap = allocGrid();
-    fillGrid(distanceMap, 0);
+    distanceMap = allocGrid(0);
     calculateDistances(distanceMap, player.xLoc, player.yLoc, T_OBSTRUCTS_PASSABILITY, 0, true, true);
 
     for (i=0; i<COLS; i++) {
@@ -2349,7 +2347,7 @@ void exploreKey(const boolean controlKey) {
             x = finalX = player.xLoc;
             y = finalY = player.yLoc;
 
-            exploreMap = allocGrid();
+            exploreMap = allocGrid(0);
             getExploreMap(exploreMap, false);
             do {
                 dir = nextStep(exploreMap, x, y, NULL, false);

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -23,12 +23,12 @@
 
 extern tcell tmap[DCOLS][DROWS];                        // grids with info about the map
 extern pcell pmap[DCOLS][DROWS];                        // grids with info about the map
-extern short **scentMap;
+extern dungeongrid *scentMap;
 extern cellDisplayBuffer displayBuffer[COLS][ROWS];
 extern short terrainRandomValues[DCOLS][DROWS][8];
-extern short **safetyMap;                                       // used to help monsters flee
-extern short **allySafetyMap;
-extern short **chokeMap;
+extern dungeongrid *safetyMap;                                       // used to help monsters flee
+extern dungeongrid *allySafetyMap;
+extern dungeongrid *chokeMap;
 
 extern const short nbDirs[8][2];
 extern const short cDirs[8][2];

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -589,7 +589,7 @@ void populateItems(short upstairsX, short upstairsY) {
     }
 
     if (D_INSPECT_LEVELGEN) {
-        dungeongrid *map = allocGrid();
+        dungeongrid *map = allocGrid(0);
         for (i=0; i<DCOLS; i++) {
             for (j=0; j<DROWS; j++) {
                 map->cells[i][j] = itemSpawnHeatMap[i][j] * -1;
@@ -670,7 +670,7 @@ void populateItems(short upstairsX, short upstairsY) {
         brogueAssert(!cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY));
 
         if (D_INSPECT_LEVELGEN) {
-            dungeongrid *map = allocGrid();
+            dungeongrid *map = allocGrid(0);
             short i2, j2;
             for (i2=0; i2<DCOLS; i2++) {
                 for (j2=0; j2<DROWS; j2++) {
@@ -3242,8 +3242,7 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
     rogue.wpCoordinates[0][1] = y;
     refreshWaypoint(0);
 
-    dungeongrid *grid = allocGrid();
-    fillGrid(grid, 0);
+    dungeongrid *grid = allocGrid(0);
     calculateDistances(grid, x, y, T_PATHING_BLOCKER, NULL, true, false);
 
     for (monst=monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -589,15 +589,14 @@ void populateItems(short upstairsX, short upstairsY) {
     }
 
     if (D_INSPECT_LEVELGEN) {
-        dungeongrid *map = allocGrid(0);
+        dungeongrid map = filledGrid(0);
         for (i=0; i<DCOLS; i++) {
             for (j=0; j<DROWS; j++) {
-                map->cells[i][j] = itemSpawnHeatMap[i][j] * -1;
+                map.cells[i][j] = itemSpawnHeatMap[i][j] * -1;
             }
         }
         dumpLevelToScreen();
-        displayGrid(map);
-        freeGrid(map);
+        displayGrid(&map);
         temporaryMessage("Item spawn heat map:", REQUIRE_ACKNOWLEDGMENT);
     }
 
@@ -670,16 +669,15 @@ void populateItems(short upstairsX, short upstairsY) {
         brogueAssert(!cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY));
 
         if (D_INSPECT_LEVELGEN) {
-            dungeongrid *map = allocGrid(0);
+            dungeongrid map = filledGrid(0);
             short i2, j2;
             for (i2=0; i2<DCOLS; i2++) {
                 for (j2=0; j2<DROWS; j2++) {
-                    map->cells[i2][j2] = itemSpawnHeatMap[i2][j2] * -1;
+                    map.cells[i2][j2] = itemSpawnHeatMap[i2][j2] * -1;
                 }
             }
             dumpLevelToScreen();
-            displayGrid(map);
-            freeGrid(map);
+            displayGrid(&map);
             plotCharWithColor(theItem->displayChar, mapToWindowX(x), mapToWindowY(y), &black, &purple);
             temporaryMessage("Added an item.", REQUIRE_ACKNOWLEDGMENT);
         }
@@ -3242,11 +3240,11 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
     rogue.wpCoordinates[0][1] = y;
     refreshWaypoint(0);
 
-    dungeongrid *grid = allocGrid(0);
-    calculateDistances(grid, x, y, T_PATHING_BLOCKER, NULL, true, false);
+    dungeongrid grid = filledGrid(0);
+    calculateDistances(&grid, x, y, T_PATHING_BLOCKER, NULL, true, false);
 
     for (monst=monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
-        if (grid->cells[monst->xLoc][monst->yLoc] <= distance) {
+        if (grid.cells[monst->xLoc][monst->yLoc] <= distance) {
             if (monst->creatureState == MONSTER_SLEEPING) {
                 wakeUp(monst);
             }
@@ -3259,9 +3257,9 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
     }
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (grid->cells[i][j] >= 0 && grid->cells[i][j] <= distance) {
+            if (grid.cells[i][j] >= 0 && grid.cells[i][j] <= distance) {
                 scentMap->cells[i][j] = 0;
-                addScentToCell(i, j, 2 * grid->cells[i][j]);
+                addScentToCell(i, j, 2 * grid.cells[i][j]);
             }
         }
     }
@@ -3271,7 +3269,7 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
         rogue.aggroRange = currentAggroValue();
     }
 
-    if (grid->cells[player.xLoc][player.yLoc] >= 0 && grid->cells[player.xLoc][player.yLoc] <= distance) {
+    if (grid.cells[player.xLoc][player.yLoc] >= 0 && grid.cells[player.xLoc][player.yLoc] <= distance) {
         discover(x, y);
         discoverCell(x, y);
         colorFlash(flashColor, 0, (DISCOVERED | MAGIC_MAPPED), 10, distance, x, y);
@@ -3279,8 +3277,6 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
             message("You hear a piercing shriek; something must have triggered a nearby alarm.", 0);
         }
     }
-
-    freeGrid(grid);
 }
 
 // Generates a list of coordinates extending in a straight line

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -589,10 +589,10 @@ void populateItems(short upstairsX, short upstairsY) {
     }
 
     if (D_INSPECT_LEVELGEN) {
-        short **map = allocGrid();
+        dungeongrid *map = allocGrid();
         for (i=0; i<DCOLS; i++) {
             for (j=0; j<DROWS; j++) {
-                map[i][j] = itemSpawnHeatMap[i][j] * -1;
+                map->cells[i][j] = itemSpawnHeatMap[i][j] * -1;
             }
         }
         dumpLevelToScreen();
@@ -670,11 +670,11 @@ void populateItems(short upstairsX, short upstairsY) {
         brogueAssert(!cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY));
 
         if (D_INSPECT_LEVELGEN) {
-            short **map = allocGrid();
+            dungeongrid *map = allocGrid();
             short i2, j2;
             for (i2=0; i2<DCOLS; i2++) {
                 for (j2=0; j2<DROWS; j2++) {
-                    map[i2][j2] = itemSpawnHeatMap[i2][j2] * -1;
+                    map->cells[i2][j2] = itemSpawnHeatMap[i2][j2] * -1;
                 }
             }
             dumpLevelToScreen();
@@ -3236,18 +3236,18 @@ item *keyOnTileAt(short x, short y) {
 // Aggroes out to the given distance.
 void aggravateMonsters(short distance, short x, short y, const color *flashColor) {
     creature *monst;
-    short i, j, **grid;
+    short i, j;
 
     rogue.wpCoordinates[0][0] = x;
     rogue.wpCoordinates[0][1] = y;
     refreshWaypoint(0);
 
-    grid = allocGrid();
+    dungeongrid *grid = allocGrid();
     fillGrid(grid, 0);
     calculateDistances(grid, x, y, T_PATHING_BLOCKER, NULL, true, false);
 
     for (monst=monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
-        if (grid[monst->xLoc][monst->yLoc] <= distance) {
+        if (grid->cells[monst->xLoc][monst->yLoc] <= distance) {
             if (monst->creatureState == MONSTER_SLEEPING) {
                 wakeUp(monst);
             }
@@ -3260,9 +3260,9 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
     }
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (grid[i][j] >= 0 && grid[i][j] <= distance) {
-                scentMap[i][j] = 0;
-                addScentToCell(i, j, 2 * grid[i][j]);
+            if (grid->cells[i][j] >= 0 && grid->cells[i][j] <= distance) {
+                scentMap->cells[i][j] = 0;
+                addScentToCell(i, j, 2 * grid->cells[i][j]);
             }
         }
     }
@@ -3272,7 +3272,7 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
         rogue.aggroRange = currentAggroValue();
     }
 
-    if (grid[player.xLoc][player.yLoc] >= 0 && grid[player.xLoc][player.yLoc] <= distance) {
+    if (grid->cells[player.xLoc][player.yLoc] >= 0 && grid->cells[player.xLoc][player.yLoc] <= distance) {
         discover(x, y);
         discoverCell(x, y);
         colorFlash(flashColor, 0, (DISCOVERED | MAGIC_MAPPED), 10, distance, x, y);

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -856,8 +856,7 @@ creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFla
     }
 
     if (BROGUE_VERSION_ATLEAST(1,9,3) && (theHorde->flags & HORDE_MACHINE_THIEF)) {
-        leader->safetyMap = allocGrid(); // Keep thieves from fleeing before they see the player
-        fillGrid(leader->safetyMap, 0);
+        leader->safetyMap = allocGrid(0); // Keep thieves from fleeing before they see the player
     }
 
     preexistingMonst = monsterAtLoc(x, y);
@@ -931,8 +930,7 @@ boolean summonMinions(creature *summoner) {
     if (hordeCatalog[hordeID].flags & HORDE_SUMMONED_AT_DISTANCE) {
         // Create a grid where "1" denotes a valid summoning location: within DCOLS/2 pathing distance,
         // not in harmful terrain, and outside of the player's field of view.
-        grid = allocGrid();
-        fillGrid(grid, 0);
+        grid = allocGrid(0);
         calculateDistances(grid, summoner->xLoc, summoner->yLoc, (T_PATHING_BLOCKER | T_SACRED), NULL, true, true);
         findReplaceGrid(grid, 1, DCOLS/2, 1);
         findReplaceGrid(grid, 2, 30000, 0);
@@ -1024,8 +1022,7 @@ void populateMonsters() {
 boolean getRandomMonsterSpawnLocation(short *x, short *y) {
     dungeongrid *grid;
 
-    grid = allocGrid();
-    fillGrid(grid, 0);
+    grid = allocGrid(0);
     calculateDistances(grid, player.xLoc, player.yLoc, T_DIVIDES_LEVEL, NULL, true, true);
     getTerrainGrid(grid, 0, (T_PATHING_BLOCKER | T_HARMFUL_TERRAIN), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS | IN_FIELD_OF_VIEW));
     findReplaceGrid(grid, -30000, DCOLS/2-1, 0);
@@ -1087,8 +1084,7 @@ void teleport(creature *monst, short x, short y, boolean respectTerrainAvoidance
     if (!coordinatesAreInMap(x, y)) {
         zeroOutGrid(monstFOV);
         getFOVMask(monstFOV, monst->xLoc, monst->yLoc, DCOLS * FP_FACTOR, T_OBSTRUCTS_VISION, 0, false);
-        dungeongrid *grid = allocGrid();
-        fillGrid(grid, 0);
+        dungeongrid *grid = allocGrid(0);
         calculateDistances(grid, monst->xLoc, monst->yLoc, forbiddenFlagsForMonster(&(monst->info)) & T_DIVIDES_LEVEL, NULL, true, false);
         findReplaceGrid(grid, -30000, DCOLS/2, 0);
         findReplaceGrid(grid, 2, 30000, 1);
@@ -2023,8 +2019,7 @@ void pathTowardCreature(creature *monst, creature *target) {
 
     // is the target missing his map altogether?
     if (!target->mapToMe) {
-        target->mapToMe = allocGrid();
-        fillGrid(target->mapToMe, 0);
+        target->mapToMe = allocGrid(0);
         calculateDistances(target->mapToMe, target->xLoc, target->yLoc, 0, monst, true, false);
     }
 
@@ -2299,7 +2294,7 @@ static dungeongrid *getSafetyMap(creature *monst) {
             if (!rogue.updatedSafetyMapThisTurn) {
                 updateSafetyMap();
             }
-            monst->safetyMap = allocGrid();
+            monst->safetyMap = allocGrid(0);
             *monst->safetyMap = *safetyMap;
         }
         return monst->safetyMap;
@@ -2976,8 +2971,8 @@ void moveAlly(creature *monst) {
         if (monsterHasBoltEffect(monst, BE_BLINKING)
             && ((monst->info.flags & MONST_ALWAYS_USE_ABILITY) || rand_percent(30))) {
 
-            dungeongrid *enemyMap = allocGrid();
-            dungeongrid *costMap = allocGrid();
+            dungeongrid *enemyMap = allocGrid(0);
+            dungeongrid *costMap = allocGrid(0);
 
             for (i=0; i<DCOLS; i++) {
                 for (j=0; j<DROWS; j++) {

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1030,7 +1030,7 @@ boolean getRandomMonsterSpawnLocation(short *x, short *y) {
     findReplaceGrid(grid, DCOLS/2, 30000-1, 1);
     randomLocationInGrid(grid, x, y, 1);
     if (*x < 0 || *y < 0) {
-        fillGrid(grid, 1);
+        *grid = filledGrid(1);
         getTerrainGrid(grid, 0, (T_PATHING_BLOCKER | T_HARMFUL_TERRAIN), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS | IN_FIELD_OF_VIEW | IS_IN_MACHINE));
         randomLocationInGrid(grid, x, y, 1);
     }
@@ -1089,11 +1089,11 @@ void teleport(creature *monst, short x, short y, boolean respectTerrainAvoidance
         findReplaceGrid(grid, -30000, DCOLS/2, 0);
         findReplaceGrid(grid, 2, 30000, 1);
         if (validLocationCount(grid, 1) < 1) {
-            fillGrid(grid, 1);
+            *grid = filledGrid(1);
         }
         if (respectTerrainAvoidancePreferences) {
             if (monst->info.flags & MONST_RESTRICTED_TO_LIQUID) {
-                fillGrid(grid, 0);
+                *grid = filledGrid(0);
                 getTMGrid(grid, 1, TM_ALLOWS_SUBMERGING);
             }
             getTerrainGrid(grid, 0, avoidedFlagsForMonster(&(monst->info)), (IS_IN_MACHINE | HAS_PLAYER | HAS_MONSTER | HAS_STAIRS));

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1766,7 +1766,7 @@ void populateCreatureCostMap(dungeongrid *costMap, creature *monst) {
             if ((tFlags & T_LAVA_INSTA_DEATH)
                 && !(monst->info.flags & (MONST_IMMUNE_TO_FIRE | MONST_FLIES | MONST_INVULNERABLE))
                 && (monst->status[STATUS_LEVITATING] || monst->status[STATUS_IMMUNE_TO_FIRE])
-                && max(monst->status[STATUS_LEVITATING], monst->status[STATUS_IMMUNE_TO_FIRE]) < (rogue.mapToShore->cells[i][j] + distanceBetween(i, j, monst->xLoc, monst->yLoc) * monst->movementSpeed / 100)) {
+                && max(monst->status[STATUS_LEVITATING], monst->status[STATUS_IMMUNE_TO_FIRE]) < (rogue.mapToShore.cells[i][j] + distanceBetween(i, j, monst->xLoc, monst->yLoc) * monst->movementSpeed / 100)) {
                 // Only a temporary effect will permit the monster to survive the lava, and the remaining duration either isn't
                 // enough to get it to the spot, or it won't suffice to let it return to shore if it does get there.
                 // Treat these locations as obstacles.
@@ -1777,7 +1777,7 @@ void populateCreatureCostMap(dungeongrid *costMap, creature *monst) {
             if (((tFlags & T_AUTO_DESCENT) || (tFlags & T_IS_DEEP_WATER) && !(monst->info.flags & MONST_IMMUNE_TO_WATER))
                 && !(monst->info.flags & MONST_FLIES)
                 && (monst->status[STATUS_LEVITATING])
-                && monst->status[STATUS_LEVITATING] < (rogue.mapToShore->cells[i][j] + distanceBetween(i, j, monst->xLoc, monst->yLoc) * monst->movementSpeed / 100)) {
+                && monst->status[STATUS_LEVITATING] < (rogue.mapToShore.cells[i][j] + distanceBetween(i, j, monst->xLoc, monst->yLoc) * monst->movementSpeed / 100)) {
                 // Only a temporary effect will permit the monster to levitate over the chasm/water, and the remaining duration either isn't
                 // enough to get it to the spot, or it won't suffice to let it return to shore if it does get there.
                 // Treat these locations as obstacles.

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1643,7 +1643,7 @@ void travel(short x, short y, boolean autoConfirm) {
         return;
     }
 
-    dungeongrid *distanceMap = allocGrid();
+    dungeongrid *distanceMap = allocGrid(0);
 
     calculateDistances(distanceMap, x, y, 0, &player, false, false);
     if (distanceMap->cells[player.xLoc][player.yLoc] < 30000) {
@@ -1862,7 +1862,7 @@ void getExploreMap(dungeongrid *map, boolean headingToStairs) {// calculate expl
     short i, j;
     item *theItem;
 
-    dungeongrid *costMap = allocGrid();
+    dungeongrid *costMap = allocGrid(0);
     populateCreatureCostMap(costMap, &player);
 
     for (i=0; i<DCOLS; i++) {
@@ -1957,7 +1957,7 @@ boolean explore(short frameDelay) {
     rogue.disturbed = false;
     rogue.automationActive = true;
 
-    distanceMap = allocGrid();
+    distanceMap = allocGrid(0);
     do {
         // fight any adjacent enemies
         dir = adjacentFightingDir();

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3095,8 +3095,8 @@ extern "C" {
 
     // Grid operations
     dungeongrid *allocGrid(short initial);
+    dungeongrid filledGrid(short initial);
     void freeGrid(dungeongrid *array);
-    void fillGrid(dungeongrid *grid, short fillValue);
     void hiliteGrid(dungeongrid *grid, color *hiliteColor, short hiliteStrength);
     void findReplaceGrid(dungeongrid *grid, short findValueMin, short findValueMax, short fillValue);
     short floodFillGrid(dungeongrid *grid, short x, short y, short eligibleValueMin, short eligibleValueMax, short fillValue);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3094,7 +3094,7 @@ extern "C" {
                                      boolean deterministic);
 
     // Grid operations
-    dungeongrid *allocGrid();
+    dungeongrid *allocGrid(short initial);
     void freeGrid(dungeongrid *array);
     void fillGrid(dungeongrid *grid, short fillValue);
     void hiliteGrid(dungeongrid *grid, color *hiliteColor, short hiliteStrength);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2149,6 +2149,10 @@ typedef struct monsterClass {
     enum monsterTypes memberList[15];
 } monsterClass;
 
+typedef struct dungeongrid {
+    short cells[DCOLS][DROWS];
+} dungeongrid;
+
 typedef struct creature {
     creatureType info;
     short xLoc;
@@ -2177,8 +2181,8 @@ typedef struct creature {
     short absorptionBolt;               // bolt index that the monster will learn to cast when absorption is complete
     short corpseAbsorptionCounter;      // used to measure both the time until the monster stops being interested in the corpse,
                                         // and, later, the time until the monster finishes absorbing the corpse.
-    short **mapToMe;                    // if a pack leader, this is a periodically updated pathing map to get to the leader
-    short **safetyMap;                  // fleeing monsters store their own safety map when out of player FOV to avoid omniscience
+    dungeongrid *mapToMe;                    // if a pack leader, this is a periodically updated pathing map to get to the leader
+    dungeongrid *safetyMap;                  // fleeing monsters store their own safety map when out of player FOV to avoid omniscience
     short ticksUntilTurn;               // how long before the creature gets its next move
 
     // Locally cached statistics that may be temporarily modified:
@@ -2305,8 +2309,8 @@ typedef struct playerCharacter {
     short sidebarLocationList[ROWS*2][2];   // to keep track of which location each line of the sidebar references
 
     // maps
-    short **mapToShore;                 // how many steps to get back to shore
-    short **mapToSafeTerrain;           // so monsters can get to safety
+    dungeongrid *mapToShore;                 // how many steps to get back to shore
+    dungeongrid *mapToSafeTerrain;           // so monsters can get to safety
 
     // recording info
     boolean recording;                  // whether we are recording the game
@@ -2348,7 +2352,7 @@ typedef struct playerCharacter {
     boolean featRecord[FEAT_COUNT];
 
     // waypoints:
-    short **wpDistance[MAX_WAYPOINT_COUNT];
+    dungeongrid *wpDistance[MAX_WAYPOINT_COUNT];
     short wpCount;
     short wpCoordinates[MAX_WAYPOINT_COUNT][2];
     short wpRefreshTicker;
@@ -2370,7 +2374,7 @@ typedef struct levelData {
     struct item *items;
     struct creature *monsters;
     struct creature *dormantMonsters;
-    short **scentMap;
+    dungeongrid *scentMap;
     uint64_t levelSeed;
     short upStairsLoc[2];
     short downStairsLoc[2];
@@ -2649,6 +2653,7 @@ extern boolean serverMode;
 extern boolean hasGraphics;
 extern enum graphicsModes graphicsMode;
 
+
 #if defined __cplusplus
 extern "C" {
 #endif
@@ -2689,7 +2694,7 @@ extern "C" {
     void normColor(color *baseColor, const short aggregateMultiplier, const short colorTranslation);
     void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *returnForeColor, color *returnBackColor);
     void logBuffer(char array[DCOLS][DROWS]);
-    //void logBuffer(short **array);
+    //void logBuffer(dungeongrid *array);
     boolean search(short searchStrength);
     boolean proposeOrConfirmLocation(short x, short y, char *failureMessage);
     boolean useStairs(short stairDirection);
@@ -2701,7 +2706,7 @@ extern "C" {
                           item *adoptiveItem,
                           item *parentSpawnedItems[50],
                           creature *parentSpawnedMonsters[50]);
-    void attachRooms(short **grid, const dungeonProfile *theDP, short attempts, short maxRoomCount);
+    void attachRooms(dungeongrid *grid, const dungeonProfile *theDP, short attempts, short maxRoomCount);
     void digDungeon();
     void updateMapToShore();
     short levelIsDisconnectedWithBlockingMap(char blockingMap[DCOLS][DROWS], boolean countRegionSize);
@@ -2713,7 +2718,7 @@ extern "C" {
                          boolean refresh,
                          boolean superpriority);
     boolean spawnDungeonFeature(short x, short y, dungeonFeature *feat, boolean refreshCell, boolean abortIfBlocking);
-    void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit);
+    void restoreMonster(creature *monst, dungeongrid *mapToStairs, dungeongrid *mapToPit);
     void restoreItem(item *theItem);
     void refreshWaypoint(short wpIndex);
     void setUpWaypoints();
@@ -2742,7 +2747,7 @@ extern "C" {
     void printHelpScreen();
     void printDiscoveriesScreen();
     void printHighScores(boolean hiliteMostRecent);
-    void displayGrid(short **map);
+    void displayGrid(dungeongrid *map);
     void printSeed();
     void printProgressBar(short x, short y, const char barLabel[COLS], long amtFilled, long amtMax, color *fillColor, boolean dim);
     short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight);
@@ -2847,25 +2852,25 @@ extern "C" {
     boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *aborted);
     boolean diagonalBlocked(const short x1, const short y1, const short x2, const short y2, const boolean limitToPlayerKnowledge);
     boolean playerMoves(short direction);
-    void calculateDistances(short **distanceMap,
+    void calculateDistances(dungeongrid *distanceMap,
                             short destinationX, short destinationY,
                             unsigned long blockingTerrainFlags,
                             creature *traveler,
                             boolean canUseSecretDoors,
                             boolean eightWays);
     short pathingDistance(short x1, short y1, short x2, short y2, unsigned long blockingTerrainFlags);
-    short nextStep(short **distanceMap, short x, short y, creature *monst, boolean reverseDirections);
+    short nextStep(dungeongrid *distanceMap, short x, short y, creature *monst, boolean reverseDirections);
     void travelRoute(short path[1000][2], short steps);
     void travel(short x, short y, boolean autoConfirm);
-    void populateGenericCostMap(short **costMap);
+    void populateGenericCostMap(dungeongrid *costMap);
     void getLocationFlags(const short x, const short y,
                           unsigned long *tFlags, unsigned long *TMFlags, unsigned long *cellFlags,
                           const boolean limitToPlayerKnowledge);
-    void populateCreatureCostMap(short **costMap, creature *monst);
+    void populateCreatureCostMap(dungeongrid *costMap, creature *monst);
     enum directions adjacentFightingDir();
-    void getExploreMap(short **map, boolean headingToStairs);
+    void getExploreMap(dungeongrid *map, boolean headingToStairs);
     boolean explore(short frameDelay);
-    short getPlayerPathOnMap(short path[1000][2], short **map, short originX, short originY);
+    short getPlayerPathOnMap(short path[1000][2], dungeongrid *map, short originX, short originY);
     void reversePath(short path[1000][2], short steps);
     void hilitePath(short path[1000][2], short steps, boolean unhilite);
     void clearCursorPath();
@@ -2953,7 +2958,7 @@ extern "C" {
     creature *monsterAtLoc(short x, short y);
     creature *dormantMonsterAtLoc(short x, short y);
     void perimeterCoords(short returnCoords[2], short n);
-    boolean monsterBlinkToPreferenceMap(creature *monst, short **preferenceMap, boolean blinkUphill);
+    boolean monsterBlinkToPreferenceMap(creature *monst, dungeongrid *preferenceMap, boolean blinkUphill);
     boolean monsterSummons(creature *monst, boolean alwaysUse);
     boolean resurrectAlly(const short x, const short y);
     void unAlly(creature *monst);
@@ -3089,19 +3094,18 @@ extern "C" {
                                      boolean deterministic);
 
     // Grid operations
-    short **allocGrid();
-    void freeGrid(short **array);
-    void copyGrid(short **to, short **from);
-    void fillGrid(short **grid, short fillValue);
-    void hiliteGrid(short **grid, color *hiliteColor, short hiliteStrength);
-    void findReplaceGrid(short **grid, short findValueMin, short findValueMax, short fillValue);
-    short floodFillGrid(short **grid, short x, short y, short eligibleValueMin, short eligibleValueMax, short fillValue);
-    void drawRectangleOnGrid(short **grid, short x, short y, short width, short height, short value);
-    void drawCircleOnGrid(short **grid, short x, short y, short radius, short value);
-    void getTerrainGrid(short **grid, short value, unsigned long terrainFlags, unsigned long mapFlags);
-    void getTMGrid(short **grid, short value, unsigned long TMflags);
-    short validLocationCount(short **grid, short validValue);
-    void randomLocationInGrid(short **grid, short *x, short *y, short validValue);
+    dungeongrid *allocGrid();
+    void freeGrid(dungeongrid *array);
+    void fillGrid(dungeongrid *grid, short fillValue);
+    void hiliteGrid(dungeongrid *grid, color *hiliteColor, short hiliteStrength);
+    void findReplaceGrid(dungeongrid *grid, short findValueMin, short findValueMax, short fillValue);
+    short floodFillGrid(dungeongrid *grid, short x, short y, short eligibleValueMin, short eligibleValueMax, short fillValue);
+    void drawRectangleOnGrid(dungeongrid *grid, short x, short y, short width, short height, short value);
+    void drawCircleOnGrid(dungeongrid *grid, short x, short y, short radius, short value);
+    void getTerrainGrid(dungeongrid *grid, short value, unsigned long terrainFlags, unsigned long mapFlags);
+    void getTMGrid(dungeongrid *grid, short value, unsigned long TMflags);
+    short validLocationCount(dungeongrid *grid, short validValue);
+    void randomLocationInGrid(dungeongrid *grid, short *x, short *y, short validValue);
     boolean getQualifyingPathLocNear(short *retValX, short *retValY,
                                      short x, short y,
                                      boolean hallwaysAllowed,
@@ -3110,7 +3114,7 @@ extern "C" {
                                      unsigned long forbiddenTerrainFlags,
                                      unsigned long forbiddenMapFlags,
                                      boolean deterministic);
-    void createBlobOnGrid(short **grid,
+    void createBlobOnGrid(dungeongrid *grid,
                           short *retMinX, short *retMinY, short *retWidth, short *retHeight,
                           short roundCount,
                           short minBlobWidth, short minBlobHeight,
@@ -3271,10 +3275,10 @@ extern "C" {
                           short winHeight,
                           rogueEvent *returnEvent);
 
-    void dijkstraScan(short **distanceMap, short **costMap, boolean useDiagonals);
+    void dijkstraScan(dungeongrid *distanceMap, dungeongrid *costMap, boolean useDiagonals);
     void pdsClear(pdsMap *map, short maxDistance, boolean eightWays);
     void pdsSetDistance(pdsMap *map, short x, short y, short distance);
-    void pdsBatchOutput(pdsMap *map, short **distanceMap);
+    void pdsBatchOutput(pdsMap *map, dungeongrid *distanceMap);
 
 #if defined __cplusplus
 }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2309,8 +2309,8 @@ typedef struct playerCharacter {
     short sidebarLocationList[ROWS*2][2];   // to keep track of which location each line of the sidebar references
 
     // maps
-    dungeongrid *mapToShore;                 // how many steps to get back to shore
-    dungeongrid *mapToSafeTerrain;           // so monsters can get to safety
+    dungeongrid mapToShore;                 // how many steps to get back to shore
+    dungeongrid mapToSafeTerrain;           // so monsters can get to safety
 
     // recording info
     boolean recording;                  // whether we are recording the game
@@ -2374,7 +2374,7 @@ typedef struct levelData {
     struct item *items;
     struct creature *monsters;
     struct creature *dormantMonsters;
-    dungeongrid *scentMap;
+    dungeongrid scentMap;
     uint64_t levelSeed;
     short upStairsLoc[2];
     short downStairsLoc[2];

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -531,10 +531,9 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                 }
             }
         }
-        dungeongrid *mapToStairs = allocGrid(0);
         for (flying = 0; flying <= 1; flying++) {
-            *mapToStairs = filledGrid(0);
-            calculateDistances(mapToStairs, px, py, (flying ? T_OBSTRUCTS_PASSABILITY : T_PATHING_BLOCKER) | T_SACRED, NULL, true, true);
+            dungeongrid mapToStairs = filledGrid(0);
+            calculateDistances(&mapToStairs, px, py, (flying ? T_OBSTRUCTS_PASSABILITY : T_PATHING_BLOCKER) | T_SACRED, NULL, true, true);
             for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
                 x = monst->xLoc;
                 y = monst->yLoc;
@@ -549,9 +548,9 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                     && !(cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY))
                     && !monst->status[STATUS_ENTRANCED]
                     && !monst->status[STATUS_PARALYZED]
-                    && (mapToStairs->cells[monst->xLoc][monst->yLoc] < 30000 || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)) {
+                    && (mapToStairs.cells[monst->xLoc][monst->yLoc] < 30000 || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)) {
 
-                    monst->status[STATUS_ENTERS_LEVEL_IN] = clamp(mapToStairs->cells[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100 + 1, 1, 150);
+                    monst->status[STATUS_ENTERS_LEVEL_IN] = clamp(mapToStairs.cells[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100 + 1, 1, 150);
                     switch (stairDirection) {
                         case 1:
                             monst->bookkeepingFlags |= MB_APPROACHING_DOWNSTAIRS;
@@ -568,7 +567,6 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                 }
             }
         }
-        freeGrid(mapToStairs);
     }
 
     for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
@@ -827,16 +825,14 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     }
 
     if (levels[rogue.depthLevel - 1].visited) {
-        dungeongrid *mapToStairs = allocGrid(0);
-        dungeongrid *mapToPit = allocGrid(0);
-        calculateDistances(mapToStairs, player.xLoc, player.yLoc, T_PATHING_BLOCKER, NULL, true, true);
-        calculateDistances(mapToPit, levels[rogue.depthLevel-1].playerExitedVia[0],
+        dungeongrid mapToStairs = filledGrid(0);
+        calculateDistances(&mapToStairs, player.xLoc, player.yLoc, T_PATHING_BLOCKER, NULL, true, true);
+        dungeongrid mapToPit = filledGrid(0);
+        calculateDistances(&mapToPit, levels[rogue.depthLevel-1].playerExitedVia[0],
                            levels[rogue.depthLevel-1].playerExitedVia[1], T_PATHING_BLOCKER, NULL, true, true);
         for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
-            restoreMonster(monst, mapToStairs, mapToPit);
+            restoreMonster(monst, &mapToStairs, &mapToPit);
         }
-        freeGrid(mapToStairs);
-        freeGrid(mapToPit);
     }
 
     updateMapToShore();

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -504,8 +504,6 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     creature *monst;
     enum dungeonLayers layer;
     unsigned long timeAway;
-    short **mapToStairs;
-    short **mapToPit;
     boolean connectingStairsDiscovered;
 
     if (oldLevelNumber == DEEPEST_LEVEL && stairDirection != -1) {
@@ -540,7 +538,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                 }
             }
         }
-        mapToStairs = allocGrid();
+        dungeongrid *mapToStairs = allocGrid();
         fillGrid(mapToStairs, 0);
         for (flying = 0; flying <= 1; flying++) {
             fillGrid(mapToStairs, 0);
@@ -559,9 +557,9 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                     && !(cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY))
                     && !monst->status[STATUS_ENTRANCED]
                     && !monst->status[STATUS_PARALYZED]
-                    && (mapToStairs[monst->xLoc][monst->yLoc] < 30000 || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)) {
+                    && (mapToStairs->cells[monst->xLoc][monst->yLoc] < 30000 || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)) {
 
-                    monst->status[STATUS_ENTERS_LEVEL_IN] = clamp(mapToStairs[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100 + 1, 1, 150);
+                    monst->status[STATUS_ENTERS_LEVEL_IN] = clamp(mapToStairs->cells[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100 + 1, 1, 150);
                     switch (stairDirection) {
                         case 1:
                             monst->bookkeepingFlags |= MB_APPROACHING_DOWNSTAIRS;
@@ -838,8 +836,8 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     }
 
     if (levels[rogue.depthLevel - 1].visited) {
-        mapToStairs = allocGrid();
-        mapToPit = allocGrid();
+        dungeongrid *mapToStairs = allocGrid();
+        dungeongrid *mapToPit = allocGrid();
         fillGrid(mapToStairs, 0);
         fillGrid(mapToPit, 0);
         calculateDistances(mapToStairs, player.xLoc, player.yLoc, T_PATHING_BLOCKER, NULL, true, true);
@@ -874,7 +872,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     hideCursor();
 }
 
-void freeGlobalDynamicGrid(short ***grid) {
+void freeGlobalDynamicGrid(dungeongrid **grid) {
     if (*grid) {
         freeGrid(*grid);
         *grid = NULL;

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -222,8 +222,7 @@ void initializeRogue(uint64_t seed) {
 
     // initialize the waypoints list
     for (i=0; i<MAX_WAYPOINT_COUNT; i++) {
-        rogue.wpDistance[i] = allocGrid();
-        fillGrid(rogue.wpDistance[i], 0);
+        rogue.wpDistance[i] = allocGrid(0);
     }
 
     rogue.rewardRoomsGenerated = 0;
@@ -295,17 +294,11 @@ void initializeRogue(uint64_t seed) {
     purgatory->nextCreature = NULL;
 
     scentMap            = NULL;
-    safetyMap           = allocGrid();
-    allySafetyMap       = allocGrid();
-    chokeMap            = allocGrid();
+    safetyMap           = allocGrid(0);
+    allySafetyMap       = allocGrid(0);
+    chokeMap            = allocGrid(0);
 
-    rogue.mapToSafeTerrain = allocGrid();
-
-    // Zero out the dynamic grids, as an essential safeguard against OOSes:
-    fillGrid(safetyMap, 0);
-    fillGrid(allySafetyMap, 0);
-    fillGrid(chokeMap, 0);
-    fillGrid(rogue.mapToSafeTerrain, 0);
+    rogue.mapToSafeTerrain = allocGrid(0);
 
     // initialize the player
 
@@ -538,8 +531,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                 }
             }
         }
-        dungeongrid *mapToStairs = allocGrid();
-        fillGrid(mapToStairs, 0);
+        dungeongrid *mapToStairs = allocGrid(0);
         for (flying = 0; flying <= 1; flying++) {
             fillGrid(mapToStairs, 0);
             calculateDistances(mapToStairs, px, py, (flying ? T_OBSTRUCTS_PASSABILITY : T_PATHING_BLOCKER) | T_SACRED, NULL, true, true);
@@ -629,9 +621,8 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     updateRingBonuses(); // also updates miner's light
 
     if (!levels[rogue.depthLevel - 1].visited) { // level has not already been visited
-        levels[rogue.depthLevel - 1].scentMap = allocGrid();
+        levels[rogue.depthLevel - 1].scentMap = allocGrid(0);
         scentMap = levels[rogue.depthLevel - 1].scentMap;
-        fillGrid(levels[rogue.depthLevel - 1].scentMap, 0);
 
         // generate a seed from the current RNG state
         do {
@@ -836,10 +827,8 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     }
 
     if (levels[rogue.depthLevel - 1].visited) {
-        dungeongrid *mapToStairs = allocGrid();
-        dungeongrid *mapToPit = allocGrid();
-        fillGrid(mapToStairs, 0);
-        fillGrid(mapToPit, 0);
+        dungeongrid *mapToStairs = allocGrid(0);
+        dungeongrid *mapToPit = allocGrid(0);
         calculateDistances(mapToStairs, player.xLoc, player.yLoc, T_PATHING_BLOCKER, NULL, true, true);
         calculateDistances(mapToPit, levels[rogue.depthLevel-1].playerExitedVia[0],
                            levels[rogue.depthLevel-1].playerExitedVia[1], T_PATHING_BLOCKER, NULL, true, true);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -533,7 +533,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
         }
         dungeongrid *mapToStairs = allocGrid(0);
         for (flying = 0; flying <= 1; flying++) {
-            fillGrid(mapToStairs, 0);
+            *mapToStairs = filledGrid(0);
             calculateDistances(mapToStairs, px, py, (flying ? T_OBSTRUCTS_PASSABILITY : T_PATHING_BLOCKER) | T_SACRED, NULL, true, true);
             for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
                 x = monst->xLoc;

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1733,12 +1733,12 @@ void updateSafeTerrainMap() {
                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
 
                 costMap.cells[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
-                rogue.mapToSafeTerrain->cells[i][j] = 30000; // OOS prophylactic
+                rogue.mapToSafeTerrain.cells[i][j] = 30000; // OOS prophylactic
             } else if ((monst && (monst->turnsSpentStationary > 1 || (monst->info.flags & MONST_GETS_TURN_ON_ACTIVATION)))
                        || (cellHasTerrainFlag(i, j, T_PATHING_BLOCKER & ~T_HARMFUL_TERRAIN) && !cellHasTMFlag(i, j, TM_IS_SECRET))) {
 
                 costMap.cells[i][j] = PDS_FORBIDDEN;
-                rogue.mapToSafeTerrain->cells[i][j] = 30000;
+                rogue.mapToSafeTerrain.cells[i][j] = 30000;
             } else if (cellHasTerrainFlag(i, j, T_HARMFUL_TERRAIN) || pmap[i][j].layers[DUNGEON] == DOOR) {
                 // The door thing is an aesthetically offensive but necessary hack to make sure
                 // that monsters trying to find their way out of caustic gas do not sprint for
@@ -1747,14 +1747,14 @@ void updateSafeTerrainMap() {
                 // allies will fidget back and forth in a doorway while they asphyxiate.
                 // This will have to do. It's a difficult problem to solve elegantly.
                 costMap.cells[i][j] = 1;
-                rogue.mapToSafeTerrain->cells[i][j] = 30000;
+                rogue.mapToSafeTerrain.cells[i][j] = 30000;
             } else {
                 costMap.cells[i][j] = 1;
-                rogue.mapToSafeTerrain->cells[i][j] = 0;
+                rogue.mapToSafeTerrain.cells[i][j] = 0;
             }
         }
     }
-    dijkstraScan(rogue.mapToSafeTerrain, &costMap, false);
+    dijkstraScan(&rogue.mapToSafeTerrain, &costMap, false);
 }
 
 void processIncrementalAutoID() {
@@ -2582,7 +2582,7 @@ void playerTurnEnded() {
     if ((player.status[STATUS_LEVITATING] && cellHasTerrainFlag(player.xLoc, player.yLoc, T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT))
         || (player.status[STATUS_IMMUNE_TO_FIRE] && cellHasTerrainFlag(player.xLoc, player.yLoc, T_LAVA_INSTA_DEATH))) {
         if (!rogue.receivedLevitationWarning) {
-            turnsRequiredToShore = rogue.mapToShore->cells[player.xLoc][player.yLoc] * player.movementSpeed / 100;
+            turnsRequiredToShore = rogue.mapToShore.cells[player.xLoc][player.yLoc] * player.movementSpeed / 100;
             if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_LAVA_INSTA_DEATH)) {
                 turnsToShore = max(player.status[STATUS_LEVITATING], player.status[STATUS_IMMUNE_TO_FIRE]) * 100 / player.movementSpeed;
             } else {
@@ -2619,10 +2619,10 @@ void resetScentTurnNumber() { // don't want player.scentTurnNumber to roll over 
         if (levels[d].visited) {
             for (i=0; i<DCOLS; i++) {
                 for (j=0; j<DROWS; j++) {
-                    if (levels[d].scentMap->cells[i][j] > 15000) {
-                        levels[d].scentMap->cells[i][j] -= 15000;
+                    if (levels[d].scentMap.cells[i][j] > 15000) {
+                        levels[d].scentMap.cells[i][j] -= 15000;
                     } else {
-                        levels[d].scentMap->cells[i][j] = 0;
+                        levels[d].scentMap.cells[i][j] = 0;
                     }
                 }
             }

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1521,8 +1521,8 @@ void updateAllySafetyMap() {
 
     rogue.updatedAllySafetyMapThisTurn = true;
 
-    dungeongrid *playerCostMap = allocGrid();
-    dungeongrid *monsterCostMap = allocGrid();
+    dungeongrid *playerCostMap = allocGrid(0);
+    dungeongrid *monsterCostMap = allocGrid(0);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
@@ -1597,8 +1597,8 @@ void updateSafetyMap() {
 
     rogue.updatedSafetyMapThisTurn = true;
 
-    dungeongrid *playerCostMap = allocGrid();
-    dungeongrid *monsterCostMap = allocGrid();
+    dungeongrid *playerCostMap = allocGrid(0);
+    dungeongrid *monsterCostMap = allocGrid(0);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
@@ -1729,7 +1729,7 @@ void updateSafeTerrainMap() {
     creature *monst;
 
     rogue.updatedMapToSafeTerrainThisTurn = true;
-    dungeongrid *costMap = allocGrid();
+    dungeongrid *costMap = allocGrid(0);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1521,40 +1521,40 @@ void updateAllySafetyMap() {
 
     rogue.updatedAllySafetyMapThisTurn = true;
 
-    dungeongrid *playerCostMap = allocGrid(0);
-    dungeongrid *monsterCostMap = allocGrid(0);
+    dungeongrid playerCostMap = filledGrid(0);
+    dungeongrid monsterCostMap = filledGrid(0);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             allySafetyMap->cells[i][j] = 30000;
 
-            playerCostMap->cells[i][j] = monsterCostMap->cells[i][j] = 1;
+            playerCostMap.cells[i][j] = monsterCostMap.cells[i][j] = 1;
 
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
 
-                playerCostMap->cells[i][j] = monsterCostMap->cells[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+                playerCostMap.cells[i][j] = monsterCostMap.cells[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag(i, j, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
-                playerCostMap->cells[i][j] = monsterCostMap->cells[i][j] = PDS_FORBIDDEN;
+                playerCostMap.cells[i][j] = monsterCostMap.cells[i][j] = PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag(i, j, T_SACRED)) {
-                playerCostMap->cells[i][j] = 1;
-                monsterCostMap->cells[i][j] = PDS_FORBIDDEN;
+                playerCostMap.cells[i][j] = 1;
+                monsterCostMap.cells[i][j] = PDS_FORBIDDEN;
             } else if ((pmap[i][j].flags & HAS_MONSTER) && monstersAreEnemies(&player, monsterAtLoc(i, j))) {
-                playerCostMap->cells[i][j] = 1;
-                monsterCostMap->cells[i][j] = PDS_FORBIDDEN;
+                playerCostMap.cells[i][j] = 1;
+                monsterCostMap.cells[i][j] = PDS_FORBIDDEN;
                 allySafetyMap->cells[i][j] = 0;
             }
         }
     }
 
-    playerCostMap->cells[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
-    monsterCostMap->cells[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
+    playerCostMap.cells[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
+    monsterCostMap.cells[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
 
-    dijkstraScan(allySafetyMap, playerCostMap, false);
+    dijkstraScan(allySafetyMap, &playerCostMap, false);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (monsterCostMap->cells[i][j] < 0) {
+            if (monsterCostMap.cells[i][j] < 0) {
                 continue;
             }
 
@@ -1571,10 +1571,7 @@ void updateAllySafetyMap() {
             }
         }
     }
-    dijkstraScan(allySafetyMap, monsterCostMap, false);
-
-    freeGrid(playerCostMap);
-    freeGrid(monsterCostMap);
+    dijkstraScan(allySafetyMap, &monsterCostMap, false);
 }
 
 void resetDistanceCellInGrid(dungeongrid *grid, short x, short y) {
@@ -1597,28 +1594,28 @@ void updateSafetyMap() {
 
     rogue.updatedSafetyMapThisTurn = true;
 
-    dungeongrid *playerCostMap = allocGrid(0);
-    dungeongrid *monsterCostMap = allocGrid(0);
+    dungeongrid playerCostMap = filledGrid(0);
+    dungeongrid monsterCostMap = filledGrid(0);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             safetyMap->cells[i][j] = 30000;
 
-            playerCostMap->cells[i][j] = monsterCostMap->cells[i][j] = 1; // prophylactic
+            playerCostMap.cells[i][j] = monsterCostMap.cells[i][j] = 1; // prophylactic
 
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
 
-                playerCostMap->cells[i][j] = monsterCostMap->cells[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+                playerCostMap.cells[i][j] = monsterCostMap.cells[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag(i, j, T_SACRED)) {
-                playerCostMap->cells[i][j] = 1;
-                monsterCostMap->cells[i][j] = PDS_FORBIDDEN;
+                playerCostMap.cells[i][j] = 1;
+                monsterCostMap.cells[i][j] = PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag(i, j, T_LAVA_INSTA_DEATH)) {
-                monsterCostMap->cells[i][j] = PDS_FORBIDDEN;
+                monsterCostMap.cells[i][j] = PDS_FORBIDDEN;
                 if (player.status[STATUS_LEVITATING] || !player.status[STATUS_IMMUNE_TO_FIRE]) {
-                    playerCostMap->cells[i][j] = 1;
+                    playerCostMap.cells[i][j] = 1;
                 } else {
-                    playerCostMap->cells[i][j] = PDS_FORBIDDEN;
+                    playerCostMap.cells[i][j] = PDS_FORBIDDEN;
                 }
             } else {
                 if (pmap[i][j].flags & HAS_MONSTER) {
@@ -1629,56 +1626,56 @@ void updateSafetyMap() {
                          || monst->creatureState == MONSTER_ALLY)
                         && monst->creatureState != MONSTER_FLEEING) {
 
-                        playerCostMap->cells[i][j] = 1;
-                        monsterCostMap->cells[i][j] = PDS_FORBIDDEN;
+                        playerCostMap.cells[i][j] = 1;
+                        monsterCostMap.cells[i][j] = PDS_FORBIDDEN;
                         continue;
                     }
                 }
 
                 if (cellHasTerrainFlag(i, j, (T_AUTO_DESCENT | T_IS_DF_TRAP))) {
-                    monsterCostMap->cells[i][j] = PDS_FORBIDDEN;
+                    monsterCostMap.cells[i][j] = PDS_FORBIDDEN;
                     if (player.status[STATUS_LEVITATING]) {
-                        playerCostMap->cells[i][j] = 1;
+                        playerCostMap.cells[i][j] = 1;
                     } else {
-                        playerCostMap->cells[i][j] = PDS_FORBIDDEN;
+                        playerCostMap.cells[i][j] = PDS_FORBIDDEN;
                     }
                 } else if (cellHasTerrainFlag(i, j, T_IS_FIRE)) {
-                    monsterCostMap->cells[i][j] = PDS_FORBIDDEN;
+                    monsterCostMap.cells[i][j] = PDS_FORBIDDEN;
                     if (player.status[STATUS_IMMUNE_TO_FIRE]) {
-                        playerCostMap->cells[i][j] = 1;
+                        playerCostMap.cells[i][j] = 1;
                     } else {
-                        playerCostMap->cells[i][j] = PDS_FORBIDDEN;
+                        playerCostMap.cells[i][j] = PDS_FORBIDDEN;
                     }
                 } else if (cellHasTerrainFlag(i, j, (T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES))) {
                     if (player.status[STATUS_LEVITATING]) {
-                        playerCostMap->cells[i][j] = 1;
+                        playerCostMap.cells[i][j] = 1;
                     } else {
-                        playerCostMap->cells[i][j] = 5;
+                        playerCostMap.cells[i][j] = 5;
                     }
-                    monsterCostMap->cells[i][j] = 5;
+                    monsterCostMap.cells[i][j] = 5;
                 } else if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
                            && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY)
                            && !(pmap[i][j].flags & IN_FIELD_OF_VIEW)) {
                     // Secret door that the player can't currently see
-                    playerCostMap->cells[i][j] = 100;
-                    monsterCostMap->cells[i][j] = 1;
+                    playerCostMap.cells[i][j] = 100;
+                    monsterCostMap.cells[i][j] = 1;
                 } else {
-                    playerCostMap->cells[i][j] = monsterCostMap->cells[i][j] = 1;
+                    playerCostMap.cells[i][j] = monsterCostMap.cells[i][j] = 1;
                 }
             }
         }
     }
 
     safetyMap->cells[player.xLoc][player.yLoc] = 0;
-    playerCostMap->cells[player.xLoc][player.yLoc] = 1;
-    monsterCostMap->cells[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
+    playerCostMap.cells[player.xLoc][player.yLoc] = 1;
+    monsterCostMap.cells[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
 
-    playerCostMap->cells[rogue.upLoc[0]][rogue.upLoc[1]] = PDS_FORBIDDEN;
-    monsterCostMap->cells[rogue.upLoc[0]][rogue.upLoc[1]] = PDS_FORBIDDEN;
-    playerCostMap->cells[rogue.downLoc[0]][rogue.downLoc[1]] = PDS_FORBIDDEN;
-    monsterCostMap->cells[rogue.downLoc[0]][rogue.downLoc[1]] = PDS_FORBIDDEN;
+    playerCostMap.cells[rogue.upLoc[0]][rogue.upLoc[1]] = PDS_FORBIDDEN;
+    monsterCostMap.cells[rogue.upLoc[0]][rogue.upLoc[1]] = PDS_FORBIDDEN;
+    playerCostMap.cells[rogue.downLoc[0]][rogue.downLoc[1]] = PDS_FORBIDDEN;
+    monsterCostMap.cells[rogue.downLoc[0]][rogue.downLoc[1]] = PDS_FORBIDDEN;
 
-    dijkstraScan(safetyMap, playerCostMap, false);
+    dijkstraScan(safetyMap, &playerCostMap, false);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
@@ -1695,7 +1692,7 @@ void updateSafetyMap() {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (monsterCostMap->cells[i][j] < 0) {
+            if (monsterCostMap.cells[i][j] < 0) {
                 continue;
             }
 
@@ -1712,16 +1709,14 @@ void updateSafetyMap() {
             }
         }
     }
-    dijkstraScan(safetyMap, monsterCostMap, false);
+    dijkstraScan(safetyMap, &monsterCostMap, false);
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (monsterCostMap->cells[i][j] < 0) {
+            if (monsterCostMap.cells[i][j] < 0) {
                 safetyMap->cells[i][j] = 30000;
             }
         }
     }
-    freeGrid(playerCostMap);
-    freeGrid(monsterCostMap);
 }
 
 void updateSafeTerrainMap() {
@@ -1729,7 +1724,7 @@ void updateSafeTerrainMap() {
     creature *monst;
 
     rogue.updatedMapToSafeTerrainThisTurn = true;
-    dungeongrid *costMap = allocGrid(0);
+    dungeongrid costMap = filledGrid(0);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
@@ -1737,12 +1732,12 @@ void updateSafeTerrainMap() {
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
 
-                costMap->cells[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+                costMap.cells[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                 rogue.mapToSafeTerrain->cells[i][j] = 30000; // OOS prophylactic
             } else if ((monst && (monst->turnsSpentStationary > 1 || (monst->info.flags & MONST_GETS_TURN_ON_ACTIVATION)))
                        || (cellHasTerrainFlag(i, j, T_PATHING_BLOCKER & ~T_HARMFUL_TERRAIN) && !cellHasTMFlag(i, j, TM_IS_SECRET))) {
 
-                costMap->cells[i][j] = PDS_FORBIDDEN;
+                costMap.cells[i][j] = PDS_FORBIDDEN;
                 rogue.mapToSafeTerrain->cells[i][j] = 30000;
             } else if (cellHasTerrainFlag(i, j, T_HARMFUL_TERRAIN) || pmap[i][j].layers[DUNGEON] == DOOR) {
                 // The door thing is an aesthetically offensive but necessary hack to make sure
@@ -1751,16 +1746,15 @@ void updateSafeTerrainMap() {
                 // gas will fill their tile, so they are not actually safe. Without this fix,
                 // allies will fidget back and forth in a doorway while they asphyxiate.
                 // This will have to do. It's a difficult problem to solve elegantly.
-                costMap->cells[i][j] = 1;
+                costMap.cells[i][j] = 1;
                 rogue.mapToSafeTerrain->cells[i][j] = 30000;
             } else {
-                costMap->cells[i][j] = 1;
+                costMap.cells[i][j] = 1;
                 rogue.mapToSafeTerrain->cells[i][j] = 0;
             }
         }
     }
-    dijkstraScan(rogue.mapToSafeTerrain, costMap, false);
-    freeGrid(costMap);
+    dijkstraScan(rogue.mapToSafeTerrain, &costMap, false);
 }
 
 void processIncrementalAutoID() {


### PR DESCRIPTION
This creates a new

```c
typedef struct dungeongrid {
    short cells[DCOLS][DROWS];
} dungeongrid;
```

which replaces essentially all of `short**` arrays that are passed around in various places.

A typical change looks like the difference between

```c
// OLD
short **grid = allocGrid();
fillGrid(grid, 0);
dijkstraMap(grid, cost);
return grid[x][y];
```

```c
// NEW
dungeongrid grid = filledGrid(0);
dijkstraMap(&grid, cost);
return grid.cells[x][y];
```

---

In C, arrays behave slightly strangely: when a variable is declared with array type, as in `int arr[]`, expressions `arr` are "really" more like `&arr` - they are essentially rvalues which is why you can't assign an array variable, even though you can assign any other type of variable.

Putting an array into a struct fixes this inconsistency; *structs* are plain values, even if they happen to include arrays. So `dungeongrid` is just a value like any `int` or `short` or `boolean`, albeit taking up a lot more space on the stack (around 4KB).

In particular, the main benefit of this style is almost never needing to `allocGrid`, since they can just sit on the stack, be returned from functions, etc., without needing to worry about calling `freeGrid` appropriately.

Several places in the codebase "reused" a buffer to avoid needing to allocate/deallocate it multiple times, but this led to code that was (slightly) more involved, since it was unclear exactly how/whether the grid was _really_ being reused. Now, there's no problem - just declaring it as a local inside the (e.g.) loop where it's used handled everything that's needed.

One downside is needing to write `grid.cells[x][y]` or `grid->cells[x][y]` instead of just `grid[x][y]` depending on how it's used, though this aspect of the change is very mechanical and has basically no wide-reaching effects. 

---

One possible risk of this approach is blowing out the function call stack - although 2KB memory is not _that_ much (the function call stack is usually at least 1MB at least on modern systems) this may end up limiting the function call depth excessively, especially if a recursive function happened to (say, accidentally) declare a `dungeongrid` local variable.

I don't think this risk is _too_ great but it's worth considering, especially if targeting very-constrained devices is important.

Keep in mind that the _total_ memory used is the same; the difference is that memory formerly placed on the heap is now placed on the stack.

C has no "standard" ABI, so compilers are free to do reasonable things, like choose a calling convention for a `dungeongrid makeGrid(int v)` to really be more like `void makeGrid(dungeongrid* dest, int v)`, which should avoid much of the possible overhead.

---

I think it's possible to take this approach and improve it just a bit more, by rewriting some functions to just return `dungeongrid` values, instead of taking out-parameters.

One example is `dijkstraMap`, which goes like

```c
dungeongrid pathMap = filledGrid(30000);
pathMap.cells[newX][newY] = 0;
dijkstraScan(&pathMap, &costMap, false);
```

this is what _most_ (but not all) uses look like. They could probably be made clearer with a helper like

```c
dungeongrid pathMap = dijkstraPathFrom(newX, newY, &costMap, false);
```

---

I left a few calls to `allocGrid` behind. These were used in globals, or places where the memory footprint would genuinely be increased if switching to a "flat" value structure - namely inside `struct creature`.

