### PR TITLE
Take game recording feature out of beta

### DIFF
--- a/changes/game-recording-considered-stable.md
+++ b/changes/game-recording-considered-stable.md
@@ -1,0 +1,1 @@
+After fixing the known remaining out-of-sync errors, game saving and recording playback are now considered stable.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2670,7 +2670,7 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             if (rogue.playbackMode || serverMode) {
                 return;
             }
-            if (confirm("Suspend this game? (This feature is still in beta.)", false)) {
+            if (confirm("Suspend this game?", false)) {
                 saveGame();
             }
             break;

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -295,7 +295,7 @@ unsigned long recallNumber(short numberOfBytes) {
 
 #define OOS_APOLOGY "Playback of the recording has diverged from the originally recorded game.\n\n\
 This could be caused by recording or playing the file on a modified version of Brogue, or it could \
-simply be the result of a bug.  (The recording feature is still in beta for this reason.)\n\n\
+simply be the result of a bug.\n\n\
 If this is a different computer from the one on which the recording was saved, the recording \
 might succeed on the original computer."
 


### PR DESCRIPTION
We have now fixed all reload/playback errors that still existed in 1.9.3, namely:

- OOS due to secret door revealed by monster during auto-explore,
- OOS on the last turn of a recording missing the last keystroke.

Ignoring the possibility that 1.10 will introduce new sources of OOS errors that we are not yet aware of, now is a good time to declare the recording feature stable.