### PR TITLE
Auto-kinking improvements

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3383,11 +3383,13 @@ short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2],
             boolean burningThrough = (theBolt->flags & BF_FIERY) && cellHasTerrainFlag(x, y, T_IS_FLAMMABLE);
             boolean isCastByPlayer = (originLoc[0] == player.xLoc && originLoc[1] == player.yLoc);
 
+            creature *caster = monsterAtLoc(originLoc[0], originLoc[1]);
             creature *monst = monsterAtLoc(x, y);
             boolean isMonster = monst
                 && !(monst->bookkeepingFlags & MB_SUBMERGED)
-                && !monsterIsHidden(monst, monsterAtLoc(originLoc[0], originLoc[1]));
-            boolean isAllyOfCaster = ((monst && monst->creatureState == MONSTER_ALLY) == isCastByPlayer);
+                && !monsterIsHidden(monst, caster);
+            boolean isEnemyOfCaster = (monst && caster && monstersAreEnemies(monst, caster));
+            boolean isAllyOfCaster = (monst && caster && monstersAreTeammates(monst, caster));
 
             // small bonus for making it this far
             score += 2;
@@ -3396,7 +3398,7 @@ short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2],
             if (x == targetLoc[0] && y == targetLoc[1]) {
 
                 if ((!targetsEnemies && !targetsAllies) ||
-                    (targetsEnemies && isMonster && !isAllyOfCaster) ||
+                    (targetsEnemies && isMonster && isEnemyOfCaster) ||
                     (targetsAllies && isMonster && isAllyOfCaster)) {
 
                     // big bonus for hitting the target
@@ -3422,7 +3424,7 @@ short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2],
 
             // hitting a creature with a bolt meant for enemies
             if (isMonster && targetsEnemies) {
-                score += !isAllyOfCaster ? 50 : -200;
+                score += isEnemyOfCaster ? 50 : -200;
             }
 
             // hitting a creature with a bolt meant for allies

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4762,7 +4762,7 @@ boolean zap(short originLoc[2], short targetLoc[2], bolt *theBolt, boolean hideD
     y = originLoc[1];
 
     initialBoltLength = boltLength = 5 * theBolt->magnitude;
-    numCells = getLineCoordinates(listOfCoordinates, originLoc, targetLoc, (hideDetails ? NULL : theBolt));
+    numCells = getLineCoordinates(listOfCoordinates, originLoc, targetLoc, (hideDetails ? &boltCatalog[BOLT_NONE] : theBolt));
     shootingMonst = monsterAtLoc(originLoc[0], originLoc[1]);
 
     if (hideDetails) {
@@ -6271,7 +6271,7 @@ boolean useStaffOrWand(item *theItem, boolean *commandsRecorded) {
     originLoc[0] = player.xLoc;
     originLoc[1] = player.yLoc;
     confirmedTarget = chooseTarget(zapTarget, maxDistance, false, autoTarget,
-        targetAllies, (boltKnown ? &theBolt : NULL), &trajectoryHiliteColor);
+        targetAllies, (boltKnown ? &theBolt : &boltCatalog[BOLT_NONE]), &trajectoryHiliteColor);
     if (confirmedTarget
         && boltKnown
         && theBolt.boltEffect == BE_BLINKING


### PR DESCRIPTION
Fix ally casting: The condition that checked whether the creature on a bolt's trajectory is on the same side as the bolt's caster didn't work when the caster is an ally of the player. In that case it gave a positive bonus for hitting the creature, instead of a negative one. The issue was that if the bolt was not cast by the player, then it was assumed to be cast by an enemy of the player.

Auto-kink unknown bolts: Until a wand or staff is identified, we need to hide whether it targets allies or enemies. We were achieving it by disabling the auto-kinking, but it would be more convenient for the user that we treat it like a throw and do our best effort to reach the target cell.

Fixes the issues reported by @zenzombie on `playtesting` Discord channel.