### PR TITLE
Funky fade now only keeps most recent message

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2204,7 +2204,7 @@ void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart
 
                 foreColor = (invert ? white : black);
 
-                if (j < MESSAGE_LINES
+                if (j == (MESSAGE_LINES - 1)
                     && i >= mapToWindowX(0)
                     && i < mapToWindowX(strLenWithoutEscapes(displayedMessage[MESSAGE_LINES - j - 1]))) {
                     tempChar = displayedMessage[MESSAGE_LINES - j - 1][windowToMapX(i)];

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1137,7 +1137,6 @@ void victory(boolean superVictory) {
     //
     // First screen - Congratulations...
     //
-    deleteMessages();
     if (superVictory) {
         message(    "Light streams through the portal, and you are teleported out of the dungeon.", 0);
         copyDisplayBuffer(dbuf, displayBuffer);


### PR DESCRIPTION
The end game screens call
* `deleteMessages()`
* `message("I say good show")` and
* `funkyFade()`

..with the expectation that the final congratulatory message is only one visible in the message display (due to `deleteMessages()`) while the funky fade runs.

However, `message()` now redraws the entire message display area (for message collapsing) instead of simply inserting a new line at the bottom.  This makes the `deleteMessages()` calls ineffectual, and we see older message appearing again in the display.  Since they might have color code sequences, which funky fade does not understand, we see garbled output.

This change causes `funkyFade()` to ignore all displayed lines except the last one, enforcing the assumption it appears to be making.  It also drops the superfluous `deleteMessages()` call.