### PR TITLE
Compiler enforces string-format security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include config.mk
 
 cflags := -Isrc/brogue -Isrc/platform -std=c99 \
-	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-unused-result -Wno-format
+	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-unused-result -Wno-format -Werror=format-security
 libs := -lm
 cppflags := -DDATADIR=$(DATADIR)
 

--- a/src/brogue/SeedCatalog.c
+++ b/src/brogue/SeedCatalog.c
@@ -70,7 +70,7 @@ static void printSeedCatalogItem(item *theItem, creature *theMonster, boolean is
 
     if (theMonster != NULL) {   //carried by monster
         if (isCsvFormat) {
-            sprintf(carriedByMonsterName, theMonster->info.monsterName);
+            sprintf(carriedByMonsterName, "%s", theMonster->info.monsterName);
             strcpy(mutationName, theMonster->mutationIndex >= 0 ? mutationCatalog[theMonster->mutationIndex].title : "");
         } else {
             getMonsterDetailedName(theMonster, carriedByMonsterName);


### PR DESCRIPTION
On Arch, the default `$CFLAGS` when building user-packages includes ` -Werror=format-security`, which causes builds to fail. 

There is only one line that needs a trivial fix, and I also added the compiler flag to the defaults.  

This seems like a pretty straight-forward, and non-controversial change, but I've only tested it on my setup so LMK if there are any issues you have =]