### PR TITLE
Fix infinite loop involving exposeTileToFire

### DIFF
--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1263,6 +1263,7 @@ typedef struct pcell {                              // permanent cell; have to r
     unsigned long rememberedCellFlags;              // map cell flags the player remembers from that spot
     unsigned long rememberedTerrainFlags;           // terrain flags the player remembers from that spot
     unsigned long rememberedTMFlags;                // TM flags the player remembers from that spot
+    short exposedToFire;                            // number of times the tile has been exposed to fire since the last environment update
 } pcell;
 
 typedef struct tcell {          // transient cell; stuff we don't need to remember between levels

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1132,9 +1132,11 @@ boolean exposeTileToFire(short x, short y, boolean alwaysIgnite) {
     enum directions dir;
     boolean fireIgnited = false, explosivePromotion = false;
 
-    if (!cellHasTerrainFlag(x, y, T_IS_FLAMMABLE)) {
+    if (!cellHasTerrainFlag(x, y, T_IS_FLAMMABLE) || pmap[x][y].exposedToFire >= 12) {
         return false;
     }
+
+    pmap[x][y].exposedToFire++;
 
     // Pick the extinguishing layer with the best priority.
     for (layer=0; layer < NUMBER_TERRAIN_LAYERS; layer++) {
@@ -1404,6 +1406,13 @@ void updateEnvironment() {
     boolean isVolumetricGas = false;
 
     monstersFall();
+
+    // reset exposedToFire
+    for (i=0; i<DCOLS; i++) {
+        for (j=0; j<DROWS; j++) {
+            pmap[i][j].exposedToFire = 0;
+        }
+    }
 
     // update gases twice
     for (i=0; i<DCOLS && !isVolumetricGas; i++) {


### PR DESCRIPTION
In most games, tiles are normally exposed to fire up to 5 times per environment update. In rare circumstances (shooting a firebolt into a fire?) it can go up to 6 times. But it never goes higher than that... except when a bug causes an infinite loop involving `promoteTile()` and `exposeTileToFire()`, in which case the same tile can be exposed to fire over a thousand times, until Brogue runs out of stack space and crashes.

This commit limits `exposeTileToFire()` to 12 calls per tile per environment update. This fixes #341, without causing OOS errors on games unaffected by the bug. Tested on 10 victories and 10 ascensions from WebBrogue.