### PR TITLE
Fix conversion from long long to int causing truncation.

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3350,7 +3350,7 @@ short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2],
         }
 
         // normalize the step, to move exactly one row or column at a time
-        fixpt m = max(abs(step[0]), abs(step[1]));
+        fixpt m = max(llabs(step[0]), llabs(step[1]));
         step[0] = step[0] * FP_FACTOR / m;
         step[1] = step[1] * FP_FACTOR / m;
 


### PR DESCRIPTION
I fixed the issue by using `llabs()` instead of `abs()` following the suggestion given by the compiler but maybe you do not want to use C99 standard (`llabs` is available since C99 only).

The warning I got was:
```
src/brogue/Items.c:3353:23: warning: absolute value function 'abs' given an argument of type 'fixpt' (aka 'long long') but has parameter of type 'int' which may cause truncation of value
      [-Wabsolute-value]
        fixpt m = max(abs(step[0]), abs(step[1]));
                      ^
src/brogue/Items.c:3353:23: note: use function 'llabs' instead
        fixpt m = max(abs(step[0]), abs(step[1]));
                      ^~~
                      llabs
```