### PR TITLE
Refactoring: Great `pos`itioning - add a `pos` struct type, and use it in most places

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -185,7 +185,7 @@ void splitMonster(creature *monst, short x, short y) {
     }
 
     // Find the contiguous group of monsters.
-    addMonsterToContiguousMonsterGrid(monst->xLoc, monst->yLoc, monst, monsterGrid);
+    addMonsterToContiguousMonsterGrid(monst->loc.x, monst->loc.y, monst, monsterGrid);
 
     // Find the eligible edges around the group of monsters.
     for (i=0; i<DCOLS; i++) {
@@ -246,8 +246,8 @@ void splitMonster(creature *monst, short x, short y) {
                         clone->status[STATUS_LEVITATING] = 0;
                     }
 
-                    clone->xLoc = i;
-                    clone->yLoc = j;
+                    clone->loc.x = i;
+                    clone->loc.y = j;
                     pmap[i][j].flags |= HAS_MONSTER;
                     clone->ticksUntilTurn = max(clone->ticksUntilTurn, 101);
                     fadeInMonster(clone);
@@ -346,8 +346,8 @@ void moralAttack(creature *attacker, creature *defender) {
         }
 
         if ((defender->info.abilityFlags & MA_CLONE_SELF_ON_DEFEND) && alliedCloneCount(defender) < 100) {
-            if (distanceBetween(defender->xLoc, defender->yLoc, attacker->xLoc, attacker->yLoc) <= 1) {
-                splitMonster(defender, attacker->xLoc, attacker->yLoc);
+            if (distanceBetween(defender->loc.x, defender->loc.y, attacker->loc.x, attacker->loc.y) <= 1) {
+                splitMonster(defender, attacker->loc.x, attacker->loc.y);
             } else {
                 splitMonster(defender, 0, 0);
             }
@@ -492,10 +492,10 @@ boolean forceWeaponHit(creature *defender, item *theItem) {
 
     monsterName(monstName, defender, true);
 
-    oldLoc[0] = defender->xLoc;
-    oldLoc[1] = defender->yLoc;
-    newLoc[0] = defender->xLoc + clamp(defender->xLoc - player.xLoc, -1, 1);
-    newLoc[1] = defender->yLoc + clamp(defender->yLoc - player.yLoc, -1, 1);
+    oldLoc[0] = defender->loc.x;
+    oldLoc[1] = defender->loc.y;
+    newLoc[0] = defender->loc.x + clamp(defender->loc.x - player.loc.x, -1, 1);
+    newLoc[1] = defender->loc.y + clamp(defender->loc.y - player.loc.y, -1, 1);
     if (canDirectlySeeMonster(defender)
         && !cellHasTerrainFlag(newLoc[0], newLoc[1], T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION)
         && !(pmap[newLoc[0]][newLoc[1]].flags & (HAS_MONSTER | HAS_PLAYER))) {
@@ -508,18 +508,18 @@ boolean forceWeaponHit(creature *defender, item *theItem) {
     theBolt.magnitude = max(1, netEnchant(theItem) / FP_FACTOR);
     zap(oldLoc, newLoc, &theBolt, false);
     if (!(defender->bookkeepingFlags & MB_IS_DYING)
-        && distanceBetween(oldLoc[0], oldLoc[1], defender->xLoc, defender->yLoc) > 0
-        && distanceBetween(oldLoc[0], oldLoc[1], defender->xLoc, defender->yLoc) < weaponForceDistance(netEnchant(theItem))) {
+        && distanceBetween(oldLoc[0], oldLoc[1], defender->loc.x, defender->loc.y) > 0
+        && distanceBetween(oldLoc[0], oldLoc[1], defender->loc.x, defender->loc.y) < weaponForceDistance(netEnchant(theItem))) {
 
-        if (pmap[defender->xLoc + newLoc[0] - oldLoc[0]][defender->yLoc + newLoc[1] - oldLoc[1]].flags & (HAS_MONSTER | HAS_PLAYER)) {
-            otherMonster = monsterAtLoc(defender->xLoc + newLoc[0] - oldLoc[0], defender->yLoc + newLoc[1] - oldLoc[1]);
+        if (pmap[defender->loc.x + newLoc[0] - oldLoc[0]][defender->loc.y + newLoc[1] - oldLoc[1]].flags & (HAS_MONSTER | HAS_PLAYER)) {
+            otherMonster = monsterAtLoc(defender->loc.x + newLoc[0] - oldLoc[0], defender->loc.y + newLoc[1] - oldLoc[1]);
             monsterName(buf2, otherMonster, true);
         } else {
             otherMonster = NULL;
-            strcpy(buf2, tileCatalog[pmap[defender->xLoc + newLoc[0] - oldLoc[0]][defender->yLoc + newLoc[1] - oldLoc[1]].layers[highestPriorityLayer(defender->xLoc + newLoc[0] - oldLoc[0], defender->yLoc + newLoc[1] - oldLoc[1], true)]].description);
+            strcpy(buf2, tileCatalog[pmap[defender->loc.x + newLoc[0] - oldLoc[0]][defender->loc.y + newLoc[1] - oldLoc[1]].layers[highestPriorityLayer(defender->loc.x + newLoc[0] - oldLoc[0], defender->loc.y + newLoc[1] - oldLoc[1], true)]].description);
         }
 
-        forceDamage = distanceBetween(oldLoc[0], oldLoc[1], defender->xLoc, defender->yLoc);
+        forceDamage = distanceBetween(oldLoc[0], oldLoc[1], defender->loc.x, defender->loc.y);
 
         if (!(defender->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))
             && inflictDamage(NULL, defender, forceDamage, &white, false)) {
@@ -607,13 +607,13 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
         if (!(defender->bookkeepingFlags & MB_SUBMERGED)) {
             switch (enchantType) {
                 case W_SPEED:
-                    createFlare(player.xLoc, player.yLoc, SCROLL_ENCHANTMENT_LIGHT);
+                    createFlare(player.loc.x, player.loc.y, SCROLL_ENCHANTMENT_LIGHT);
                     break;
                 case W_QUIETUS:
-                    createFlare(defender->xLoc, defender->yLoc, QUIETUS_FLARE_LIGHT);
+                    createFlare(defender->loc.x, defender->loc.y, QUIETUS_FLARE_LIGHT);
                     break;
                 case W_SLAYING:
-                    createFlare(defender->xLoc, defender->yLoc, SLAYING_FLARE_LIGHT);
+                    createFlare(defender->loc.x, defender->loc.y, SLAYING_FLARE_LIGHT);
                     break;
                 default:
                     flashMonster(defender, effectColors[enchantType], 100);
@@ -665,7 +665,7 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
 
                 for (i = 0; i < (weaponImageCount(enchant)); i++) {
                     newMonst = generateMonster(MK_SPECTRAL_IMAGE, true, false);
-                    getQualifyingPathLocNear(&(newMonst->xLoc), &(newMonst->yLoc), defender->xLoc, defender->yLoc, true,
+                    getQualifyingPathLocNear(&(newMonst->loc.x), &(newMonst->loc.y), defender->loc.x, defender->loc.y, true,
                                              T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                              avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                     newMonst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER | MB_TELEPATHICALLY_REVEALED);
@@ -713,7 +713,7 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
                                 break;
                         }
                     }
-                    pmap[newMonst->xLoc][newMonst->yLoc].flags |= HAS_MONSTER;
+                    pmap[newMonst->loc.x][newMonst->loc.y].flags |= HAS_MONSTER;
                     fadeInMonster(newMonst);
                 }
                 updateVision(true);
@@ -859,8 +859,8 @@ void applyArmorRunicEffect(char returnString[DCOLS], creature *attacker, short *
                 for (i=0; i<8; i++) {
                     hitList[i] = NULL;
                     dir = i % 8;
-                    newX = player.xLoc + nbDirs[dir][0];
-                    newY = player.yLoc + nbDirs[dir][1];
+                    newX = player.loc.x + nbDirs[dir][0];
+                    newY = player.loc.y + nbDirs[dir][1];
                     if (coordinatesAreInMap(newX, newY) && (pmap[newX][newY].flags & HAS_MONSTER)) {
                         monst = monsterAtLoc(newX, newY);
                         if (monst
@@ -948,7 +948,7 @@ void applyArmorRunicEffect(char returnString[DCOLS], creature *attacker, short *
                 sprintf(returnString, "flames suddenly explode out of your %s!", armorName);
                 message(returnString, runicKnown ? 0 : REQUIRE_ACKNOWLEDGMENT);
                 returnString[0] = '\0';
-                spawnDungeonFeature(player.xLoc, player.yLoc, &(dungeonFeatureCatalog[DF_ARMOR_IMMOLATION]), true, false);
+                spawnDungeonFeature(player.loc.x, player.loc.y, &(dungeonFeatureCatalog[DF_ARMOR_IMMOLATION]), true, false);
                 runicDiscovered = true;
             }
         default:
@@ -979,12 +979,12 @@ void decrementWeaponAutoIDTimer() {
 void processStaggerHit(creature *attacker, creature *defender) {
     if ((defender->info.flags & (MONST_INVULNERABLE | MONST_IMMOBILE | MONST_INANIMATE))
         || (defender->bookkeepingFlags & MB_CAPTIVE)
-        || cellHasTerrainFlag(defender->xLoc, defender->yLoc, T_OBSTRUCTS_PASSABILITY)) {
+        || cellHasTerrainFlag(defender->loc.x, defender->loc.y, T_OBSTRUCTS_PASSABILITY)) {
 
         return;
     }
-    short newX = clamp(defender->xLoc - attacker->xLoc, -1, 1) + defender->xLoc;
-    short newY = clamp(defender->yLoc - attacker->yLoc, -1, 1) + defender->yLoc;
+    short newX = clamp(defender->loc.x - attacker->loc.x, -1, 1) + defender->loc.x;
+    short newY = clamp(defender->loc.y - attacker->loc.y, -1, 1) + defender->loc.y;
     if (coordinatesAreInMap(newX, newY)
         && !cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY)
         && !(pmap[newX][newY].flags & (HAS_MONSTER | HAS_PLAYER))) {
@@ -1054,8 +1054,8 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
 
     if ((attacker->info.abilityFlags & MA_SEIZES)
         && (!(attacker->bookkeepingFlags & MB_SEIZING) || !(defender->bookkeepingFlags & MB_SEIZED))
-        && (distanceBetween(attacker->xLoc, attacker->yLoc, defender->xLoc, defender->yLoc) == 1
-            && !diagonalBlocked(attacker->xLoc, attacker->yLoc, defender->xLoc, defender->yLoc, false))) {
+        && (distanceBetween(attacker->loc.x, attacker->loc.y, defender->loc.x, defender->loc.y) == 1
+            && !diagonalBlocked(attacker->loc.x, attacker->loc.y, defender->loc.x, defender->loc.y, false))) {
 
         attacker->bookkeepingFlags |= MB_SEIZING;
         defender->bookkeepingFlags |= MB_SEIZED;
@@ -1340,8 +1340,8 @@ boolean canAbsorb(creature *ally, boolean ourBolts[NUMBER_BOLT_KINDS], creature 
         && ally->newPowerCount > 0
         && (ally->targetCorpseLoc[0] <= 0)
         && !((ally->info.flags | prey->info.flags) & (MONST_INANIMATE | MONST_IMMOBILE))
-        && !monsterAvoids(ally, prey->xLoc, prey->yLoc)
-        && grid[ally->xLoc][ally->yLoc] <= 10) {
+        && !monsterAvoids(ally, prey->loc.x, prey->loc.y)
+        && grid[ally->loc.x][ally->loc.y] <= 10) {
 
         if (~(ally->info.abilityFlags) & prey->info.abilityFlags & LEARNABLE_ABILITIES) {
             return true;
@@ -1377,7 +1377,7 @@ boolean anyoneWantABite(creature *decedent) {
     if ((!(decedent->info.abilityFlags & LEARNABLE_ABILITIES)
          && !(decedent->info.flags & LEARNABLE_BEHAVIORS)
          && decedent->info.bolts[0] == BOLT_NONE)
-        || (cellHasTerrainFlag(decedent->xLoc, decedent->yLoc, T_PATHING_BLOCKER))
+        || (cellHasTerrainFlag(decedent->loc.x, decedent->loc.y, T_PATHING_BLOCKER))
         || decedent->info.monsterID == MK_SPECTRAL_IMAGE
         || (decedent->info.flags & (MONST_INANIMATE | MONST_IMMOBILE))) {
 
@@ -1386,7 +1386,7 @@ boolean anyoneWantABite(creature *decedent) {
 
     grid = allocGrid();
     fillGrid(grid, 0);
-    calculateDistances(grid, decedent->xLoc, decedent->yLoc, T_PATHING_BLOCKER, NULL, true, true);
+    calculateDistances(grid, decedent->loc.x, decedent->loc.y, T_PATHING_BLOCKER, NULL, true, true);
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *ally = nextCreature(&it);
         if (canAbsorb(ally, ourBolts, decedent, grid)) {
@@ -1405,8 +1405,8 @@ boolean anyoneWantABite(creature *decedent) {
             }
         }
         if (firstAlly) {
-            firstAlly->targetCorpseLoc[0] = decedent->xLoc;
-            firstAlly->targetCorpseLoc[1] = decedent->yLoc;
+            firstAlly->targetCorpseLoc[0] = decedent->loc.x;
+            firstAlly->targetCorpseLoc[1] = decedent->loc.y;
             strcpy(firstAlly->targetCorpseName, decedent->info.monsterName);
             firstAlly->corpseAbsorptionCounter = 20; // 20 turns to get there and start eating before he loses interest
 
@@ -1517,7 +1517,7 @@ boolean inflictDamage(creature *attacker, creature *defender,
         if (theBlood.layer == GAS) {
             theBlood.startProbability *= 100;
         }
-        spawnDungeonFeature(defender->xLoc, defender->yLoc, &theBlood, true, false);
+        spawnDungeonFeature(defender->loc.x, defender->loc.y, &theBlood, true, false);
     }
 
     if (defender != &player && defender->creatureState == MONSTER_SLEEPING) {
@@ -1641,7 +1641,7 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
 
     if (!administrativeDeath && (decedent->info.abilityFlags & MA_DF_ON_DEATH)
         && !(decedent->bookkeepingFlags & MB_IS_FALLING)) {
-        spawnDungeonFeature(decedent->xLoc, decedent->yLoc, &dungeonFeatureCatalog[decedent->info.DFType], true, false);
+        spawnDungeonFeature(decedent->loc.x, decedent->loc.y, &dungeonFeatureCatalog[decedent->info.DFType], true, false);
 
         if (monsterText[decedent->info.monsterID].DFMessage[0] && canSeeMonster(decedent)) {
             monsterName(monstName, decedent, true);
@@ -1663,8 +1663,8 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
 
             messageWithColor("you feel a sense of loss.", &badMessageColor, 0);
         }
-        x = decedent->xLoc;
-        y = decedent->yLoc;
+        x = decedent->loc.x;
+        y = decedent->loc.y;
         if (decedent->bookkeepingFlags & MB_IS_DORMANT) {
             pmap[x][y].flags &= ~HAS_DORMANT_MONSTER;
         } else {
@@ -1691,8 +1691,8 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
                 decedent->carriedMonster = NULL;
                 prependCreature(monsters, carriedMonster);
 
-                carriedMonster->xLoc = x;
-                carriedMonster->yLoc = y;
+                carriedMonster->loc.x = x;
+                carriedMonster->loc.y = y;
                 carriedMonster->ticksUntilTurn = 200;
                 pmap[x][y].flags |= HAS_MONSTER;
                 fadeInMonster(carriedMonster);
@@ -1719,10 +1719,10 @@ void buildHitList(creature **hitList, const creature *attacker, creature *defend
     short i, x, y, newX, newY, newestX, newestY;
     enum directions dir, newDir;
 
-    x = attacker->xLoc;
-    y = attacker->yLoc;
-    newX = defender->xLoc;
-    newY = defender->yLoc;
+    x = attacker->loc.x;
+    y = attacker->loc.y;
+    newX = defender->loc.x;
+    newY = defender->loc.y;
 
     dir = NO_DIRECTION;
     for (i = 0; i < DIRECTION_COUNT; i++) {
@@ -1746,7 +1746,7 @@ void buildHitList(creature **hitList, const creature *attacker, creature *defend
                 defender = monsterAtLoc(newestX, newestY);
                 if (defender
                     && monsterWillAttackTarget(attacker, defender)
-                    && (!cellHasTerrainFlag(defender->xLoc, defender->yLoc, T_OBSTRUCTS_PASSABILITY) || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
+                    && (!cellHasTerrainFlag(defender->loc.x, defender->loc.y, T_OBSTRUCTS_PASSABILITY) || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
 
                     hitList[i] = defender;
                 }

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -325,7 +325,6 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
                                  unsigned long forbiddenMapFlags,
                                  boolean deterministic) {
     short **grid, **costMap;
-    short loc[2];
 
     // First check the given location to see if it works, as an optimization.
     if (!cellHasTerrainFlag(x, y, blockingTerrainFlags | forbiddenTerrainFlags)
@@ -378,12 +377,13 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
 
     // Fall back to a pathing-agnostic alternative if there are no solutions.
     if (*retValX == -1 && *retValY == -1) {
-        if (getQualifyingLocNear(loc, x, y, hallwaysAllowed, NULL,
+        pos loc;
+        if (getQualifyingLocNear(&loc, x, y, hallwaysAllowed, NULL,
                                  (blockingTerrainFlags | forbiddenTerrainFlags),
                                  (blockingMapFlags | forbiddenMapFlags),
                                  false, deterministic)) {
-            *retValX = loc[0];
-            *retValY = loc[1];
+            *retValX = loc.x;
+            *retValY = loc.y;
             return true; // Found a fallback solution.
         } else {
             return false; // No solutions.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -109,8 +109,8 @@ void hideCursor() {
 void showCursor() {
     // Return or enter turns on cursor mode. When the path is hidden, move the cursor to the player.
     if (!coordinatesAreInMap(rogue.cursorLoc[0], rogue.cursorLoc[1])) {
-        rogue.cursorLoc[0] = player.xLoc;
-        rogue.cursorLoc[1] = player.yLoc;
+        rogue.cursorLoc[0] = player.loc.x;
+        rogue.cursorLoc[1] = player.loc.y;
         rogue.cursorMode = true;
         rogue.cursorPathIntensity = (rogue.cursorMode ? 50 : 20);
     } else {
@@ -153,7 +153,7 @@ void processSnapMap(short **map) {
 
     populateCreatureCostMap(costMap, &player);
     fillGrid(map, 30000);
-    map[player.xLoc][player.yLoc] = 0;
+    map[player.loc.x][player.loc.y] = 0;
     dijkstraScan(map, costMap, true);
     for (i = 0; i < DCOLS; i++) {
         for (j = 0; j < DROWS; j++) {
@@ -592,16 +592,16 @@ void mainInputLoop() {
         steps = 0;
         clearCursorPath();
 
-        originLoc[0] = player.xLoc;
-        originLoc[1] = player.yLoc;
+        originLoc[0] = player.loc.x;
+        originLoc[1] = player.loc.y;
 
         if (playingBack && rogue.cursorMode) {
             temporaryMessage("Examine what? (<hjklyubn>, mouse, or <tab>)", 0);
         }
 
         if (!playingBack
-            && player.xLoc == cursor[0]
-            && player.yLoc == cursor[1]
+            && player.loc.x == cursor[0]
+            && player.loc.y == cursor[1]
             && oldTargetLoc[0] == cursor[0]
             && oldTargetLoc[1] == cursor[1]) {
 
@@ -618,7 +618,7 @@ void mainInputLoop() {
         populateCreatureCostMap(costMap, &player);
 
         fillGrid(playerPathingMap, 30000);
-        playerPathingMap[player.xLoc][player.yLoc] = 0;
+        playerPathingMap[player.loc.x][player.loc.y] = 0;
         dijkstraScan(playerPathingMap, costMap, true);
         processSnapMap(cursorSnapMap);
 
@@ -650,7 +650,7 @@ void mainInputLoop() {
                     costMap[pathDestination[0]][pathDestination[1]] = 1;
                     dijkstraScan(playerPathingMap, costMap, true);
                     costMap[pathDestination[0]][pathDestination[1]] = backupCost;
-                    steps = getPlayerPathOnMap(path, playerPathingMap, player.xLoc, player.yLoc);
+                    steps = getPlayerPathOnMap(path, playerPathingMap, player.loc.x, player.loc.y);
 
 //                  steps = getPlayerPathOnMap(path, playerPathingMap, pathDestination[0], pathDestination[1]) - 1; // Get new path.
 //                  reversePath(path, steps);   // Flip it around, back-to-front.
@@ -661,7 +661,7 @@ void mainInputLoop() {
                     }
                     steps++;
 //                  if (playerPathingMap[cursor[0]][cursor[1]] != 1
-                    if (playerPathingMap[player.xLoc][player.yLoc] != 1
+                    if (playerPathingMap[player.loc.x][player.loc.y] != 1
                         || pathDestination[0] != cursor[0]
                         || pathDestination[1] != cursor[1]) {
 
@@ -676,7 +676,7 @@ void mainInputLoop() {
                            &white,
                            (steps <= 0
                             || (path[steps-1][0] == cursor[0] && path[steps-1][1] == cursor[1])
-                            || (!playingBack && distanceBetween(player.xLoc, player.yLoc, cursor[0], cursor[1]) <= 1) ? 100 : 25),
+                            || (!playingBack && distanceBetween(player.loc.x, player.loc.y, cursor[0], cursor[1]) <= 1) ? 100 : 25),
                            true);
 
                 oldTargetLoc[0] = cursor[0];
@@ -771,8 +771,8 @@ void mainInputLoop() {
             }
 
             if (theEvent.eventType == KEYSTROKE
-                && (theEvent.param1 == ASCEND_KEY && cursor[0] == rogue.upLoc[0] && cursor[1] == rogue.upLoc[1]
-                    || theEvent.param1 == DESCEND_KEY && cursor[0] == rogue.downLoc[0] && cursor[1] == rogue.downLoc[1])) {
+                && (theEvent.param1 == ASCEND_KEY && cursor[0] == rogue.upLoc.x && cursor[1] == rogue.upLoc.y
+                    || theEvent.param1 == DESCEND_KEY && cursor[0] == rogue.downLoc.x && cursor[1] == rogue.downLoc.y)) {
 
                     targetConfirmed = true;
                     doEvent = false;
@@ -794,7 +794,7 @@ void mainInputLoop() {
                 && steps > 1) {
                 // Control-clicking moves the player one step along the path.
                 for (dir=0;
-                     dir < DIRECTION_COUNT && (player.xLoc + nbDirs[dir][0] != path[0][0] || player.yLoc + nbDirs[dir][1] != path[0][1]);
+                     dir < DIRECTION_COUNT && (player.loc.x + nbDirs[dir][0] != path[0][0] || player.loc.y + nbDirs[dir][1] != path[0][1]);
                      dir++);
                 playerMoves(dir);
             } else if (D_WORMHOLING) {
@@ -805,14 +805,14 @@ void mainInputLoop() {
                     && originLoc[1] == cursor[1]) {
 
                     confirmMessages();
-                } else if (abs(player.xLoc - cursor[0]) + abs(player.yLoc - cursor[1]) == 1 // horizontal or vertical
-                           || (distanceBetween(player.xLoc, player.yLoc, cursor[0], cursor[1]) == 1 // includes diagonals
-                               && (!diagonalBlocked(player.xLoc, player.yLoc, cursor[0], cursor[1], !rogue.playbackOmniscience)
+                } else if (abs(player.loc.x - cursor[0]) + abs(player.loc.y - cursor[1]) == 1 // horizontal or vertical
+                           || (distanceBetween(player.loc.x, player.loc.y, cursor[0], cursor[1]) == 1 // includes diagonals
+                               && (!diagonalBlocked(player.loc.x, player.loc.y, cursor[0], cursor[1], !rogue.playbackOmniscience)
                                    || ((pmap[cursor[0]][cursor[1]].flags & HAS_MONSTER) && (monsterAtLoc(cursor[0], cursor[1])->info.flags & MONST_ATTACKABLE_THRU_WALLS)) // there's a turret there
                                    || ((terrainFlags(cursor[0], cursor[1]) & T_OBSTRUCTS_PASSABILITY) && (terrainMechFlags(cursor[0], cursor[1]) & TM_PROMOTES_ON_PLAYER_ENTRY))))) { // there's a lever there
                                                                                                                                                                                       // Clicking one space away will cause the player to try to move there directly irrespective of path.
                                    for (dir=0;
-                                        dir < DIRECTION_COUNT && (player.xLoc + nbDirs[dir][0] != cursor[0] || player.yLoc + nbDirs[dir][1] != cursor[1]);
+                                        dir < DIRECTION_COUNT && (player.loc.x + nbDirs[dir][0] != cursor[0] || player.loc.y + nbDirs[dir][1] != cursor[1]);
                                         dir++);
                                    playerMoves(dir);
                                } else if (steps) {
@@ -1482,7 +1482,7 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
     bakeTerrainColors(&cellForeColor, &cellBackColor, x, y);
 
     if (rogue.displayAggroRangeMode && (pmap[x][y].flags & IN_FIELD_OF_VIEW)) {
-        distance = min(rogue.scentTurnNumber - scentMap[x][y], scentDistance(x, y, player.xLoc, player.yLoc));
+        distance = min(rogue.scentTurnNumber - scentMap[x][y], scentDistance(x, y, player.loc.x, player.loc.y));
         if (distance > rogue.aggroRange * 2) {
             applyColorAverage(&cellForeColor, &orange, 12);
             applyColorAverage(&cellBackColor, &orange, 12);
@@ -1776,7 +1776,8 @@ void colorMultiplierFromDungeonLight(short x, short y, color *editColor) {
     editColor->colorDances = false;
 }
 
-void plotCharWithColor(enum displayGlyph inputChar, short xLoc, short yLoc, const color *cellForeColor, const color *cellBackColor) {
+void plotCharWithColor(enum displayGlyph inputChar, short x, short y, const color *cellForeColor, const color *cellBackColor) {
+    pos loc = { x, y };
     short oldRNG;
 
     short foreRed = cellForeColor->red,
@@ -1789,7 +1790,7 @@ void plotCharWithColor(enum displayGlyph inputChar, short xLoc, short yLoc, cons
 
     foreRand, backRand;
 
-    brogueAssert(coordinatesAreInWindow(xLoc, yLoc));
+    brogueAssert(coordinatesAreInWindow(loc.x, loc.y));
 
     if (rogue.gameHasEnded || rogue.playbackFastForward) {
         return;
@@ -1823,7 +1824,7 @@ void plotCharWithColor(enum displayGlyph inputChar, short xLoc, short yLoc, cons
         inputChar = ' ';
     }
 
-    cellDisplayBuffer *target = &displayBuffer[xLoc][yLoc];
+    cellDisplayBuffer *target = &displayBuffer[loc.x][loc.y];
     target->character = inputChar;
     target->foreColorComponents[0] = foreRed;
     target->foreColorComponents[1] = foreGreen;
@@ -2153,7 +2154,7 @@ void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart
     fastForward = false;
     distanceMap = allocGrid();
     fillGrid(distanceMap, 0);
-    calculateDistances(distanceMap, player.xLoc, player.yLoc, T_OBSTRUCTS_PASSABILITY, 0, true, true);
+    calculateDistances(distanceMap, player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY, 0, true, true);
 
     for (i=0; i<COLS; i++) {
         x2 = (double) ((i - x) * 5.0 / COLS);
@@ -2350,8 +2351,8 @@ void exploreKey(const boolean controlKey) {
     dir = adjacentFightingDir();
     if (dir == NO_DIRECTION) {
         for (dir = 0; dir < DIRECTION_COUNT; dir++) {
-            x = player.xLoc + nbDirs[dir][0];
-            y = player.yLoc + nbDirs[dir][1];
+            x = player.loc.x + nbDirs[dir][0];
+            y = player.loc.y + nbDirs[dir][1];
             if (coordinatesAreInMap(x, y)
                 && !(pmap[x][y].flags & DISCOVERED)) {
 
@@ -2360,8 +2361,8 @@ void exploreKey(const boolean controlKey) {
             }
         }
         if (!tooDark) {
-            x = finalX = player.xLoc;
-            y = finalY = player.yLoc;
+            x = finalX = player.loc.x;
+            y = finalY = player.loc.y;
 
             exploreMap = allocGrid();
             getExploreMap(exploreMap, false);
@@ -2379,13 +2380,13 @@ void exploreKey(const boolean controlKey) {
             freeGrid(exploreMap);
         }
     } else {
-        x = finalX = player.xLoc + nbDirs[dir][0];
-        y = finalY = player.yLoc + nbDirs[dir][1];
+        x = finalX = player.loc.x + nbDirs[dir][0];
+        y = finalY = player.loc.y + nbDirs[dir][1];
     }
 
     if (tooDark) {
         message("It's too dark to explore!", 0);
-    } else if (x == player.xLoc && y == player.yLoc) {
+    } else if (x == player.loc.x && y == player.loc.y) {
         message("I see no path for further exploration.", 0);
     } else if (proposeOrConfirmLocation(finalX, finalY, "I see no path for further exploration.")) {
         explore(controlKey ? 1 : 20); // Do the exploring until interrupted.
@@ -2520,8 +2521,8 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             if (D_WORMHOLING) {
                 recordKeystroke(DESCEND_KEY, false, false);
                 useStairs(1);
-            } else if (proposeOrConfirmLocation(rogue.downLoc[0], rogue.downLoc[1], "I see no way down.")) {
-                travel(rogue.downLoc[0], rogue.downLoc[1], true);
+            } else if (proposeOrConfirmLocation(rogue.downLoc.x, rogue.downLoc.y, "I see no way down.")) {
+                travel(rogue.downLoc.x, rogue.downLoc.y, true);
             }
             break;
         case ASCEND_KEY:
@@ -2529,8 +2530,8 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             if (D_WORMHOLING) {
                 recordKeystroke(ASCEND_KEY, false, false);
                 useStairs(-1);
-            } else if (proposeOrConfirmLocation(rogue.upLoc[0], rogue.upLoc[1], "I see no way up.")) {
-                travel(rogue.upLoc[0], rogue.upLoc[1], true);
+            } else if (proposeOrConfirmLocation(rogue.upLoc.x, rogue.upLoc.y, "I see no way up.")) {
+                travel(rogue.upLoc.x, rogue.upLoc.y, true);
             }
             break;
         case RETURN_KEY:
@@ -2716,7 +2717,7 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             /*DEBUG {
                 cellDisplayBuffer dbuf[COLS][ROWS];
                 copyDisplayBuffer(dbuf, displayBuffer);
-                funkyFade(dbuf, &white, 0, 100, mapToWindowX(player.xLoc), mapToWindowY(player.yLoc), false);
+                funkyFade(dbuf, &white, 0, 100, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
             }*/
             // DEBUG displayLoops();
             // DEBUG displayChokeMap();
@@ -2724,7 +2725,7 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             //DEBUG displayWaypoints();
             // DEBUG {displayGrid(safetyMap); displayMoreSign(); displayLevel();}
             // parseFile();
-            // DEBUG spawnDungeonFeature(player.xLoc, player.yLoc, &dungeonFeatureCatalog[DF_METHANE_GAS_ARMAGEDDON], true, false);
+            // DEBUG spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_METHANE_GAS_ARMAGEDDON], true, false);
             printSeed();
             break;
         case EASY_MODE_KEY:
@@ -3030,8 +3031,8 @@ void displayMonsterFlashes(boolean flashingEnabled) {
         if (monst->bookkeepingFlags & MB_WILL_FLASH) {
             monst->bookkeepingFlags &= ~MB_WILL_FLASH;
             if (flashingEnabled && canSeeMonster(monst) && count < 100) {
-                x[count] = monst->xLoc;
-                y[count] = monst->yLoc;
+                x[count] = monst->loc.x;
+                y[count] = monst->loc.y;
                 strength[count] = monst->flashStrength;
                 flashColor[count] = &(monst->flashColor);
                 count++;
@@ -3772,8 +3773,8 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
 
     printY = 0;
 
-    px = player.xLoc;
-    py = player.yLoc;
+    px = player.loc.x;
+    py = player.loc.y;
 
     zeroOutGrid(addedEntity);
 
@@ -3805,7 +3806,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
     entityList[displayEntityCount] = &player;
     entityType[displayEntityCount] = EDT_CREATURE;
     displayEntityCount++;
-    addedEntity[player.xLoc][player.yLoc] = true;
+    addedEntity[player.loc.x][player.loc.y] = true;
 
     // Focused entity, if it must go first.
     if (focusedEntityMustGoFirst && !addedEntity[focusX][focusY]) {
@@ -3824,16 +3825,16 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
             for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
                 creature *monst = nextCreature(&it);
                 if ((canDirectlySeeMonster(monst) || (indirectVision && (canSeeMonster(monst) || rogue.playbackOmniscience)))
-                    && !addedEntity[monst->xLoc][monst->yLoc]
+                    && !addedEntity[monst->loc.x][monst->loc.y]
                     && !(monst->info.flags & MONST_NOT_LISTED_IN_SIDEBAR)
-                    && (px - monst->xLoc) * (px - monst->xLoc) + (py - monst->yLoc) * (py - monst->yLoc) < shortestDistance) {
+                    && (px - monst->loc.x) * (px - monst->loc.x) + (py - monst->loc.y) * (py - monst->loc.y) < shortestDistance) {
 
-                    shortestDistance = (px - monst->xLoc) * (px - monst->xLoc) + (py - monst->yLoc) * (py - monst->yLoc);
+                    shortestDistance = (px - monst->loc.x) * (px - monst->loc.x) + (py - monst->loc.y) * (py - monst->loc.y);
                     closestMonst = monst;
                 }
             }
             if (shortestDistance < 10000) {
-                addedEntity[closestMonst->xLoc][closestMonst->yLoc] = true;
+                addedEntity[closestMonst->loc.x][closestMonst->loc.y] = true;
                 entityList[displayEntityCount] = closestMonst;
                 entityType[displayEntityCount] = EDT_CREATURE;
                 displayEntityCount++;
@@ -3844,16 +3845,16 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
         do {
             shortestDistance = 10000;
             for (theItem = floorItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
-                if ((playerCanDirectlySee(theItem->xLoc, theItem->yLoc) || (indirectVision && (playerCanSeeOrSense(theItem->xLoc, theItem->yLoc) || rogue.playbackOmniscience)))
-                    && !addedEntity[theItem->xLoc][theItem->yLoc]
-                    && (px - theItem->xLoc) * (px - theItem->xLoc) + (py - theItem->yLoc) * (py - theItem->yLoc) < shortestDistance) {
+                if ((playerCanDirectlySee(theItem->loc.x, theItem->loc.y) || (indirectVision && (playerCanSeeOrSense(theItem->loc.x, theItem->loc.y) || rogue.playbackOmniscience)))
+                    && !addedEntity[theItem->loc.x][theItem->loc.y]
+                    && (px - theItem->loc.x) * (px - theItem->loc.x) + (py - theItem->loc.y) * (py - theItem->loc.y) < shortestDistance) {
 
-                    shortestDistance = (px - theItem->xLoc) * (px - theItem->xLoc) + (py - theItem->yLoc) * (py - theItem->yLoc);
+                    shortestDistance = (px - theItem->loc.x) * (px - theItem->loc.x) + (py - theItem->loc.y) * (py - theItem->loc.y);
                     closestItem = theItem;
                 }
             }
             if (shortestDistance < 10000) {
-                addedEntity[closestItem->xLoc][closestItem->yLoc] = true;
+                addedEntity[closestItem->loc.x][closestItem->loc.y] = true;
                 entityList[displayEntityCount] = closestItem;
                 entityType[displayEntityCount] = EDT_ITEM;
                 displayEntityCount++;
@@ -3893,16 +3894,16 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
     for (i=0; i<displayEntityCount && printY < ROWS - 1; i++) { // Bottom line is reserved for the depth.
         oldPrintY = printY;
         if (entityType[i] == EDT_CREATURE) {
-            x = ((creature *) entityList[i])->xLoc;
-            y = ((creature *) entityList[i])->yLoc;
+            x = ((creature *) entityList[i])->loc.x;
+            y = ((creature *) entityList[i])->loc.y;
             printY = printMonsterInfo((creature *) entityList[i],
                                       printY,
                                       (focusEntity && (x != focusX || y != focusY)),
                                       (x == focusX && y == focusY));
 
         } else if (entityType[i] == EDT_ITEM) {
-            x = ((item *) entityList[i])->xLoc;
-            y = ((item *) entityList[i])->yLoc;
+            x = ((item *) entityList[i])->loc.x;
+            y = ((item *) entityList[i])->loc.y;
             printY = printItemInfo((item *) entityList[i],
                                    printY,
                                    (focusEntity && (x != focusX || y != focusY)),
@@ -4432,7 +4433,7 @@ void displayGrid(short **map) {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (cellHasTerrainFlag(i, j, T_WAYPOINT_BLOCKER) || (map[i][j] == map[0][0]) || (i == player.xLoc && j == player.yLoc)) {
+            if (cellHasTerrainFlag(i, j, T_WAYPOINT_BLOCKER) || (map[i][j] == map[0][0]) || (i == player.loc.x && j == player.loc.y)) {
                 continue;
             }
             if (map[i][j] > topRange) {
@@ -4451,7 +4452,7 @@ void displayGrid(short **map) {
         for (j=0; j<DROWS; j++) {
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY | T_LAVA_INSTA_DEATH)
                 || (map[i][j] == map[0][0])
-                || (i == player.xLoc && j == player.yLoc)) {
+                || (i == player.loc.x && j == player.loc.y)) {
                 continue;
             }
             score = 300 - (map[i][j] - bottomRange) * 300 / max(1, (topRange - bottomRange));
@@ -4626,13 +4627,13 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
         printString("                    ", 0, y, &white, &black, 0); // Start with a blank line
 
         // Unhighlight if it's highlighted as part of the path.
-        inPath = (pmap[monst->xLoc][monst->yLoc].flags & IS_IN_PATH) ? true : false;
-        pmap[monst->xLoc][monst->yLoc].flags &= ~IS_IN_PATH;
-        getCellAppearance(monst->xLoc, monst->yLoc, &monstChar, &monstForeColor, &monstBackColor);
+        inPath = (pmap[monst->loc.x][monst->loc.y].flags & IS_IN_PATH) ? true : false;
+        pmap[monst->loc.x][monst->loc.y].flags &= ~IS_IN_PATH;
+        getCellAppearance(monst->loc.x, monst->loc.y, &monstChar, &monstForeColor, &monstBackColor);
         applyColorBounds(&monstForeColor, 0, 100);
         applyColorBounds(&monstBackColor, 0, 100);
         if (inPath) {
-            pmap[monst->xLoc][monst->yLoc].flags |= IS_IN_PATH;
+            pmap[monst->loc.x][monst->loc.y].flags |= IS_IN_PATH;
         }
 
         if (dim) {
@@ -4659,7 +4660,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 //encodeMessageColor(monstName, strlen(monstName) - 4, &playerInDarknessColor);
                 encodeMessageColor(monstName, strlen(monstName) - 4, &monstForeColor);
                 strcat(monstName, "(dark)");
-            } else if (!(pmap[player.xLoc][player.yLoc].flags & IS_IN_SHADOW)) {
+            } else if (!(pmap[player.loc.x][player.loc.y].flags & IS_IN_SHADOW)) {
                 strcat(monstName, " xxxx");
                 //encodeMessageColor(monstName, strlen(monstName) - 4, &playerInLightColor);
                 encodeMessageColor(monstName, strlen(monstName) - 4, &monstForeColor);
@@ -4758,7 +4759,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 printProgressBar(0, y++, statusStrings[i], monst->status[i], monst->maxStatus[i], &redBar, dim);
             }
         }
-        if (monst->targetCorpseLoc[0] == monst->xLoc && monst->targetCorpseLoc[1] == monst->yLoc) {
+        if (monst->targetCorpseLoc[0] == monst->loc.x && monst->targetCorpseLoc[1] == monst->loc.y) {
             printProgressBar(0, y++,  monsterText[monst->info.monsterID].absorbStatus, monst->corpseAbsorptionCounter, 20, &redBar, dim);
         }
     }
@@ -4779,7 +4780,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 } else if (monst->bookkeepingFlags & MB_CAPTIVE && y < ROWS - 1) {
                     printString("     (Captive)      ", 0, y++, (dim ? &darkGray : &gray), &black, 0);
                 } else if ((monst->info.flags & MONST_RESTRICTED_TO_LIQUID)
-                           && !cellHasTMFlag(monst->xLoc, monst->yLoc, TM_ALLOWS_SUBMERGING)) {
+                           && !cellHasTMFlag(monst->loc.x, monst->loc.y, TM_ALLOWS_SUBMERGING)) {
                     printString("     (Helpless)     ", 0, y++, (dim ? &darkGray : &gray), &black, 0);
                 } else if (monst->creatureState == MONSTER_SLEEPING && y < ROWS - 1) {
                     printString("     (Sleeping)     ", 0, y++, (dim ? &darkGray : &gray), &black, 0);
@@ -4912,13 +4913,13 @@ short printItemInfo(item *theItem, short y, boolean dim, boolean highlight) {
 
     if (y < ROWS - 1) {
         // Unhighlight if it's highlighted as part of the path.
-        inPath = (pmap[theItem->xLoc][theItem->yLoc].flags & IS_IN_PATH) ? true : false;
-        pmap[theItem->xLoc][theItem->yLoc].flags &= ~IS_IN_PATH;
-        getCellAppearance(theItem->xLoc, theItem->yLoc, &itemChar, &itemForeColor, &itemBackColor);
+        inPath = (pmap[theItem->loc.x][theItem->loc.y].flags & IS_IN_PATH) ? true : false;
+        pmap[theItem->loc.x][theItem->loc.y].flags &= ~IS_IN_PATH;
+        getCellAppearance(theItem->loc.x, theItem->loc.y, &itemChar, &itemForeColor, &itemBackColor);
         applyColorBounds(&itemForeColor, 0, 100);
         applyColorBounds(&itemBackColor, 0, 100);
         if (inPath) {
-            pmap[theItem->xLoc][theItem->yLoc].flags |= IS_IN_PATH;
+            pmap[theItem->loc.x][theItem->loc.y].flags |= IS_IN_PATH;
         }
         if (dim) {
             applyColorAverage(&itemForeColor, &black, 50);
@@ -5138,7 +5139,7 @@ void printMonsterDetails(creature *monst, cellDisplayBuffer rbuf[COLS][ROWS]) {
     char textBuf[COLS * 100];
 
     monsterDetails(textBuf, monst);
-    printTextBox(textBuf, monst->xLoc, 0, 0, &white, &black, rbuf, NULL, 0);
+    printTextBox(textBuf, monst->loc.x, 0, 0, &white, &black, rbuf, NULL, 0);
 }
 
 // Displays the item info box with the dark blue background.
@@ -5233,5 +5234,5 @@ void printFloorItemDetails(item *theItem, cellDisplayBuffer rbuf[COLS][ROWS]) {
     char textBuf[COLS * 100];
 
     itemDetails(textBuf, theItem);
-    printTextBox(textBuf, theItem->xLoc, 0, 0, &white, &black, rbuf, NULL, 0);
+    printTextBox(textBuf, theItem->loc.x, 0, 0, &white, &black, rbuf, NULL, 0);
 }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5188,7 +5188,7 @@ short hiliteTrajectory(short coordinateList[DCOLS][2], short numCells, boolean e
 boolean moveCursor(boolean *targetConfirmed,
                    boolean *canceled,
                    boolean *tabKey,
-                   short targetLoc[2],
+                   pos *targetLoc,
                    rogueEvent *event,
                    buttonState *state,
                    boolean colorsDance,
@@ -5201,10 +5201,7 @@ boolean moveCursor(boolean *targetConfirmed,
     rogueEvent theEvent;
     short oldRNG;
 
-    short *cursor = rogue.cursorLoc; // shorthand
-
-    cursor[0] = targetLoc[0];
-    cursor[1] = targetLoc[1];
+    rogue.cursorLoc = *targetLoc;
 
     *targetConfirmed = *canceled = *tabKey = false;
     sidebarHighlighted = false;
@@ -5250,11 +5247,11 @@ boolean moveCursor(boolean *targetConfirmed,
                 && rogue.sidebarLocationList[theEvent.param2][0] > -1) {
 
                 // If the cursor is on an entity in the sidebar.
-                cursor[0] = rogue.sidebarLocationList[theEvent.param2][0];
-                cursor[1] = rogue.sidebarLocationList[theEvent.param2][1];
+                rogue.cursorLoc.x = rogue.sidebarLocationList[theEvent.param2][0];
+                rogue.cursorLoc.y = rogue.sidebarLocationList[theEvent.param2][1];
                 sidebarHighlighted = true;
                 cursorMovementCommand = true;
-                refreshSideBar(cursor[0], cursor[1], false);
+                refreshSideBar(rogue.cursorLoc.x, rogue.cursorLoc.y, false);
                 if (theEvent.eventType == MOUSE_UP) {
                     *targetConfirmed = true;
                 }
@@ -5264,12 +5261,12 @@ boolean moveCursor(boolean *targetConfirmed,
                 // If the cursor is in the map area, or is allowed to leave the map and it isn't a click.
                 if (theEvent.eventType == MOUSE_UP
                     && !theEvent.shiftKey
-                    && (theEvent.controlKey || (cursor[0] == windowToMapX(theEvent.param1) && cursor[1] == windowToMapY(theEvent.param2)))) {
+                    && (theEvent.controlKey || (rogue.cursorLoc.x == windowToMapX(theEvent.param1) && rogue.cursorLoc.y == windowToMapY(theEvent.param2)))) {
 
                     *targetConfirmed = true;
                 }
-                cursor[0] = windowToMapX(theEvent.param1);
-                cursor[1] = windowToMapY(theEvent.param2);
+                rogue.cursorLoc.x = windowToMapX(theEvent.param1);
+                rogue.cursorLoc.y = windowToMapY(theEvent.param2);
                 cursorMovementCommand = true;
             } else {
                 cursorMovementCommand = false;
@@ -5283,64 +5280,64 @@ boolean moveCursor(boolean *targetConfirmed,
                 case LEFT_ARROW:
                 case LEFT_KEY:
                 case NUMPAD_4:
-                    if (keysMoveCursor && cursor[0] > 0) {
-                        cursor[0] -= moveIncrement;
+                    if (keysMoveCursor && rogue.cursorLoc.x > 0) {
+                        rogue.cursorLoc.x -= moveIncrement;
                     }
                     cursorMovementCommand = movementKeystroke = keysMoveCursor;
                     break;
                 case RIGHT_ARROW:
                 case RIGHT_KEY:
                 case NUMPAD_6:
-                    if (keysMoveCursor && cursor[0] < DCOLS - 1) {
-                        cursor[0] += moveIncrement;
+                    if (keysMoveCursor && rogue.cursorLoc.x < DCOLS - 1) {
+                        rogue.cursorLoc.x += moveIncrement;
                     }
                     cursorMovementCommand = movementKeystroke = keysMoveCursor;
                     break;
                 case UP_ARROW:
                 case UP_KEY:
                 case NUMPAD_8:
-                    if (keysMoveCursor && cursor[1] > 0) {
-                        cursor[1] -= moveIncrement;
+                    if (keysMoveCursor && rogue.cursorLoc.y > 0) {
+                        rogue.cursorLoc.y -= moveIncrement;
                     }
                     cursorMovementCommand = movementKeystroke = keysMoveCursor;
                     break;
                 case DOWN_ARROW:
                 case DOWN_KEY:
                 case NUMPAD_2:
-                    if (keysMoveCursor && cursor[1] < DROWS - 1) {
-                        cursor[1] += moveIncrement;
+                    if (keysMoveCursor && rogue.cursorLoc.y < DROWS - 1) {
+                        rogue.cursorLoc.y += moveIncrement;
                     }
                     cursorMovementCommand = movementKeystroke = keysMoveCursor;
                     break;
                 case UPLEFT_KEY:
                 case NUMPAD_7:
-                    if (keysMoveCursor && cursor[0] > 0 && cursor[1] > 0) {
-                        cursor[0] -= moveIncrement;
-                        cursor[1] -= moveIncrement;
+                    if (keysMoveCursor && rogue.cursorLoc.x > 0 && rogue.cursorLoc.y > 0) {
+                        rogue.cursorLoc.x -= moveIncrement;
+                        rogue.cursorLoc.y -= moveIncrement;
                     }
                     cursorMovementCommand = movementKeystroke = keysMoveCursor;
                     break;
                 case UPRIGHT_KEY:
                 case NUMPAD_9:
-                    if (keysMoveCursor && cursor[0] < DCOLS - 1 && cursor[1] > 0) {
-                        cursor[0] += moveIncrement;
-                        cursor[1] -= moveIncrement;
+                    if (keysMoveCursor && rogue.cursorLoc.x < DCOLS - 1 && rogue.cursorLoc.y > 0) {
+                        rogue.cursorLoc.x += moveIncrement;
+                        rogue.cursorLoc.y -= moveIncrement;
                     }
                     cursorMovementCommand = movementKeystroke = keysMoveCursor;
                     break;
                 case DOWNLEFT_KEY:
                 case NUMPAD_1:
-                    if (keysMoveCursor && cursor[0] > 0 && cursor[1] < DROWS - 1) {
-                        cursor[0] -= moveIncrement;
-                        cursor[1] += moveIncrement;
+                    if (keysMoveCursor && rogue.cursorLoc.x > 0 && rogue.cursorLoc.y < DROWS - 1) {
+                        rogue.cursorLoc.x -= moveIncrement;
+                        rogue.cursorLoc.y += moveIncrement;
                     }
                     cursorMovementCommand = movementKeystroke = keysMoveCursor;
                     break;
                 case DOWNRIGHT_KEY:
                 case NUMPAD_3:
-                    if (keysMoveCursor && cursor[0] < DCOLS - 1 && cursor[1] < DROWS - 1) {
-                        cursor[0] += moveIncrement;
-                        cursor[1] += moveIncrement;
+                    if (keysMoveCursor && rogue.cursorLoc.x < DCOLS - 1 && rogue.cursorLoc.y < DROWS - 1) {
+                        rogue.cursorLoc.x += moveIncrement;
+                        rogue.cursorLoc.y += moveIncrement;
                     }
                     cursorMovementCommand = movementKeystroke = keysMoveCursor;
                     break;
@@ -5366,10 +5363,10 @@ boolean moveCursor(boolean *targetConfirmed,
         }
 
         if (sidebarHighlighted
-            && (!(pmap[cursor[0]][cursor[1]].flags & (HAS_PLAYER | HAS_MONSTER))
-                || !canSeeMonster(monsterAtLoc(cursor[0], cursor[1])))
-            && (!(pmap[cursor[0]][cursor[1]].flags & HAS_ITEM) || !playerCanSeeOrSense(cursor[0], cursor[1]))
-            && (!cellHasTMFlag(cursor[0], cursor[1], TM_LIST_IN_SIDEBAR) || !playerCanSeeOrSense(cursor[0], cursor[1]))) {
+            && (!(pmap[rogue.cursorLoc.x][rogue.cursorLoc.y].flags & (HAS_PLAYER | HAS_MONSTER))
+                || !canSeeMonster(monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y)))
+            && (!(pmap[rogue.cursorLoc.x][rogue.cursorLoc.y].flags & HAS_ITEM) || !playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y))
+            && (!cellHasTMFlag(rogue.cursorLoc.x, rogue.cursorLoc.y, TM_LIST_IN_SIDEBAR) || !playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y))) {
 
             // The sidebar is highlighted but the cursor is not on a visible item, monster or terrain. Un-highlight the sidebar.
             refreshSideBar(-1, -1, false);
@@ -5378,11 +5375,11 @@ boolean moveCursor(boolean *targetConfirmed,
 
         if (targetCanLeaveMap && !movementKeystroke) {
             // permit it to leave the map by up to 1 space in any direction if mouse controlled.
-            cursor[0] = clamp(cursor[0], -1, DCOLS);
-            cursor[1] = clamp(cursor[1], -1, DROWS);
+            rogue.cursorLoc.x = clamp(rogue.cursorLoc.x, -1, DCOLS);
+            rogue.cursorLoc.y = clamp(rogue.cursorLoc.y, -1, DROWS);
         } else {
-            cursor[0] = clamp(cursor[0], 0, DCOLS - 1);
-            cursor[1] = clamp(cursor[1], 0, DROWS - 1);
+            rogue.cursorLoc.x = clamp(rogue.cursorLoc.x, 0, DCOLS - 1);
+            rogue.cursorLoc.y = clamp(rogue.cursorLoc.y, 0, DROWS - 1);
         }
     } while (again && (!event || !cursorMovementCommand));
 
@@ -5396,8 +5393,7 @@ boolean moveCursor(boolean *targetConfirmed,
         sidebarHighlighted = false;
     }
 
-    targetLoc[0] = cursor[0];
-    targetLoc[1] = cursor[1];
+    *targetLoc = rogue.cursorLoc;
 
     return !cursorMovementCommand;
 }
@@ -5429,7 +5425,7 @@ boolean chooseTarget(short returnLoc[2],
                      boolean targetAllies,
                      const bolt *theBolt,
                      const color *trajectoryColor) {
-    short originLoc[2], targetLoc[2], oldTargetLoc[2], coordinates[DCOLS][2], numCells, i, distance, newX, newY;
+    short originLoc[2], oldTargetLoc[2], coordinates[DCOLS][2], numCells, i, distance, newX, newY;
     creature *monst;
     boolean canceled, targetConfirmed, tabKey, cursorInTrajectory, focusedOnSomething = false;
     rogueEvent event = {0};
@@ -5441,7 +5437,7 @@ boolean chooseTarget(short returnLoc[2],
     if (rogue.playbackMode) {
         // In playback, pull the next event (a mouseclick) and use that location as the target.
         pullMouseClickDuringPlayback(returnLoc);
-        rogue.cursorLoc[0] = rogue.cursorLoc[1] = -1;
+        rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
         return true;
     }
 
@@ -5452,97 +5448,96 @@ boolean chooseTarget(short returnLoc[2],
     originLoc[0] = player.loc.x;
     originLoc[1] = player.loc.y;
 
-    targetLoc[0] = oldTargetLoc[0] = player.loc.x;
-    targetLoc[1] = oldTargetLoc[1] = player.loc.y;
+    oldTargetLoc[0] = player.loc.x;
+    oldTargetLoc[1] = player.loc.y;
+
+    pos targetLoc = player.loc;
 
     if (autoTarget) {
         if (creatureIsTargetable(rogue.lastTarget) && (targetAllies == (rogue.lastTarget->creatureState == MONSTER_ALLY))) {
             monst = rogue.lastTarget;
         } else {
             //rogue.lastTarget = NULL;
-            if (nextTargetAfter(&newX, &newY, targetLoc[0], targetLoc[1], !targetAllies, targetAllies, false, false, true, false)) {
-                targetLoc[0] = newX;
-                targetLoc[1] = newY;
+            if (nextTargetAfter(&newX, &newY, targetLoc.x, targetLoc.y, !targetAllies, targetAllies, false, false, true, false)) {
+                targetLoc = (pos) { .x = newX, .y = newY };
             }
-            monst = monsterAtLoc(targetLoc[0], targetLoc[1]);
+            monst = monsterAtLoc(targetLoc.x, targetLoc.y);
         }
         if (monst) {
-            targetLoc[0] = monst->loc.x;
-            targetLoc[1] = monst->loc.y;
+            targetLoc = monst->loc;
             refreshSideBar(monst->loc.x, monst->loc.y, false);
             focusedOnSomething = true;
         }
     }
 
-    numCells = getLineCoordinates(coordinates, originLoc, targetLoc, theBolt);
+    numCells = getLineCoordinates(coordinates, originLoc, (const short[2]){ targetLoc.x, targetLoc.y }, theBolt);
     if (maxDistance > 0) {
         numCells = min(numCells, maxDistance);
     }
     if (stopAtTarget) {
-        numCells = min(numCells, distanceBetween(player.loc.x, player.loc.y, targetLoc[0], targetLoc[1]));
+        numCells = min(numCells, distanceBetween(player.loc.x, player.loc.y, targetLoc.x, targetLoc.y));
     }
 
     targetConfirmed = canceled = tabKey = false;
 
     do {
-        printLocationDescription(targetLoc[0], targetLoc[1]);
+        printLocationDescription(targetLoc.x, targetLoc.y);
 
         if (canceled) {
             refreshDungeonCell(oldTargetLoc[0], oldTargetLoc[1]);
             hiliteTrajectory(coordinates, numCells, true, theBolt, trajectoryColor);
             confirmMessages();
-            rogue.cursorLoc[0] = rogue.cursorLoc[1] = -1;
+            rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
             restoreRNG;
             return false;
         }
 
         if (tabKey) {
-            if (nextTargetAfter(&newX, &newY, targetLoc[0], targetLoc[1], !targetAllies, targetAllies, false, false, true, event.shiftKey)) {
-                targetLoc[0] = newX;
-                targetLoc[1] = newY;
+            if (nextTargetAfter(&newX, &newY, targetLoc.x, targetLoc.y, !targetAllies, targetAllies, false, false, true, event.shiftKey)) {
+                targetLoc = (pos) { .x = newX, .y = newY };
             }
         }
 
-        monst = monsterAtLoc(targetLoc[0], targetLoc[1]);
+        monst = monsterAtLoc(targetLoc.x, targetLoc.y);
         if (monst != NULL && monst != &player && canSeeMonster(monst)) {
             focusedOnSomething = true;
-        } else if (playerCanSeeOrSense(targetLoc[0], targetLoc[1])
-                   && (pmap[targetLoc[0]][targetLoc[1]].flags & HAS_ITEM) || cellHasTMFlag(targetLoc[0], targetLoc[1], TM_LIST_IN_SIDEBAR)) {
+        } else if (playerCanSeeOrSense(targetLoc.x, targetLoc.y)
+                   && (pmap[targetLoc.x][targetLoc.y].flags & HAS_ITEM) || cellHasTMFlag(targetLoc.x, targetLoc.y, TM_LIST_IN_SIDEBAR)) {
             focusedOnSomething = true;
         } else if (focusedOnSomething) {
             refreshSideBar(-1, -1, false);
             focusedOnSomething = false;
         }
         if (focusedOnSomething) {
-            refreshSideBar(targetLoc[0], targetLoc[1], false);
+            refreshSideBar(targetLoc.x, targetLoc.y, false);
         }
 
         refreshDungeonCell(oldTargetLoc[0], oldTargetLoc[1]);
         hiliteTrajectory(coordinates, numCells, true, theBolt, &trajColor);
 
         if (!targetConfirmed) {
-            numCells = getLineCoordinates(coordinates, originLoc, targetLoc, theBolt);
+            numCells = getLineCoordinates(coordinates, originLoc, (const short[2]){targetLoc.x, targetLoc.y}, theBolt);
             if (maxDistance > 0) {
                 numCells = min(numCells, maxDistance);
             }
 
             if (stopAtTarget) {
-                numCells = min(numCells, distanceBetween(player.loc.x, player.loc.y, targetLoc[0], targetLoc[1]));
+                numCells = min(numCells, distanceBetween(player.loc.x, player.loc.y, targetLoc.x, targetLoc.y));
             }
             distance = hiliteTrajectory(coordinates, numCells, false, theBolt, &trajColor);
             cursorInTrajectory = false;
             for (i=0; i<distance; i++) {
-                if (coordinates[i][0] == targetLoc[0] && coordinates[i][1] == targetLoc[1]) {
+                if (coordinates[i][0] == targetLoc.x && coordinates[i][1] == targetLoc.y) {
                     cursorInTrajectory = true;
                     break;
                 }
             }
-            hiliteCell(targetLoc[0], targetLoc[1], &white, (cursorInTrajectory ? 100 : 35), true);
+            hiliteCell(targetLoc.x, targetLoc.y, &white, (cursorInTrajectory ? 100 : 35), true);
         }
 
-        oldTargetLoc[0] = targetLoc[0];
-        oldTargetLoc[1] = targetLoc[1];
-        moveCursor(&targetConfirmed, &canceled, &tabKey, targetLoc, &event, NULL, false, true, false);
+        oldTargetLoc[0] = targetLoc.x;
+        oldTargetLoc[1] = targetLoc.y;
+        moveCursor(&targetConfirmed, &canceled, &tabKey, &targetLoc, &event, NULL, false, true, false);
         if (event.eventType == RIGHT_MOUSE_UP) { // Right mouse cancels.
             canceled = true;
         }
@@ -5553,22 +5548,22 @@ boolean chooseTarget(short returnLoc[2],
     hiliteTrajectory(coordinates, numCells, true, theBolt, trajectoryColor);
     refreshDungeonCell(oldTargetLoc[0], oldTargetLoc[1]);
 
-    if (originLoc[0] == targetLoc[0] && originLoc[1] == targetLoc[1]) {
+    if (originLoc[0] == targetLoc.x && originLoc[1] == targetLoc.y) {
         confirmMessages();
         restoreRNG;
-        rogue.cursorLoc[0] = rogue.cursorLoc[1] = -1;
+        rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
         return false;
     }
 
-    monst = monsterAtLoc(targetLoc[0], targetLoc[1]);
+    monst = monsterAtLoc(targetLoc.x, targetLoc.y);
     if (monst && monst != &player && canSeeMonster(monst)) {
         rogue.lastTarget = monst;
     }
 
-    returnLoc[0] = targetLoc[0];
-    returnLoc[1] = targetLoc[1];
+    returnLoc[0] = targetLoc.x;
+    returnLoc[1] = targetLoc.y;
     restoreRNG;
-    rogue.cursorLoc[0] = rogue.cursorLoc[1] = -1;
+    rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
     return true;
 }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -364,18 +364,18 @@ item *placeItem(item *theItem, short x, short y) {
     char theItemName[DCOLS], buf[DCOLS];
     if (x <= 0 || y <= 0) {
         randomMatchingLocation(&(loc[0]), &(loc[1]), FLOOR, NOTHING, -1);
-        theItem->xLoc = loc[0];
-        theItem->yLoc = loc[1];
+        theItem->loc.x = loc[0];
+        theItem->loc.y = loc[1];
     } else {
-        theItem->xLoc = x;
-        theItem->yLoc = y;
+        theItem->loc.x = x;
+        theItem->loc.y = y;
     }
 
     removeItemFromChain(theItem, floorItems); // just in case; double-placing an item will result in game-crashing loops in the item list
     addItemToChain(theItem, floorItems);
-    pmap[theItem->xLoc][theItem->yLoc].flags |= HAS_ITEM;
+    pmap[theItem->loc.x][theItem->loc.y].flags |= HAS_ITEM;
     if ((theItem->flags & ITEM_MAGIC_DETECTED) && itemMagicPolarity(theItem)) {
-        pmap[theItem->xLoc][theItem->yLoc].flags |= ITEM_DETECTED;
+        pmap[theItem->loc.x][theItem->loc.y].flags |= ITEM_DETECTED;
     }
     if (cellHasTerrainFlag(x, y, T_IS_DF_TRAP)
         && !cellHasTerrainFlag(x, y, T_MOVES_ITEMS)
@@ -819,8 +819,8 @@ void pickUpItemAt(short x, short y) {
             if (!rogue.yendorWarden) {
                 getRandomMonsterSpawnLocation(&guardianX, &guardianY);
                 monst = generateMonster(MK_WARDEN_OF_YENDOR, false, false);
-                monst->xLoc = guardianX;
-                monst->yLoc = guardianY;
+                monst->loc.x = guardianX;
+                monst->loc.y = guardianY;
                 pmap[guardianX][guardianY].flags |= HAS_MONSTER;
                 rogue.yendorWarden = monst;
             }
@@ -1004,8 +1004,8 @@ void swapItemToEnchantLevel(item *theItem, short newEnchant, boolean enchantment
         sprintf(buf2, "%s shatter%s from the strain!",
                 buf1,
                 theItem->quantity == 1 ? "s" : "");
-        x = theItem->xLoc;
-        y = theItem->yLoc;
+        x = theItem->loc.x;
+        y = theItem->loc.y;
         removeItemFromChain(theItem, floorItems);
         pmap[x][y].flags &= ~(HAS_ITEM | ITEM_DETECTED);
         if (pmap[x][y].flags & (ANY_KIND_OF_VISIBLE | DISCOVERED | ITEM_DETECTED)) {
@@ -1100,15 +1100,15 @@ boolean swapItemEnchants(const short machineNumber) {
 }
 
 void updateFloorItems() {
-    short x, y, loc[2];
+    short x, y;
     char buf[DCOLS*3], buf2[DCOLS*3];
     enum dungeonLayers layer;
     item *theItem, *nextItem;
 
     for (theItem=floorItems->nextItem; theItem != NULL; theItem = nextItem) {
         nextItem = theItem->nextItem;
-        x = theItem->xLoc;
-        y = theItem->yLoc;
+        x = theItem->loc.x;
+        y = theItem->loc.y;
         if (rogue.absoluteTurnNumber < theItem->spawnTurnNumber) {
             // we are simulating an earlier turn than when the item fell into this level... let's not touch it yet
             continue;
@@ -1148,17 +1148,17 @@ void updateFloorItems() {
             continue;
         }
         if (cellHasTerrainFlag(x, y, T_MOVES_ITEMS)) {
-            getQualifyingLocNear(loc, x, y, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
+            pos loc;
+            getQualifyingLocNear(&loc, x, y, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
             removeItemFrom(x, y);
-            pmap[loc[0]][loc[1]].flags |= HAS_ITEM;
+            pmap[loc.x][loc.y].flags |= HAS_ITEM;
             if (pmap[x][y].flags & ITEM_DETECTED) {
                 pmap[x][y].flags &= ~ITEM_DETECTED;
-                pmap[loc[0]][loc[1]].flags |= ITEM_DETECTED;
+                pmap[loc.x][loc.y].flags |= ITEM_DETECTED;
             }
-            theItem->xLoc = loc[0];
-            theItem->yLoc = loc[1];
+            theItem->loc = loc;
             refreshDungeonCell(x, y);
-            refreshDungeonCell(loc[0], loc[1]);
+            refreshDungeonCell(loc.x, loc.y);
             continue;
         }
         if (cellHasTMFlag(x, y, TM_PROMOTES_ON_ITEM)) {
@@ -1170,7 +1170,7 @@ void updateFloorItems() {
             continue;
         }
         if (pmap[x][y].machineNumber
-            && pmap[x][y].machineNumber == pmap[player.xLoc][player.yLoc].machineNumber
+            && pmap[x][y].machineNumber == pmap[player.loc.x][player.loc.y].machineNumber
             && (theItem->flags & ITEM_KIND_AUTO_ID)) {
 
             identifyItemKind(theItem);
@@ -1179,8 +1179,8 @@ void updateFloorItems() {
             && pmap[x][y].machineNumber) {
 
             while (nextItem != NULL
-                   && pmap[x][y].machineNumber == pmap[nextItem->xLoc][nextItem->yLoc].machineNumber
-                   && cellHasTMFlag(nextItem->xLoc, nextItem->yLoc, TM_SWAP_ENCHANTS_ACTIVATION)) {
+                   && pmap[x][y].machineNumber == pmap[nextItem->loc.x][nextItem->loc.y].machineNumber
+                   && cellHasTMFlag(nextItem->loc.x, nextItem->loc.y, TM_SWAP_ENCHANTS_ACTIVATION)) {
 
                 // Skip future items that are also swappable, so that we don't inadvertently
                 // destroy the next item and then try to update it.
@@ -3233,8 +3233,8 @@ item *keyOnTileAt(short x, short y) {
     creature *monst;
 
     if ((pmap[x][y].flags & HAS_PLAYER)
-        && player.xLoc == x
-        && player.yLoc == y
+        && player.loc.x == x
+        && player.loc.y == y
         && keyInPackFor(x, y)) {
 
         return keyInPackFor(x, y);
@@ -3271,7 +3271,7 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
 
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        if (grid[monst->xLoc][monst->yLoc] <= distance) {
+        if (grid[monst->loc.x][monst->loc.y] <= distance) {
             if (monst->creatureState == MONSTER_SLEEPING) {
                 wakeUp(monst);
             }
@@ -3291,12 +3291,12 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
         }
     }
 
-    if (player.xLoc == x && player.yLoc == y) {
+    if (player.loc.x == x && player.loc.y == y) {
         player.status[STATUS_AGGRAVATING] = player.maxStatus[STATUS_AGGRAVATING] = distance;
         rogue.aggroRange = currentAggroValue();
     }
 
-    if (grid[player.xLoc][player.yLoc] >= 0 && grid[player.xLoc][player.yLoc] <= distance) {
+    if (grid[player.loc.x][player.loc.y] >= 0 && grid[player.loc.x][player.loc.y] <= distance) {
         discover(x, y);
         discoverCell(x, y);
         colorFlash(flashColor, 0, (DISCOVERED | MAGIC_MAPPED), 10, distance, x, y);
@@ -3381,7 +3381,7 @@ short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2],
             boolean targetsEnemies = theBolt->flags & BF_TARGET_ENEMIES;
             boolean targetsAllies = theBolt->flags & BF_TARGET_ALLIES;
             boolean burningThrough = (theBolt->flags & BF_FIERY) && cellHasTerrainFlag(x, y, T_IS_FLAMMABLE);
-            boolean isCastByPlayer = (originLoc[0] == player.xLoc && originLoc[1] == player.yLoc);
+            boolean isCastByPlayer = (originLoc[0] == player.loc.x && originLoc[1] == player.loc.y);
 
             creature *caster = monsterAtLoc(originLoc[0], originLoc[1]);
             creature *monst = monsterAtLoc(x, y);
@@ -3706,7 +3706,7 @@ boolean negate(creature *monst) {
             monst->info.flags &= ~NEGATABLE_TRAITS;
             negated = true;
             monst->wasNegated = true;
-            refreshDungeonCell(monst->xLoc, monst->yLoc);
+            refreshDungeonCell(monst->loc.x, monst->loc.y);
             refreshSideBar(-1, -1, false);
         }
         for (i = 0; i < 20; i++) {
@@ -3821,7 +3821,7 @@ boolean polymorph(creature *monst) {
 
     monst->ticksUntilTurn = max(monst->ticksUntilTurn, 101);
 
-    refreshDungeonCell(monst->xLoc, monst->yLoc);
+    refreshDungeonCell(monst->loc.x, monst->loc.y);
     if (boltCatalog[BOLT_POLYMORPH].backColor) {
         flashMonster(monst, boltCatalog[BOLT_POLYMORPH].backColor, 100);
     }
@@ -3903,7 +3903,7 @@ void makePlayerTelepathic(short duration) {
     player.status[STATUS_TELEPATHIC] = player.maxStatus[STATUS_TELEPATHIC] = duration;
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        refreshDungeonCell(monst->xLoc, monst->yLoc);
+        refreshDungeonCell(monst->loc.x, monst->loc.y);
     }
     if (!hasNextCreature(iterateCreatures(monsters))) {
         message("you can somehow tell that you are alone on this depth at the moment.", 0);
@@ -3973,7 +3973,7 @@ void rechargeItems(unsigned long categories) {
 //    char buf[DCOLS*3], mName[DCOLS];
 //
 //    for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
-//        if (pmap[monst->xLoc][monst->yLoc].flags & IN_FIELD_OF_VIEW
+//        if (pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW
 //            && monst->creatureState != MONSTER_FLEEING
 //            && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
 //
@@ -3993,7 +3993,7 @@ void rechargeItems(unsigned long categories) {
 //        sprintf(buf, "%s emits a brilliant flash of red light!", emitterName);
 //    }
 //    message(buf, 0);
-//    colorFlash(&redFlashColor, 0, IN_FIELD_OF_VIEW, 15, DCOLS, player.xLoc, player.yLoc);
+//    colorFlash(&redFlashColor, 0, IN_FIELD_OF_VIEW, 15, DCOLS, player.loc.x, player.loc.y);
 //}
 
 void negationBlast(const char *emitterName, const short distance) {
@@ -4002,13 +4002,13 @@ void negationBlast(const char *emitterName, const short distance) {
 
     sprintf(buf, "%s emits a numbing torrent of anti-magic!", emitterName);
     messageWithColor(buf, &itemMessageColor, 0);
-    colorFlash(&pink, 0, IN_FIELD_OF_VIEW, 3 + distance / 5, distance, player.xLoc, player.yLoc);
+    colorFlash(&pink, 0, IN_FIELD_OF_VIEW, 3 + distance / 5, distance, player.loc.x, player.loc.y);
     negate(&player);
     flashMonster(&player, &pink, 100);
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        if ((pmap[monst->xLoc][monst->yLoc].flags & IN_FIELD_OF_VIEW)
-            && (player.xLoc - monst->xLoc) * (player.xLoc - monst->xLoc) + (player.yLoc - monst->yLoc) * (player.yLoc - monst->yLoc) <= distance * distance) {
+        if ((pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW)
+            && (player.loc.x - monst->loc.x) * (player.loc.x - monst->loc.x) + (player.loc.y - monst->loc.y) * (player.loc.y - monst->loc.y) <= distance * distance) {
 
             if (canSeeMonster(monst)) {
                 flashMonster(monst, &pink, 100);
@@ -4017,8 +4017,8 @@ void negationBlast(const char *emitterName, const short distance) {
         }
     }
     for (theItem = floorItems; theItem != NULL; theItem = theItem->nextItem) {
-        if ((pmap[theItem->xLoc][theItem->yLoc].flags & IN_FIELD_OF_VIEW)
-            && (player.xLoc - theItem->xLoc) * (player.xLoc - theItem->xLoc) + (player.yLoc - theItem->yLoc) * (player.yLoc - theItem->yLoc) <= distance * distance) {
+        if ((pmap[theItem->loc.x][theItem->loc.y].flags & IN_FIELD_OF_VIEW)
+            && (player.loc.x - theItem->loc.x) * (player.loc.x - theItem->loc.x) + (player.loc.y - theItem->loc.y) * (player.loc.y - theItem->loc.y) <= distance * distance) {
 
             theItem->flags &= ~(ITEM_MAGIC_DETECTED | ITEM_CURSED);
             switch (theItem->category) {
@@ -4027,8 +4027,8 @@ void negationBlast(const char *emitterName, const short distance) {
                     theItem->enchant1 = theItem->enchant2 = theItem->charges = 0;
                     theItem->flags &= ~(ITEM_RUNIC | ITEM_RUNIC_HINTED | ITEM_RUNIC_IDENTIFIED | ITEM_PROTECTED);
                     identify(theItem);
-                    pmap[theItem->xLoc][theItem->yLoc].flags &= ~ITEM_DETECTED;
-                    refreshDungeonCell(theItem->xLoc, theItem->yLoc);
+                    pmap[theItem->loc.x][theItem->loc.y].flags &= ~ITEM_DETECTED;
+                    refreshDungeonCell(theItem->loc.x, theItem->loc.y);
                     break;
                 case STAFF:
                     theItem->charges = 0;
@@ -4057,11 +4057,11 @@ void discordBlast(const char *emitterName, const short distance) {
 
     sprintf(buf, "%s emits a wave of unsettling purple radiation!", emitterName);
     messageWithColor(buf, &itemMessageColor, 0);
-    colorFlash(&discordColor, 0, IN_FIELD_OF_VIEW, 3 + distance / 5, distance, player.xLoc, player.yLoc);
+    colorFlash(&discordColor, 0, IN_FIELD_OF_VIEW, 3 + distance / 5, distance, player.loc.x, player.loc.y);
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        if ((pmap[monst->xLoc][monst->yLoc].flags & IN_FIELD_OF_VIEW)
-            && (player.xLoc - monst->xLoc) * (player.xLoc - monst->xLoc) + (player.yLoc - monst->yLoc) * (player.yLoc - monst->yLoc) <= distance * distance) {
+        if ((pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW)
+            && (player.loc.x - monst->loc.x) * (player.loc.x - monst->loc.x) + (player.loc.y - monst->loc.y) * (player.loc.y - monst->loc.y) <= distance * distance) {
 
             if (!(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
                 if (canSeeMonster(monst)) {
@@ -4080,7 +4080,7 @@ void crystalize(short radius) {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j < DROWS; j++) {
-            if ((player.xLoc - i) * (player.xLoc - i) + (player.yLoc - j) * (player.yLoc - j) <= radius * radius
+            if ((player.loc.x - i) * (player.loc.x - i) + (player.loc.y - j) * (player.loc.y - j) <= radius * radius
                 && !(pmap[i][j].flags & IMPREGNABLE)) {
 
                 if (i == 0 || i == DCOLS - 1 || j == 0 || j == DROWS - 1) {
@@ -4103,7 +4103,7 @@ void crystalize(short radius) {
         }
     }
     updateVision(false);
-    colorFlash(&forceFieldColor, 0, 0, radius, radius, player.xLoc, player.yLoc);
+    colorFlash(&forceFieldColor, 0, 0, radius, radius, player.loc.x, player.loc.y);
     displayLevel();
     refreshSideBar(-1, -1, false);
 }
@@ -4118,7 +4118,7 @@ boolean imbueInvisibility(creature *monst, short duration) {
             autoID = true;
         }
         monst->status[STATUS_INVISIBLE] = monst->maxStatus[STATUS_INVISIBLE] = duration;
-        refreshDungeonCell(monst->xLoc, monst->yLoc);
+        refreshDungeonCell(monst->loc.x, monst->loc.y);
         refreshSideBar(-1, -1, false);
         if (boltCatalog[BOLT_POLYMORPH].backColor) {
             flashMonster(monst, boltCatalog[BOLT_INVISIBILITY].backColor, 100);
@@ -4251,11 +4251,11 @@ void beckonMonster(creature *monst, short x, short y) {
     if (monst->bookkeepingFlags & MB_CAPTIVE) {
         freeCaptive(monst);
     }
-    from[0] = monst->xLoc;
-    from[1] = monst->yLoc;
+    from[0] = monst->loc.x;
+    from[1] = monst->loc.y;
     to[0] = x;
     to[1] = y;
-    theBolt.magnitude = max(1, (distanceBetween(x, y, monst->xLoc, monst->yLoc) - 2) / 2);
+    theBolt.magnitude = max(1, (distanceBetween(x, y, monst->loc.x, monst->loc.y) - 2) / 2);
     zap(from, to, &theBolt, false);
     if (monst->ticksUntilTurn < player.attackSpeed+1) {
         monst->ticksUntilTurn = player.attackSpeed+1;
@@ -4392,12 +4392,12 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
             case BE_BECKONING:
                 if (!(monst->info.flags & MONST_IMMOBILE)
                     && caster
-                    && distanceBetween(caster->xLoc, caster->yLoc, monst->xLoc, monst->yLoc) > 1) {
+                    && distanceBetween(caster->loc.x, caster->loc.y, monst->loc.x, monst->loc.y) > 1) {
 
                     if (canSeeMonster(monst) && autoID) {
                         *autoID = true;
                     }
-                    beckonMonster(monst, caster->xLoc, caster->yLoc);
+                    beckonMonster(monst, caster->loc.x, caster->loc.y);
                     if (canSeeMonster(monst) && autoID) {
                         *autoID = true;
                     }
@@ -4442,7 +4442,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                         monst->status[STATUS_DISCORDANT] = 0;
                         becomeAllyWith(monst);
                         //refreshSideBar(-1, -1, false);
-                        refreshDungeonCell(monst->xLoc, monst->yLoc);
+                        refreshDungeonCell(monst->loc.x, monst->loc.y);
                         if (canSeeMonster(monst)) {
                             if (autoID) {
                                 *autoID = true;
@@ -4477,7 +4477,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                     && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
 
                     empowerMonster(monst);
-                    createFlare(monst->xLoc, monst->yLoc, EMPOWERMENT_LIGHT);
+                    createFlare(monst->loc.x, monst->loc.y, EMPOWERMENT_LIGHT);
                     if (canSeeMonster(monst) && autoID) {
                         *autoID = true;
                     }
@@ -4590,8 +4590,8 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
     switch (theBolt->boltEffect) {
         case BE_BLINKING:
             if (caster == &player) {
-                player.xLoc = x;
-                player.yLoc = y;
+                player.loc.x = x;
+                player.loc.y = y;
                 if (lightingChanged) {
                     *lightingChanged = true;
                 }
@@ -4658,7 +4658,7 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
         case BE_CONJURATION:
             for (i = 0; i < (staffBladeCount(theBolt->magnitude * FP_FACTOR)); i++) {
                 monst = generateMonster(MK_SPECTRAL_BLADE, true, false);
-                getQualifyingPathLocNear(&(monst->xLoc), &(monst->yLoc), x, y, true,
+                getQualifyingPathLocNear(&(monst->loc.x), &(monst->loc.y), x, y, true,
                                          T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                                          avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                 monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);
@@ -4666,8 +4666,8 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
                 monst->leader = &player;
                 monst->creatureState = MONSTER_ALLY;
                 monst->ticksUntilTurn = monst->info.attackSpeed + 1; // So they don't move before the player's next turn.
-                pmap[monst->xLoc][monst->yLoc].flags |= HAS_MONSTER;
-                //refreshDungeonCell(monst->xLoc, monst->yLoc);
+                pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
+                //refreshDungeonCell(monst->loc.x, monst->loc.y);
                 fadeInMonster(monst);
             }
             updateVision(true);
@@ -4680,13 +4680,13 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
         case BE_BLINKING:
             if (pmap[x][y].flags & HAS_MONSTER) { // We're blinking onto an area already occupied by a submerged monster.
                                                   // Make sure we don't get the shooting monster by accident.
-                caster->xLoc = caster->yLoc = -1; // Will be set back to the destination in a moment.
+                caster->loc.x = caster->loc.y = -1; // Will be set back to the destination in a moment.
                 monst = monsterAtLoc(x, y);
                 findAlternativeHomeFor(monst, &x2, &y2, true);
                 if (x2 >= 0) {
                     // Found an alternative location.
-                    monst->xLoc = x2;
-                    monst->yLoc = y2;
+                    monst->loc.x = x2;
+                    monst->loc.y = y2;
                     pmap[x][y].flags &= ~HAS_MONSTER;
                     pmap[x2][y2].flags |= HAS_MONSTER;
                 } else {
@@ -4699,8 +4699,8 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
             }
             caster->bookkeepingFlags &= ~MB_SUBMERGED;
             pmap[x][y].flags |= (caster == &player ? HAS_PLAYER : HAS_MONSTER);
-            caster->xLoc = x;
-            caster->yLoc = y;
+            caster->loc.x = x;
+            caster->loc.y = y;
             // Always break free on blink
             disentangle(caster);
             applyInstantTileEffectsToCreature(caster);
@@ -4708,8 +4708,8 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
                 // increase scent turn number so monsters don't sniff around at the old cell like idiots
                 rogue.scentTurnNumber += 30;
                 // get any items at the destination location
-                if (pmap[player.xLoc][player.yLoc].flags & HAS_ITEM) {
-                    pickUpItemAt(player.xLoc, player.yLoc);
+                if (pmap[player.loc.x][player.loc.y].flags & HAS_ITEM) {
+                    pickUpItemAt(player.loc.x, player.loc.y);
                 }
                 updateVision(true);
             }
@@ -5102,9 +5102,9 @@ boolean nextTargetAfter(short *returnX,
         n = (selectedIndex + i) % targetCount;
         newX = deduplicatedTargetList[n][0];
         newY = deduplicatedTargetList[n][1];
-        if ((newX != player.xLoc || newY != player.yLoc)
+        if ((newX != player.loc.x || newY != player.loc.y)
             && (newX != targetX || newY != targetY)
-            && (!requireOpenPath || openPathBetween(player.xLoc, player.yLoc, newX, newY))) {
+            && (!requireOpenPath || openPathBetween(player.loc.x, player.loc.y, newX, newY))) {
 
             brogueAssert(coordinatesAreInMap(newX, newY));
             brogueAssert(n >= 0 && n < targetCount);
@@ -5418,7 +5418,7 @@ static boolean creatureIsTargetable(creature *monst) {
         && canSeeMonster(monst)
         && monst->depth == rogue.depthLevel
         && !(monst->bookkeepingFlags & MB_IS_DYING)
-        && openPathBetween(player.xLoc, player.yLoc, monst->xLoc, monst->yLoc);
+        && openPathBetween(player.loc.x, player.loc.y, monst->loc.x, monst->loc.y);
 }
 
 // Return true if a target is chosen, or false if canceled.
@@ -5449,11 +5449,11 @@ boolean chooseTarget(short returnLoc[2],
     rogue.RNG = RNG_COSMETIC;
     //assureCosmeticRNG;
 
-    originLoc[0] = player.xLoc;
-    originLoc[1] = player.yLoc;
+    originLoc[0] = player.loc.x;
+    originLoc[1] = player.loc.y;
 
-    targetLoc[0] = oldTargetLoc[0] = player.xLoc;
-    targetLoc[1] = oldTargetLoc[1] = player.yLoc;
+    targetLoc[0] = oldTargetLoc[0] = player.loc.x;
+    targetLoc[1] = oldTargetLoc[1] = player.loc.y;
 
     if (autoTarget) {
         if (creatureIsTargetable(rogue.lastTarget) && (targetAllies == (rogue.lastTarget->creatureState == MONSTER_ALLY))) {
@@ -5467,9 +5467,9 @@ boolean chooseTarget(short returnLoc[2],
             monst = monsterAtLoc(targetLoc[0], targetLoc[1]);
         }
         if (monst) {
-            targetLoc[0] = monst->xLoc;
-            targetLoc[1] = monst->yLoc;
-            refreshSideBar(monst->xLoc, monst->yLoc, false);
+            targetLoc[0] = monst->loc.x;
+            targetLoc[1] = monst->loc.y;
+            refreshSideBar(monst->loc.x, monst->loc.y, false);
             focusedOnSomething = true;
         }
     }
@@ -5479,7 +5479,7 @@ boolean chooseTarget(short returnLoc[2],
         numCells = min(numCells, maxDistance);
     }
     if (stopAtTarget) {
-        numCells = min(numCells, distanceBetween(player.xLoc, player.yLoc, targetLoc[0], targetLoc[1]));
+        numCells = min(numCells, distanceBetween(player.loc.x, player.loc.y, targetLoc[0], targetLoc[1]));
     }
 
     targetConfirmed = canceled = tabKey = false;
@@ -5527,7 +5527,7 @@ boolean chooseTarget(short returnLoc[2],
             }
 
             if (stopAtTarget) {
-                numCells = min(numCells, distanceBetween(player.xLoc, player.yLoc, targetLoc[0], targetLoc[1]));
+                numCells = min(numCells, distanceBetween(player.loc.x, player.loc.y, targetLoc[0], targetLoc[1]));
             }
             distance = hiliteTrajectory(coordinates, numCells, false, theBolt, &trajColor);
             cursorInTrajectory = false;
@@ -5745,14 +5745,13 @@ void throwItem(item *theItem, creature *thrower, short targetLoc[2], short maxDi
     char buf[COLS*3], buf2[COLS*3], buf3[COLS*3];
     enum displayGlyph displayChar;
     color foreColor, backColor, multColor;
-    short dropLoc[2];
     boolean hitSomethingSolid = false, fastForward = false;
     enum dungeonLayers layer;
 
     theItem->flags |= ITEM_PLAYER_AVOIDS; // Avoid thrown items, unless it's a weapon that misses a monster.
 
-    x = originLoc[0] = thrower->xLoc;
-    y = originLoc[1] = thrower->yLoc;
+    x = originLoc[0] = thrower->loc.x;
+    y = originLoc[1] = thrower->loc.y;
 
     // Using BOLT_NONE for throws because all flags are off, which means we'll try to avoid all obstacles in front of the target
     numCells = getLineCoordinates(listOfCoordinates, originLoc, targetLoc, &boltCatalog[BOLT_NONE]);
@@ -5819,8 +5818,8 @@ void throwItem(item *theItem, creature *thrower, short targetLoc[2], short maxDi
                     x = listOfCoordinates[i][0];
                     y = listOfCoordinates[i][1];
                 } else { // it was aimed point-blank into an obstruction
-                    x = thrower->xLoc;
-                    y = thrower->yLoc;
+                    x = thrower->loc.x;
+                    y = thrower->loc.y;
                 }
             }
             hitSomethingSolid = true;
@@ -5927,9 +5926,10 @@ void throwItem(item *theItem, creature *thrower, short targetLoc[2], short maxDi
         deleteItem(theItem);
         return;
     }
-    getQualifyingLocNear(dropLoc, x, y, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
-    placeItem(theItem, dropLoc[0], dropLoc[1]);
-    refreshDungeonCell(dropLoc[0], dropLoc[1]);
+    pos dropLoc;
+    getQualifyingLocNear(&dropLoc, x, y, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
+    placeItem(theItem, dropLoc.x, dropLoc.y);
+    refreshDungeonCell(dropLoc.x, dropLoc.y);
 }
 
 /*
@@ -6013,8 +6013,8 @@ void throwCommand(item *theItem, boolean autoThrow) {
     }
 
     if (autoThrow && creatureIsTargetable(rogue.lastTarget)) {
-        zapTarget[0] = rogue.lastTarget->xLoc;
-        zapTarget[1] = rogue.lastTarget->yLoc;
+        zapTarget[0] = rogue.lastTarget->loc.x;
+        zapTarget[1] = rogue.lastTarget->loc.y;
     } else if (!chooseTarget(zapTarget, maxDistance, true, autoTarget, false, &boltCatalog[BOLT_NONE], &red)) {
         // player doesn't choose a target? return
         return;
@@ -6262,8 +6262,8 @@ boolean useStaffOrWand(item *theItem, boolean *commandsRecorded) {
         trajectoryHiliteColor = *theBolt.backColor;
     }
 
-    originLoc[0] = player.xLoc;
-    originLoc[1] = player.yLoc;
+    originLoc[0] = player.loc.x;
+    originLoc[1] = player.loc.y;
     confirmedTarget = chooseTarget(zapTarget, maxDistance, false, autoTarget,
         targetAllies, (boltKnown ? &theBolt : &boltCatalog[BOLT_NONE]), &trajectoryHiliteColor);
     if (confirmedTarget
@@ -6319,11 +6319,11 @@ boolean useStaffOrWand(item *theItem, boolean *commandsRecorded) {
 }
 
 void summonGuardian(item *theItem) {
-    short x = player.xLoc, y = player.yLoc;
+    short x = player.loc.x, y = player.loc.y;
     creature *monst;
 
     monst = generateMonster(MK_CHARM_GUARDIAN, false, false);
-    getQualifyingPathLocNear(&(monst->xLoc), &(monst->yLoc), x, y, true,
+    getQualifyingPathLocNear(&(monst->loc.x), &(monst->loc.y), x, y, true,
                              T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                              avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
     monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);
@@ -6332,7 +6332,7 @@ void summonGuardian(item *theItem) {
     monst->creatureState = MONSTER_ALLY;
     monst->ticksUntilTurn = monst->info.attackSpeed + 1; // So they don't move before the player's next turn.
     monst->status[STATUS_LIFESPAN_REMAINING] = monst->maxStatus[STATUS_LIFESPAN_REMAINING] = charmGuardianLifespan(netEnchant(theItem));
-    pmap[monst->xLoc][monst->yLoc].flags |= HAS_MONSTER;
+    pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
     fadeInMonster(monst);
 }
 
@@ -6824,7 +6824,7 @@ void readScroll(item *theItem) {
                 messageWithColor(buf2, &itemMessageColor, 0);
                 theItem->flags &= ~ITEM_CURSED;
             }
-            createFlare(player.xLoc, player.yLoc, SCROLL_ENCHANTMENT_LIGHT);
+            createFlare(player.loc.x, player.loc.y, SCROLL_ENCHANTMENT_LIGHT);
             break;
         case SCROLL_RECHARGING:
             rechargeItems(STAFF | CHARM);
@@ -6844,7 +6844,7 @@ void readScroll(item *theItem) {
             } else {
                 message("a protective golden light surrounds you, but it quickly disperses.", 0);
             }
-            createFlare(player.xLoc, player.yLoc, SCROLL_PROTECTION_LIGHT);
+            createFlare(player.loc.x, player.loc.y, SCROLL_PROTECTION_LIGHT);
             break;
         case SCROLL_PROTECT_WEAPON:
             if (rogue.weapon) {
@@ -6864,10 +6864,10 @@ void readScroll(item *theItem) {
             } else {
                 message("a protective golden light covers your empty hands, but it quickly disperses.", 0);
             }
-            createFlare(player.xLoc, player.yLoc, SCROLL_PROTECTION_LIGHT);
+            createFlare(player.loc.x, player.loc.y, SCROLL_PROTECTION_LIGHT);
             break;
         case SCROLL_SANCTUARY:
-            spawnDungeonFeature(player.xLoc, player.yLoc, &dungeonFeatureCatalog[DF_SACRED_GLYPHS], true, false);
+            spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_SACRED_GLYPHS], true, false);
             messageWithColor("sprays of color arc to the ground, forming glyphs where they alight.", &itemMessageColor, 0);
             break;
         case SCROLL_MAGIC_MAPPING:
@@ -6889,17 +6889,17 @@ void readScroll(item *theItem) {
                     }
                 }
             }
-            colorFlash(&magicMapFlashColor, 0, MAGIC_MAPPED, 15, DCOLS + DROWS, player.xLoc, player.yLoc);
+            colorFlash(&magicMapFlashColor, 0, MAGIC_MAPPED, 15, DCOLS + DROWS, player.loc.x, player.loc.y);
             break;
         case SCROLL_AGGRAVATE_MONSTER:
-            aggravateMonsters(DCOLS + DROWS, player.xLoc, player.yLoc, &gray);
+            aggravateMonsters(DCOLS + DROWS, player.loc.x, player.loc.y, &gray);
             message("the scroll emits a piercing shriek that echoes throughout the dungeon!", 0);
             break;
         case SCROLL_SUMMON_MONSTER:
             for (j=0; j<25 && numberOfMonsters < 3; j++) {
                 for (i=0; i<8; i++) {
-                    x = player.xLoc + nbDirs[i][0];
-                    y = player.yLoc + nbDirs[i][1];
+                    x = player.loc.x + nbDirs[i][0];
+                    y = player.loc.y + nbDirs[i][1];
                     if (!cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY) && !(pmap[x][y].flags & HAS_MONSTER)
                         && rand_percent(10) && (numberOfMonsters < 3)) {
                         monst = spawnHorde(0, x, y, (HORDE_LEADER_CAPTIVE | HORDE_NO_PERIODIC_SPAWN | HORDE_IS_SUMMONED | HORDE_MACHINE_ONLY), 0);
@@ -6971,9 +6971,9 @@ void drinkPotion(item *theItem) {
             message("colors are everywhere! The walls are singing!", 0);
             break;
         case POTION_INCINERATION:
-            //colorFlash(&darkOrange, 0, IN_FIELD_OF_VIEW, 4, 4, player.xLoc, player.yLoc);
+            //colorFlash(&darkOrange, 0, IN_FIELD_OF_VIEW, 4, 4, player.loc.x, player.loc.y);
             message("as you uncork the flask, it explodes in flame!", 0);
-            spawnDungeonFeature(player.xLoc, player.yLoc, &dungeonFeatureCatalog[DF_INCINERATION_POTION], true, false);
+            spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_INCINERATION_POTION], true, false);
             exposeCreatureToFire(&player);
             break;
         case POTION_DARKNESS:
@@ -6984,9 +6984,9 @@ void drinkPotion(item *theItem) {
             message("your vision flickers as a cloak of darkness settles around you!", 0);
             break;
         case POTION_DESCENT:
-            colorFlash(&darkBlue, 0, IN_FIELD_OF_VIEW, 3, 3, player.xLoc, player.yLoc);
+            colorFlash(&darkBlue, 0, IN_FIELD_OF_VIEW, 3, 3, player.loc.x, player.loc.y);
             message("vapor pours out of the flask and causes the floor to disappear!", 0);
-            spawnDungeonFeature(player.xLoc, player.yLoc, &dungeonFeatureCatalog[DF_HOLE_POTION], true, false);
+            spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_HOLE_POTION], true, false);
             if (!player.status[STATUS_LEVITATING]) {
                 player.bookkeepingFlags |= MB_IS_FALLING;
             }
@@ -6998,14 +6998,14 @@ void drinkPotion(item *theItem) {
             }
             updateEncumbrance();
             messageWithColor("newfound strength surges through your body.", &advancementMessageColor, 0);
-            createFlare(player.xLoc, player.yLoc, POTION_STRENGTH_LIGHT);
+            createFlare(player.loc.x, player.loc.y, POTION_STRENGTH_LIGHT);
             break;
         case POTION_POISON:
-            spawnDungeonFeature(player.xLoc, player.yLoc, &dungeonFeatureCatalog[DF_POISON_GAS_CLOUD_POTION], true, false);
+            spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_POISON_GAS_CLOUD_POTION], true, false);
             message("caustic gas billows out of the open flask!", 0);
             break;
         case POTION_PARALYSIS:
-            spawnDungeonFeature(player.xLoc, player.yLoc, &dungeonFeatureCatalog[DF_PARALYSIS_GAS_CLOUD_POTION], true, false);
+            spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_PARALYSIS_GAS_CLOUD_POTION], true, false);
             message("your muscles stiffen as a cloud of pink gas bursts from the open flask!", 0);
             break;
         case POTION_TELEPATHY:
@@ -7017,12 +7017,12 @@ void drinkPotion(item *theItem) {
             message("you float into the air!", 0);
             break;
         case POTION_CONFUSION:
-            spawnDungeonFeature(player.xLoc, player.yLoc, &dungeonFeatureCatalog[DF_CONFUSION_GAS_CLOUD_POTION], true, false);
+            spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_CONFUSION_GAS_CLOUD_POTION], true, false);
             message("a shimmering cloud of rainbow-colored gas billows out of the open flask!", 0);
             break;
         case POTION_LICHEN:
             message("a handful of tiny spores burst out of the open flask!", 0);
-            spawnDungeonFeature(player.xLoc, player.yLoc, &dungeonFeatureCatalog[DF_LICHEN_PLANTED], true, false);
+            spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_LICHEN_PLANTED], true, false);
             break;
         case POTION_DETECT_MAGIC:
             hadEffect = false;
@@ -7031,9 +7031,9 @@ void drinkPotion(item *theItem) {
                 if (tempItem->category & CAN_BE_DETECTED) {
                     detectMagicOnItem(tempItem);
                     if (itemMagicPolarity(tempItem)) {
-                        pmap[tempItem->xLoc][tempItem->yLoc].flags |= ITEM_DETECTED;
+                        pmap[tempItem->loc.x][tempItem->loc.y].flags |= ITEM_DETECTED;
                         hadEffect = true;
-                        refreshDungeonCell(tempItem->xLoc, tempItem->yLoc);
+                        refreshDungeonCell(tempItem->loc.x, tempItem->loc.y);
                     }
                 }
             }
@@ -7043,7 +7043,7 @@ void drinkPotion(item *theItem) {
                     detectMagicOnItem(monst->carriedItem);
                     if (itemMagicPolarity(monst->carriedItem)) {
                         hadEffect = true;
-                        refreshDungeonCell(monst->xLoc, monst->yLoc);
+                        refreshDungeonCell(monst->loc.x, monst->loc.y);
                     }
                 }
             }
@@ -7244,7 +7244,7 @@ void unequip(item *theItem) {
 }
 
 boolean canDrop() {
-    if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_OBSTRUCTS_ITEMS)) {
+    if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_ITEMS)) {
         return false;
     }
     return true;
@@ -7343,7 +7343,7 @@ item *itemAtLoc(short x, short y) {
     if (!(pmap[x][y].flags & HAS_ITEM)) {
         return NULL; // easy optimization
     }
-    for (theItem = floorItems->nextItem; theItem != NULL && (theItem->xLoc != x || theItem->yLoc != y); theItem = theItem->nextItem);
+    for (theItem = floorItems->nextItem; theItem != NULL && (theItem->loc.x != x || theItem->loc.y != y); theItem = theItem->nextItem);
     if (theItem == NULL) {
         pmap[x][y].flags &= ~HAS_ITEM;
         hiliteCell(x, y, &white, 75, true);
@@ -7357,11 +7357,11 @@ item *itemAtLoc(short x, short y) {
 item *dropItem(item *theItem) {
     item *itemFromTopOfStack, *itemOnFloor;
 
-    if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_OBSTRUCTS_ITEMS)) {
+    if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_ITEMS)) {
         return NULL;
     }
 
-    itemOnFloor = itemAtLoc(player.xLoc, player.yLoc);
+    itemOnFloor = itemAtLoc(player.loc.x, player.loc.y);
 
     if (theItem->quantity > 1 && !(theItem->category & (WEAPON | GEM))) { // peel off the top item and drop it
         itemFromTopOfStack = generateItem(ALL_ITEMS, -1);
@@ -7370,9 +7370,9 @@ item *dropItem(item *theItem) {
         itemFromTopOfStack->quantity = 1;
         if (itemOnFloor) {
             itemOnFloor->inventoryLetter = theItem->inventoryLetter; // just in case all letters are taken
-            pickUpItemAt(player.xLoc, player.yLoc);
+            pickUpItemAt(player.loc.x, player.loc.y);
         }
-        placeItem(itemFromTopOfStack, player.xLoc, player.yLoc);
+        placeItem(itemFromTopOfStack, player.loc.x, player.loc.y);
         return itemFromTopOfStack;
     } else { // drop the entire item
         if (rogue.swappedIn == theItem || rogue.swappedOut == theItem) {
@@ -7382,9 +7382,9 @@ item *dropItem(item *theItem) {
         removeItemFromChain(theItem, packItems);
         if (itemOnFloor) {
             itemOnFloor->inventoryLetter = theItem->inventoryLetter;
-            pickUpItemAt(player.xLoc, player.yLoc);
+            pickUpItemAt(player.loc.x, player.loc.y);
         }
-        placeItem(theItem, player.xLoc, player.yLoc);
+        placeItem(theItem, player.loc.x, player.loc.y);
         return theItem;
     }
 }

--- a/src/brogue/Light.c
+++ b/src/brogue/Light.c
@@ -241,18 +241,18 @@ void updateLighting() {
         creature *monst = !handledPlayer ? &player : nextCreature(&it);
         handledPlayer = true;
         if (monst->info.intrinsicLightType) {
-            paintLight(&lightCatalog[monst->info.intrinsicLightType], monst->xLoc, monst->yLoc, false, false);
+            paintLight(&lightCatalog[monst->info.intrinsicLightType], monst->loc.x, monst->loc.y, false, false);
         }
         if (monst->mutationIndex >= 0 && mutationCatalog[monst->mutationIndex].light != NO_LIGHT) {
-            paintLight(&lightCatalog[mutationCatalog[monst->mutationIndex].light], monst->xLoc, monst->yLoc, false, false);
+            paintLight(&lightCatalog[mutationCatalog[monst->mutationIndex].light], monst->loc.x, monst->loc.y, false, false);
         }
 
         if (monst->status[STATUS_BURNING] && !(monst->info.flags & MONST_FIERY)) {
-            paintLight(&lightCatalog[BURNING_CREATURE_LIGHT], monst->xLoc, monst->yLoc, false, false);
+            paintLight(&lightCatalog[BURNING_CREATURE_LIGHT], monst->loc.x, monst->loc.y, false, false);
         }
 
         if (monsterRevealed(monst)) {
-            paintLight(&lightCatalog[TELEPATHY_LIGHT], monst->xLoc, monst->yLoc, false, true);
+            paintLight(&lightCatalog[TELEPATHY_LIGHT], monst->loc.x, monst->loc.y, false, true);
         }
     }
 
@@ -260,20 +260,20 @@ void updateLighting() {
     for (creatureIterator it = iterateCreatures(dormantMonsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
         if (monsterRevealed(monst)) {
-            paintLight(&lightCatalog[TELEPATHY_LIGHT], monst->xLoc, monst->yLoc, false, true);
+            paintLight(&lightCatalog[TELEPATHY_LIGHT], monst->loc.x, monst->loc.y, false, true);
         }
     }
 
     updateDisplayDetail();
 
     // Miner's light:
-    paintLight(&rogue.minersLight, player.xLoc, player.yLoc, true, true);
+    paintLight(&rogue.minersLight, player.loc.x, player.loc.y, true, true);
 
     if (player.status[STATUS_INVISIBLE]) {
         player.info.foreColor = &playerInvisibleColor;
     } else if (playerInDarkness()) {
         player.info.foreColor = &playerInDarknessColor;
-    } else if (pmap[player.xLoc][player.yLoc].flags & IS_IN_SHADOW) {
+    } else if (pmap[player.loc.x][player.loc.y].flags & IS_IN_SHADOW) {
         player.info.foreColor = &playerInShadowColor;
     } else {
         player.info.foreColor = &playerInLightColor;
@@ -281,9 +281,9 @@ void updateLighting() {
 }
 
 boolean playerInDarkness() {
-    return (tmap[player.xLoc][player.yLoc].light[0] + 10 < minersLightColor.red
-            && tmap[player.xLoc][player.yLoc].light[1] + 10 < minersLightColor.green
-            && tmap[player.xLoc][player.yLoc].light[2] + 10 < minersLightColor.blue);
+    return (tmap[player.loc.x][player.loc.y].light[0] + 10 < minersLightColor.red
+            && tmap[player.loc.x][player.loc.y].light[1] + 10 < minersLightColor.green
+            && tmap[player.loc.x][player.loc.y].light[2] + 10 < minersLightColor.blue);
 }
 
 #define flarePrecision 1000
@@ -292,8 +292,8 @@ flare *newFlare(lightSource *light, short x, short y, short changePerFrame, shor
     flare *theFlare = malloc(sizeof(flare));
     memset(theFlare, '\0', sizeof(flare));
     theFlare->light = light;
-    theFlare->xLoc = x;
-    theFlare->yLoc = y;
+    theFlare->loc.x = x;
+    theFlare->loc.y = y;
     theFlare->coeffChangeAmount = changePerFrame;
     if (theFlare->coeffChangeAmount == 0) {
         theFlare->coeffChangeAmount = 1; // no change would mean it lasts forever, which usually breaks things
@@ -360,7 +360,7 @@ boolean drawFlareFrame(flare *theFlare) {
     tempLight.lightRadius.upperBound = ((long) tempLight.lightRadius.upperBound) * theFlare->coeff / (flarePrecision * 100);
     applyColorScalar(&tempColor, theFlare->coeff / flarePrecision);
     tempLight.lightColor = &tempColor;
-    inView = paintLight(&tempLight, theFlare->xLoc, theFlare->yLoc, false, true);
+    inView = paintLight(&tempLight, theFlare->loc.x, theFlare->loc.y, false, true);
 
     return inView;
 }

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1646,13 +1646,13 @@ void travel(short x, short y, boolean autoConfirm) {
             }
         }
 //      if (player.loc.x == x && player.loc.y == y) {
-//          rogue.cursorLoc[0] = rogue.cursorLoc[1] = 0;
+//          rogue.cursorLoc.x = rogue.cursorLoc.y = 0;
 //      } else {
-//          rogue.cursorLoc[0] = x;
-//          rogue.cursorLoc[1] = y;
+//          rogue.cursorLoc.x = x;
+//          rogue.cursorLoc.y = y;
 //      }
     } else {
-        rogue.cursorLoc[0] = rogue.cursorLoc[1] = -1;
+        rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
         message("No path is available.", 0);
     }
     freeGrid(distanceMap);
@@ -2141,11 +2141,11 @@ boolean proposeOrConfirmLocation(short x, short y, char *failureMessage) {
     if (player.loc.x == x && player.loc.y == y) {
         message("you are already there.", 0);
     } else if (pmap[x][y].flags & (DISCOVERED | MAGIC_MAPPED)) {
-        if (rogue.cursorLoc[0] == x && rogue.cursorLoc[1] == y) {
+        if (rogue.cursorLoc.x == x && rogue.cursorLoc.y == y) {
             retval = true;
         } else {
-            rogue.cursorLoc[0] = x;
-            rogue.cursorLoc[1] = y;
+            rogue.cursorLoc.x = x;
+            rogue.cursorLoc.y = y;
         }
     } else {
         message(failureMessage, 0);
@@ -2160,7 +2160,7 @@ boolean useStairs(short stairDirection) {
     if (stairDirection == 1) {
         if (rogue.depthLevel < DEEPEST_LEVEL) {
             //copyDisplayBuffer(fromBuf, displayBuffer);
-            rogue.cursorLoc[0] = rogue.cursorLoc[1] = -1;
+            rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
             rogue.depthLevel++;
             message("You descend.", 0);
             startLevel(rogue.depthLevel - 1, stairDirection);
@@ -2179,7 +2179,7 @@ boolean useStairs(short stairDirection) {
         succeeded = true;
     } else {
         if (rogue.depthLevel > 1 || numberOfMatchingPackItems(AMULET, 0, 0, false)) {
-            rogue.cursorLoc[0] = rogue.cursorLoc[1] = -1;
+            rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
             rogue.depthLevel--;
             if (rogue.depthLevel == 0) {
                 victory(false);

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -31,8 +31,8 @@ void playerRuns(short direction) {
     rogue.disturbed = (player.status[STATUS_CONFUSED] ? true : false);
 
     for (dir = 0; dir < 4; dir++) {
-        newX = player.xLoc + nbDirs[dir][0];
-        newY = player.yLoc + nbDirs[dir][1];
+        newX = player.loc.x + nbDirs[dir][0];
+        newY = player.loc.y + nbDirs[dir][1];
         cardinalPassability[dir] = monsterAvoids(&player, newX, newY);
     }
 
@@ -42,19 +42,19 @@ void playerRuns(short direction) {
             break;
         }
 
-        newX = player.xLoc + nbDirs[direction][0];
-        newY = player.yLoc + nbDirs[direction][1];
+        newX = player.loc.x + nbDirs[direction][0];
+        newY = player.loc.y + nbDirs[direction][1];
         if (!coordinatesAreInMap(newX, newY)
             || monsterAvoids(&player, newX, newY)) {
 
             rogue.disturbed = true;
         }
-        if (isDisturbed(player.xLoc, player.yLoc)) {
+        if (isDisturbed(player.loc.x, player.loc.y)) {
             rogue.disturbed = true;
         } else if (direction < 4) {
             for (dir = 0; dir < 4; dir++) {
-                newX = player.xLoc + nbDirs[dir][0];
-                newY = player.yLoc + nbDirs[dir][1];
+                newX = player.loc.x + nbDirs[dir][0];
+                newY = player.loc.y + nbDirs[dir][1];
                 if (cardinalPassability[dir] != monsterAvoids(&player, newX, newY)
                     && !(nbDirs[dir][0] + nbDirs[direction][0] == 0 &&
                          nbDirs[dir][1] + nbDirs[direction][1] == 0)) {
@@ -152,7 +152,7 @@ void describeLocation(char *buf, short x, short y) {
 
     assureCosmeticRNG;
 
-    if (x == player.xLoc && y == player.yLoc) {
+    if (x == player.loc.x && y == player.loc.y) {
         if (player.status[STATUS_LEVITATING]) {
             sprintf(buf, "you are hovering above %s.", tileText(x, y));
         } else {
@@ -305,7 +305,7 @@ void describeLocation(char *buf, short x, short y) {
         } else if (monst->status[STATUS_CONFUSED]) {
             strcpy(verb, "is staggering");
         } else if ((monst->info.flags & MONST_RESTRICTED_TO_LIQUID)
-                   && !cellHasTMFlag(monst->xLoc, monst->yLoc, TM_ALLOWS_SUBMERGING)) {
+                   && !cellHasTMFlag(monst->loc.x, monst->loc.y, TM_ALLOWS_SUBMERGING)) {
             strcpy(verb, "is lying");
             subjectMoving = false;
         } else if (monst->info.flags & MONST_IMMOBILE) {
@@ -465,7 +465,7 @@ short randValidDirectionFrom(creature *monst, short x, short y, boolean respectA
 
 void vomit(creature *monst) {
     char buf[COLS], monstName[COLS];
-    spawnDungeonFeature(monst->xLoc, monst->yLoc, &dungeonFeatureCatalog[DF_VOMIT], true, false);
+    spawnDungeonFeature(monst->loc.x, monst->loc.y, &dungeonFeatureCatalog[DF_VOMIT], true, false);
 
     if (canDirectlySeeMonster(monst)
         && !rogue.automationActive) {
@@ -513,7 +513,7 @@ void becomeAllyWith(creature *monst) {
     monst->bookkeepingFlags |= MB_FOLLOWER;
     monst->leader = &player;
     monst->bookkeepingFlags &= ~(MB_CAPTIVE | MB_SEIZED);
-    refreshDungeonCell(monst->xLoc, monst->yLoc);
+    refreshDungeonCell(monst->loc.x, monst->loc.y);
 }
 
 void freeCaptive(creature *monst) {
@@ -596,10 +596,10 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
     } else if (!(attacker->info.abilityFlags & MA_ATTACKS_EXTEND)) {
         return false;
     }
-    originLoc[0] = attacker->xLoc;
-    originLoc[1] = attacker->yLoc;
-    targetLoc[0] = attacker->xLoc + nbDirs[dir][0];
-    targetLoc[1] = attacker->yLoc + nbDirs[dir][1];
+    originLoc[0] = attacker->loc.x;
+    originLoc[1] = attacker->loc.y;
+    targetLoc[0] = attacker->loc.x + nbDirs[dir][0];
+    targetLoc[1] = attacker->loc.y + nbDirs[dir][1];
     getImpactLoc(strikeLoc, originLoc, targetLoc, 5, false, &boltCatalog[BOLT_WHIP]);
 
     defender = monsterAtLoc(strikeLoc[0], strikeLoc[1]);
@@ -649,8 +649,8 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
     }
 
     for (i = 0; i < range; i++) {
-        targetLoc[0] = attacker->xLoc + (1 + i) * nbDirs[dir][0];
-        targetLoc[1] = attacker->yLoc + (1 + i) * nbDirs[dir][1];
+        targetLoc[0] = attacker->loc.x + (1 + i) * nbDirs[dir][0];
+        targetLoc[1] = attacker->loc.y + (1 + i) * nbDirs[dir][1];
         if (!coordinatesAreInMap(targetLoc[0], targetLoc[1])) {
             break;
         }
@@ -692,8 +692,8 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         }
         if (!rogue.playbackFastForward) {
             for (i = 0; i < range; i++) {
-                targetLoc[0] = attacker->xLoc + (1 + i) * nbDirs[dir][0];
-                targetLoc[1] = attacker->yLoc + (1 + i) * nbDirs[dir][1];
+                targetLoc[0] = attacker->loc.x + (1 + i) * nbDirs[dir][0];
+                targetLoc[1] = attacker->loc.y + (1 + i) * nbDirs[dir][1];
                 if (coordinatesAreInMap(targetLoc[0], targetLoc[1])
                     && playerCanSeeOrSense(targetLoc[0], targetLoc[1])) {
 
@@ -711,8 +711,8 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         if (visualEffect) {
             pauseBrogue(16);
             for (i = 0; i < range; i++) {
-                targetLoc[0] = attacker->xLoc + (1 + i) * nbDirs[dir][0];
-                targetLoc[1] = attacker->yLoc + (1 + i) * nbDirs[dir][1];
+                targetLoc[0] = attacker->loc.x + (1 + i) * nbDirs[dir][0];
+                targetLoc[1] = attacker->loc.y + (1 + i) * nbDirs[dir][1];
                 if (coordinatesAreInMap(targetLoc[0], targetLoc[1])) {
                     refreshDungeonCell(targetLoc[0], targetLoc[1]);
                 }
@@ -729,15 +729,15 @@ void buildFlailHitList(const short x, const short y, const short newX, const sho
 
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        mx = monst->xLoc;
-        my = monst->yLoc;
+        mx = monst->loc.x;
+        my = monst->loc.y;
         if (distanceBetween(x, y, mx, my) == 1
             && distanceBetween(newX, newY, mx, my) == 1
             && canSeeMonster(monst)
             && monstersAreEnemies(&player, monst)
             && monst->creatureState != MONSTER_ALLY
             && !(monst->bookkeepingFlags & MB_IS_DYING)
-            && (!cellHasTerrainFlag(monst->xLoc, monst->yLoc, T_OBSTRUCTS_PASSABILITY) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
+            && (!cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
 
             while (hitList[i]) {
                 i++;
@@ -767,7 +767,7 @@ boolean diagonalBlocked(const short x1, const short y1, const short x2, const sh
 // Can be called from movement keys, exploration, or auto-travel.
 boolean playerMoves(short direction) {
     short initialDirection = direction, i, layer;
-    short x = player.xLoc, y = player.yLoc;
+    short x = player.loc.x, y = player.loc.y;
     short newX, newY, newestX, newestY;
     boolean playerMoved = false, specialAttackAborted = false, anyAttackHit = false;
     creature *defender = NULL, *tempMonst = NULL, *hitList[16] = {NULL};
@@ -946,8 +946,8 @@ boolean playerMoves(short direction) {
                 creature *tempMonst = nextCreature(&it);
                 if ((tempMonst->bookkeepingFlags & MB_SEIZING)
                     && monstersAreEnemies(&player, tempMonst)
-                    && distanceBetween(player.xLoc, player.yLoc, tempMonst->xLoc, tempMonst->yLoc) == 1
-                    && !diagonalBlocked(player.xLoc, player.yLoc, tempMonst->xLoc, tempMonst->yLoc, false)
+                    && distanceBetween(player.loc.x, player.loc.y, tempMonst->loc.x, tempMonst->loc.y) == 1
+                    && !diagonalBlocked(player.loc.x, player.loc.y, tempMonst->loc.x, tempMonst->loc.y, false)
                     && !tempMonst->status[STATUS_ENTRANCED]) {
 
                     monsterName(monstName, tempMonst, true);
@@ -1034,8 +1034,8 @@ boolean playerMoves(short direction) {
         }
 
         if (rogue.weapon && (rogue.weapon->flags & ITEM_LUNGE_ATTACKS)) {
-            newestX = player.xLoc + 2*nbDirs[direction][0];
-            newestY = player.yLoc + 2*nbDirs[direction][1];
+            newestX = player.loc.x + 2*nbDirs[direction][0];
+            newestY = player.loc.y + 2*nbDirs[direction][1];
             if (coordinatesAreInMap(newestX, newestY) && (pmap[newestX][newestY].flags & HAS_MONSTER)) {
                 tempMonst = monsterAtLoc(newestX, newestY);
                 if (tempMonst
@@ -1043,7 +1043,7 @@ boolean playerMoves(short direction) {
                     && monstersAreEnemies(&player, tempMonst)
                     && tempMonst->creatureState != MONSTER_ALLY
                     && !(tempMonst->bookkeepingFlags & MB_IS_DYING)
-                    && (!cellHasTerrainFlag(tempMonst->xLoc, tempMonst->yLoc, T_OBSTRUCTS_PASSABILITY) || (tempMonst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
+                    && (!cellHasTerrainFlag(tempMonst->loc.x, tempMonst->loc.y, T_OBSTRUCTS_PASSABILITY) || (tempMonst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
 
                     hitList[0] = tempMonst;
                     if (abortAttackAgainstAcidicTarget(hitList)) { // Acid mound attack confirmation.
@@ -1095,40 +1095,40 @@ boolean playerMoves(short direction) {
         }
 
         // Are we taking the stairs?
-        if (rogue.downLoc[0] == newX && rogue.downLoc[1] == newY) {
+        if (rogue.downLoc.x == newX && rogue.downLoc.y == newY) {
             committed = true;
             useStairs(1);
-        } else if (rogue.upLoc[0] == newX && rogue.upLoc[1] == newY) {
+        } else if (rogue.upLoc.x == newX && rogue.upLoc.y == newY) {
             committed = true;
             useStairs(-1);
         } else {
             // Okay, we're finally moving!
             committed = true;
 
-            player.xLoc += nbDirs[direction][0];
-            player.yLoc += nbDirs[direction][1];
+            player.loc.x += nbDirs[direction][0];
+            player.loc.y += nbDirs[direction][1];
             pmap[x][y].flags &= ~HAS_PLAYER;
-            pmap[player.xLoc][player.yLoc].flags |= HAS_PLAYER;
-            pmap[player.xLoc][player.yLoc].flags &= ~IS_IN_PATH;
+            pmap[player.loc.x][player.loc.y].flags |= HAS_PLAYER;
+            pmap[player.loc.x][player.loc.y].flags &= ~IS_IN_PATH;
             if (defender && defender->creatureState == MONSTER_ALLY) { // Swap places with ally.
-                pmap[defender->xLoc][defender->yLoc].flags &= ~HAS_MONSTER;
-                defender->xLoc = x;
-                defender->yLoc = y;
+                pmap[defender->loc.x][defender->loc.y].flags &= ~HAS_MONSTER;
+                defender->loc.x = x;
+                defender->loc.y = y;
                 if (monsterAvoids(defender, x, y)) {
-                    getQualifyingPathLocNear(&(defender->xLoc), &(defender->yLoc), player.xLoc, player.yLoc, true, forbiddenFlagsForMonster(&(defender->info)), 0, 0, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
+                    getQualifyingPathLocNear(&(defender->loc.x), &(defender->loc.y), player.loc.x, player.loc.y, true, forbiddenFlagsForMonster(&(defender->info)), 0, 0, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                 }
-                //getQualifyingLocNear(loc, player.xLoc, player.yLoc, true, NULL, forbiddenFlagsForMonster(&(defender->info)) & ~(T_IS_DF_TRAP | T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES), HAS_MONSTER, false, false);
-                //defender->xLoc = loc[0];
-                //defender->yLoc = loc[1];
-                pmap[defender->xLoc][defender->yLoc].flags |= HAS_MONSTER;
+                //getQualifyingLocNear(loc, player.loc.x, player.loc.y, true, NULL, forbiddenFlagsForMonster(&(defender->info)) & ~(T_IS_DF_TRAP | T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES), HAS_MONSTER, false, false);
+                //defender->loc.x = loc[0];
+                //defender->loc.y = loc[1];
+                pmap[defender->loc.x][defender->loc.y].flags |= HAS_MONSTER;
             }
 
-            if (pmap[player.xLoc][player.yLoc].flags & HAS_ITEM) {
-                pickUpItemAt(player.xLoc, player.yLoc);
+            if (pmap[player.loc.x][player.loc.y].flags & HAS_ITEM) {
+                pickUpItemAt(player.loc.x, player.loc.y);
                 rogue.disturbed = true;
             }
             refreshDungeonCell(x, y);
-            refreshDungeonCell(player.xLoc, player.yLoc);
+            refreshDungeonCell(player.loc.x, player.loc.y);
             playerMoved = true;
 
             checkForMissingKeys(x, y);
@@ -1458,10 +1458,10 @@ short nextStep(short **distanceMap, short x, short y, creature *monst, boolean p
 }
 
 void displayRoute(short **distanceMap, boolean removeRoute) {
-    short currentX = player.xLoc, currentY = player.yLoc, dir, newX, newY;
+    short currentX = player.loc.x, currentY = player.loc.y, dir, newX, newY;
     boolean advanced;
 
-    if (distanceMap[player.xLoc][player.yLoc] < 0 || distanceMap[player.xLoc][player.yLoc] == 30000) {
+    if (distanceMap[player.loc.x][player.loc.y] < 0 || distanceMap[player.loc.x][player.loc.y] == 30000) {
         return;
     }
     do {
@@ -1516,8 +1516,8 @@ void travelRoute(short path[1000][2], short steps) {
             }
         }
         for (dir = 0; dir < DIRECTION_COUNT && !rogue.disturbed; dir++) {
-            if (player.xLoc + nbDirs[dir][0] == path[i][0]
-                && player.yLoc + nbDirs[dir][1] == path[i][1]) {
+            if (player.loc.x + nbDirs[dir][0] == path[i][0]
+                && player.loc.y + nbDirs[dir][1] == path[i][1]) {
 
                 if (!playerMoves(dir)) {
                     rogue.disturbed = true;
@@ -1535,13 +1535,13 @@ void travelRoute(short path[1000][2], short steps) {
 }
 
 void travelMap(short **distanceMap) {
-    short currentX = player.xLoc, currentY = player.yLoc, dir, newX, newY;
+    short currentX = player.loc.x, currentY = player.loc.y, dir, newX, newY;
     boolean advanced;
 
     rogue.disturbed = false;
     rogue.automationActive = true;
 
-    if (distanceMap[player.xLoc][player.yLoc] < 0 || distanceMap[player.xLoc][player.yLoc] == 30000) {
+    if (distanceMap[player.loc.x][player.loc.y] < 0 || distanceMap[player.loc.x][player.loc.y] == 30000) {
         return;
     }
     do {
@@ -1581,10 +1581,10 @@ void travel(short x, short y, boolean autoConfirm) {
 
     if (D_WORMHOLING) {
         recordMouseClick(mapToWindowX(x), mapToWindowY(y), true, false);
-        pmap[player.xLoc][player.yLoc].flags &= ~HAS_PLAYER;
-        refreshDungeonCell(player.xLoc, player.yLoc);
-        player.xLoc = x;
-        player.yLoc = y;
+        pmap[player.loc.x][player.loc.y].flags &= ~HAS_PLAYER;
+        refreshDungeonCell(player.loc.x, player.loc.y);
+        player.loc.x = x;
+        player.loc.y = y;
         pmap[x][y].flags |= HAS_PLAYER;
         updatePlayerUnderwaterness();
         refreshDungeonCell(x, y);
@@ -1592,10 +1592,10 @@ void travel(short x, short y, boolean autoConfirm) {
         return;
     }
 
-    if (abs(player.xLoc - x) + abs(player.yLoc - y) == 1) {
+    if (abs(player.loc.x - x) + abs(player.loc.y - y) == 1) {
         // targeting a cardinal neighbor
         for (i=0; i<4; i++) {
-            if (nbDirs[i][0] == (x - player.xLoc) && nbDirs[i][1] == (y - player.yLoc)) {
+            if (nbDirs[i][0] == (x - player.loc.x) && nbDirs[i][1] == (y - player.loc.y)) {
                 playerMoves(i);
                 break;
             }
@@ -1611,14 +1611,14 @@ void travel(short x, short y, boolean autoConfirm) {
     distanceMap = allocGrid();
 
     calculateDistances(distanceMap, x, y, 0, &player, false, false);
-    if (distanceMap[player.xLoc][player.yLoc] < 30000) {
+    if (distanceMap[player.loc.x][player.loc.y] < 30000) {
         if (autoConfirm) {
             travelMap(distanceMap);
             //refreshSideBar(-1, -1, false);
         } else {
-            if (rogue.upLoc[0] == x && rogue.upLoc[1] == y) {
+            if (rogue.upLoc.x == x && rogue.upLoc.y == y) {
                 staircaseConfirmKey = ASCEND_KEY;
-            } else if (rogue.downLoc[0] == x && rogue.downLoc[1] == y) {
+            } else if (rogue.downLoc.x == x && rogue.downLoc.y == y) {
                 staircaseConfirmKey = DESCEND_KEY;
             } else {
                 staircaseConfirmKey = 0;
@@ -1645,7 +1645,7 @@ void travel(short x, short y, boolean autoConfirm) {
                 executeMouseClick(&theEvent);
             }
         }
-//      if (player.xLoc == x && player.yLoc == y) {
+//      if (player.loc.x == x && player.loc.y == y) {
 //          rogue.cursorLoc[0] = rogue.cursorLoc[1] = 0;
 //      } else {
 //          rogue.cursorLoc[0] = x;
@@ -1732,7 +1732,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
             if ((tFlags & T_LAVA_INSTA_DEATH)
                 && !(monst->info.flags & (MONST_IMMUNE_TO_FIRE | MONST_FLIES | MONST_INVULNERABLE))
                 && (monst->status[STATUS_LEVITATING] || monst->status[STATUS_IMMUNE_TO_FIRE])
-                && max(monst->status[STATUS_LEVITATING], monst->status[STATUS_IMMUNE_TO_FIRE]) < (rogue.mapToShore[i][j] + distanceBetween(i, j, monst->xLoc, monst->yLoc) * monst->movementSpeed / 100)) {
+                && max(monst->status[STATUS_LEVITATING], monst->status[STATUS_IMMUNE_TO_FIRE]) < (rogue.mapToShore[i][j] + distanceBetween(i, j, monst->loc.x, monst->loc.y) * monst->movementSpeed / 100)) {
                 // Only a temporary effect will permit the monster to survive the lava, and the remaining duration either isn't
                 // enough to get it to the spot, or it won't suffice to let it return to shore if it does get there.
                 // Treat these locations as obstacles.
@@ -1743,7 +1743,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
             if (((tFlags & T_AUTO_DESCENT) || (tFlags & T_IS_DEEP_WATER) && !(monst->info.flags & MONST_IMMUNE_TO_WATER))
                 && !(monst->info.flags & MONST_FLIES)
                 && (monst->status[STATUS_LEVITATING])
-                && monst->status[STATUS_LEVITATING] < (rogue.mapToShore[i][j] + distanceBetween(i, j, monst->xLoc, monst->yLoc) * monst->movementSpeed / 100)) {
+                && monst->status[STATUS_LEVITATING] < (rogue.mapToShore[i][j] + distanceBetween(i, j, monst->loc.x, monst->loc.y) * monst->movementSpeed / 100)) {
                 // Only a temporary effect will permit the monster to levitate over the chasm/water, and the remaining duration either isn't
                 // enough to get it to the spot, or it won't suffice to let it return to shore if it does get there.
                 // Treat these locations as obstacles.
@@ -1802,16 +1802,16 @@ enum directions adjacentFightingDir() {
     enum directions dir;
     creature *monst;
 
-    if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_OBSTRUCTS_PASSABILITY)) {
+    if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY)) {
         return NO_DIRECTION;
     }
     for (dir = 0; dir < DIRECTION_COUNT; dir++) {
-        newX = player.xLoc + nbDirs[dir][0];
-        newY = player.yLoc + nbDirs[dir][1];
+        newX = player.loc.x + nbDirs[dir][0];
+        newY = player.loc.y + nbDirs[dir][1];
         monst = monsterAtLoc(newX, newY);
         if (monst
             && canSeeMonster(monst)
-            && (!diagonalBlocked(player.xLoc, player.yLoc, newX, newY, false) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))
+            && (!diagonalBlocked(player.loc.x, player.loc.y, newX, newY, false) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))
             && monstersAreEnemies(&player, monst)
             && !(monst->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))) {
 
@@ -1856,11 +1856,11 @@ void getExploreMap(short **map, boolean headingToStairs) {// calculate explore m
         }
     }
 
-    costMap[rogue.downLoc[0]][rogue.downLoc[1]] = 100;
-    costMap[rogue.upLoc[0]][rogue.upLoc[1]]     = 100;
+    costMap[rogue.downLoc.x][rogue.downLoc.y] = 100;
+    costMap[rogue.upLoc.x][rogue.upLoc.y]     = 100;
 
     if (headingToStairs) {
-        map[rogue.downLoc[0]][rogue.downLoc[1]] = 0; // head to the stairs
+        map[rogue.downLoc.x][rogue.downLoc.y] = 0; // head to the stairs
     }
 
     dijkstraScan(map, costMap, true);
@@ -1889,7 +1889,7 @@ boolean explore(short frameDelay) {
         message("Not while you're confused.", 0);
         return false;
     }
-    if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_OBSTRUCTS_PASSABILITY)) {
+    if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY)) {
         message("Not while you're trapped.", 0);
         return false;
     }
@@ -1941,11 +1941,11 @@ boolean explore(short frameDelay) {
         getExploreMap(distanceMap, headingToStairs);
 
         // hilite path
-        steps = getPlayerPathOnMap(path, distanceMap, player.xLoc, player.yLoc);
+        steps = getPlayerPathOnMap(path, distanceMap, player.loc.x, player.loc.y);
         hilitePath(path, steps, false);
 
         // take a step
-        dir = nextStep(distanceMap, player.xLoc, player.yLoc, NULL, false);
+        dir = nextStep(distanceMap, player.loc.x, player.loc.y, NULL, false);
 
         if (!headingToStairs && rogue.autoPlayingLevel && dir == NO_DIRECTION) {
             headingToStairs = true;
@@ -1987,7 +1987,7 @@ void autoPlayLevel(boolean fastForward) {
         madeProgress = explore(fastForward ? 1 : 50);
         //refreshSideBar(-1, -1, false);
 
-        if (!madeProgress && rogue.downLoc[0] == player.xLoc && rogue.downLoc[1] == player.yLoc) {
+        if (!madeProgress && rogue.downLoc.x == player.loc.x && rogue.downLoc.y == player.loc.y) {
             useStairs(1);
             madeProgress = true;
         }
@@ -2037,8 +2037,8 @@ boolean startFighting(enum directions dir, boolean tillDeath) {
     short x, y, expectedDamage;
     creature *monst;
 
-    x = player.xLoc + nbDirs[dir][0];
-    y = player.yLoc + nbDirs[dir][1];
+    x = player.loc.x + nbDirs[dir][0];
+    y = player.loc.y + nbDirs[dir][1];
     monst = monsterAtLoc(x, y);
     if (monst->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE)) {
         return false;
@@ -2108,8 +2108,8 @@ boolean search(short searchStrength) {
     boolean foundSomething = false;
 
     radius = searchStrength / 10;
-    x = player.xLoc;
-    y = player.yLoc;
+    x = player.loc.x;
+    y = player.loc.y;
 
     for (i = x - radius; i <= x + radius; i++) {
         for (j = y - radius; j <= y + radius; j++) {
@@ -2138,7 +2138,7 @@ boolean search(short searchStrength) {
 
 boolean proposeOrConfirmLocation(short x, short y, char *failureMessage) {
     boolean retval = false;
-    if (player.xLoc == x && player.yLoc == y) {
+    if (player.loc.x == x && player.loc.y == y) {
         message("you are already there.", 0);
     } else if (pmap[x][y].flags & (DISCOVERED | MAGIC_MAPPED)) {
         if (rogue.cursorLoc[0] == x && rogue.cursorLoc[1] == y) {
@@ -2168,7 +2168,7 @@ boolean useStairs(short stairDirection) {
                 rogue.deepestLevel = rogue.depthLevel;
             }
             //copyDisplayBuffer(toBuf, displayBuffer);
-            //irisFadeBetweenBuffers(fromBuf, toBuf, mapToWindowX(player.xLoc), mapToWindowY(player.yLoc), 20, false);
+            //irisFadeBetweenBuffers(fromBuf, toBuf, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), 20, false);
         } else if (numberOfMatchingPackItems(AMULET, 0, 0, false)) {
             victory(true);
         } else {
@@ -2188,7 +2188,7 @@ boolean useStairs(short stairDirection) {
                 message("You ascend.", 0);
                 startLevel(rogue.depthLevel + 1, stairDirection);
                 //copyDisplayBuffer(toBuf, displayBuffer);
-                //irisFadeBetweenBuffers(fromBuf, toBuf, mapToWindowX(player.xLoc), mapToWindowY(player.yLoc), 20, true);
+                //irisFadeBetweenBuffers(fromBuf, toBuf, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), 20, true);
             }
             succeeded = true;
         } else {
@@ -2355,7 +2355,7 @@ void betweenOctant1andN(short *x, short *y, short x0, short y0, short n) {
     }
 }
 
-// Returns a boolean grid indicating whether each square is in the field of view of (xLoc, yLoc).
+// Returns a boolean grid indicating whether each square is in the field of view of (loc.x, loc.y).
 // forbiddenTerrain is the set of terrain flags that will block vision (but the blocking cell itself is
 // illuminated); forbiddenFlags is the set of map flags that will block vision.
 // If cautiousOnWalls is set, we will not illuminate blocking tiles unless the tile one space closer to the origin
@@ -2363,10 +2363,10 @@ void betweenOctant1andN(short *x, short *y, short x0, short y0, short n) {
 // side of the wall.
 void getFOVMask(char grid[DCOLS][DROWS], short xLoc, short yLoc, fixpt maxRadius,
                 unsigned long forbiddenTerrain, unsigned long forbiddenFlags, boolean cautiousOnWalls) {
-    short i;
+    pos loc = { xLoc, yLoc };
 
-    for (i=1; i<=8; i++) {
-        scanOctantFOV(grid, xLoc, yLoc, i, maxRadius, 1, LOS_SLOPE_GRANULARITY * -1, 0,
+    for (int i=1; i<=8; i++) {
+        scanOctantFOV(grid, loc.x, loc.y, i, maxRadius, 1, LOS_SLOPE_GRANULARITY * -1, 0,
                       forbiddenTerrain, forbiddenFlags, cautiousOnWalls);
     }
 }
@@ -2375,6 +2375,7 @@ void getFOVMask(char grid[DCOLS][DROWS], short xLoc, short yLoc, fixpt maxRadius
 void scanOctantFOV(char grid[DCOLS][DROWS], short xLoc, short yLoc, short octant, fixpt maxRadius,
                    short columnsRightFromOrigin, long startSlope, long endSlope, unsigned long forbiddenTerrain,
                    unsigned long forbiddenFlags, boolean cautiousOnWalls) {
+    const pos loc = { xLoc, yLoc };
 
     if (columnsRightFromOrigin * FP_FACTOR >= maxRadius) return;
 
@@ -2398,15 +2399,15 @@ void scanOctantFOV(char grid[DCOLS][DROWS], short xLoc, short yLoc, short octant
         iStart = (int) (-1 * fp_sqrt((maxRadius*maxRadius / FP_FACTOR) - (columnsRightFromOrigin*columnsRightFromOrigin * FP_FACTOR)) / FP_FACTOR);
     }
 
-    x = xLoc + columnsRightFromOrigin;
-    y = yLoc + iStart;
-    betweenOctant1andN(&x, &y, xLoc, yLoc, octant);
+    x = loc.x + columnsRightFromOrigin;
+    y = loc.y + iStart;
+    betweenOctant1andN(&x, &y, loc.x, loc.y, octant);
     boolean currentlyLit = coordinatesAreInMap(x, y) && !(cellHasTerrainFlag(x, y, forbiddenTerrain) ||
                                                           (pmap[x][y].flags & forbiddenFlags));
     for (i = iStart; i <= iEnd; i++) {
-        x = xLoc + columnsRightFromOrigin;
-        y = yLoc + i;
-        betweenOctant1andN(&x, &y, xLoc, yLoc, octant);
+        x = loc.x + columnsRightFromOrigin;
+        y = loc.y + i;
+        betweenOctant1andN(&x, &y, loc.x, loc.y, octant);
         if (!coordinatesAreInMap(x, y)) {
             // We're off the map -- here there be memory corruption.
             continue;
@@ -2415,14 +2416,14 @@ void scanOctantFOV(char grid[DCOLS][DROWS], short xLoc, short yLoc, short octant
         // if we're cautious on walls and this is a wall:
         if (cautiousOnWalls && cellObstructed) {
             // (x2, y2) is the tile one space closer to the origin from the tile we're on:
-            x2 = xLoc + columnsRightFromOrigin - 1;
-            y2 = yLoc + i;
+            x2 = loc.x + columnsRightFromOrigin - 1;
+            y2 = loc.y + i;
             if (i < 0) {
                 y2++;
             } else if (i > 0) {
                 y2--;
             }
-            betweenOctant1andN(&x2, &y2, xLoc, yLoc, octant);
+            betweenOctant1andN(&x2, &y2, loc.x, loc.y, octant);
 
             if (pmap[x2][y2].flags & IN_FIELD_OF_VIEW) {
                 // previous tile is visible, so illuminate
@@ -2440,7 +2441,7 @@ void scanOctantFOV(char grid[DCOLS][DROWS], short xLoc, short yLoc, short octant
                             / (columnsRightFromOrigin * 2 - 1) * 2);
             if (newStartSlope <= newEndSlope) {
                 // run next column
-                scanOctantFOV(grid, xLoc, yLoc, octant, maxRadius, columnsRightFromOrigin + 1, newStartSlope, newEndSlope,
+                scanOctantFOV(grid, loc.x, loc.y, octant, maxRadius, columnsRightFromOrigin + 1, newStartSlope, newEndSlope,
                               forbiddenTerrain, forbiddenFlags, cautiousOnWalls);
             }
             currentlyLit = false;
@@ -2450,7 +2451,7 @@ void scanOctantFOV(char grid[DCOLS][DROWS], short xLoc, short yLoc, short octant
         newEndSlope = endSlope;
         if (newStartSlope <= newEndSlope) {
             // run next column
-            scanOctantFOV(grid, xLoc, yLoc, octant, maxRadius, columnsRightFromOrigin + 1, newStartSlope, newEndSlope,
+            scanOctantFOV(grid, loc.x, loc.y, octant, maxRadius, columnsRightFromOrigin + 1, newStartSlope, newEndSlope,
                           forbiddenTerrain, forbiddenFlags, cautiousOnWalls);
         }
     }

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -430,7 +430,7 @@ void displayAnnotation() {
         if (!rogue.playbackFastForward) {
             refreshSideBar(-1, -1, false);
 
-            printTextBox(rogue.nextAnnotation, player.xLoc, 0, 0, &black, &white, rbuf, NULL, 0);
+            printTextBox(rogue.nextAnnotation, player.loc.x, 0, 0, &black, &white, rbuf, NULL, 0);
 
             rogue.playbackMode = false;
             displayMoreSign();

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2316,7 +2316,7 @@ typedef struct playerCharacter {
     pos upLoc;                          // upstairs location this level
     pos downLoc;                        // downstairs location this level
 
-    short cursorLoc[2];                 // used for the return key functionality
+    pos cursorLoc;                      // used for the return key functionality
     creature *lastTarget;               // to keep track of the last monster the player has thrown at or zapped
     item *lastItemThrown;
     short rewardRoomsGenerated;         // to meter the number of reward machines
@@ -3062,7 +3062,7 @@ extern "C" {
     boolean moveCursor(boolean *targetConfirmed,
                        boolean *canceled,
                        boolean *tabKey,
-                       short targetLoc[2],
+                       pos *targetLoc,
                        rogueEvent *event,
                        buttonState *state,
                        boolean colorsDance,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -142,6 +142,11 @@ typedef long long fixpt;
 #define COLS                    100
 #define ROWS                    (31 + MESSAGE_LINES)
 
+typedef struct pos {
+    short x;
+    short y;
+} pos;
+
 // Size of the portion of the terminal window devoted to displaying the dungeon:
 #define DCOLS                   (COLS - STAT_BAR_WIDTH - 1) // n columns on the left for the sidebar;
                                                             // one column to separate the sidebar from the map.
@@ -1359,8 +1364,7 @@ typedef struct item {
     short quantity;
     char inventoryLetter;
     char inscription[DCOLS];
-    short xLoc;
-    short yLoc;
+    pos loc;
     keyLocationProfile keyLoc[KEY_ID_MAXIMUM];
     short originDepth;
     unsigned long spawnTurnNumber;
@@ -1717,7 +1721,7 @@ typedef struct flare {
     lightSource *light;                 // Flare light
     short coeffChangeAmount;            // The constant amount by which the coefficient changes per frame, e.g. -25 means it gets 25% dimmer per frame.
     short coeffLimit;                   // Flare ends if the coefficient passes this percentage (whether going up or down).
-    short xLoc, yLoc;                   // Current flare location.
+    pos loc;                            // Current flare location.
     long coeff;                         // Current flare coefficient; always starts at 100.
     unsigned long turnNumber;           // So we can eliminate those that fired one or more turns ago.
 } flare;
@@ -2153,8 +2157,7 @@ typedef struct monsterClass {
 
 typedef struct creature {
     creatureType info;
-    short xLoc;
-    short yLoc;
+    pos loc;
     short depth;
     short currentHP;
     long turnsUntilRegen;
@@ -2310,8 +2313,8 @@ typedef struct playerCharacter {
 
     short previousPoisonPercent;        // and your poison proportion, to display percentage alerts for each.
 
-    short upLoc[2];                     // upstairs location this level
-    short downLoc[2];                   // downstairs location this level
+    pos upLoc;                          // upstairs location this level
+    pos downLoc;                        // downstairs location this level
 
     short cursorLoc[2];                 // used for the return key functionality
     creature *lastTarget;               // to keep track of the last monster the player has thrown at or zapped
@@ -2388,9 +2391,9 @@ typedef struct levelData {
     struct creatureList dormantMonsters;
     short **scentMap;
     uint64_t levelSeed;
-    short upStairsLoc[2];
-    short downStairsLoc[2];
-    short playerExitedVia[2];
+    pos upStairsLoc;
+    pos downStairsLoc;
+    pos playerExitedVia;
     unsigned long awaySince;
 } levelData;
 
@@ -3098,7 +3101,7 @@ extern "C" {
     void unequip(item *theItem);
     void drop(item *theItem);
     void findAlternativeHomeFor(creature *monst, short *x, short *y, boolean chooseRandomly);
-    boolean getQualifyingLocNear(short loc[2],
+    boolean getQualifyingLocNear(pos *loc,
                                  short x, short y,
                                  boolean hallwaysAllowed,
                                  char blockingMap[DCOLS][DROWS],
@@ -3106,7 +3109,7 @@ extern "C" {
                                  unsigned long forbiddenMapFlags,
                                  boolean forbidLiquid,
                                  boolean deterministic);
-    boolean getQualifyingGridLocNear(short loc[2],
+    boolean getQualifyingGridLocNear(pos *loc,
                                      short x, short y,
                                      boolean grid[DCOLS][DROWS],
                                      boolean deterministic);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -178,8 +178,8 @@ void initializeRogue(uint64_t seed) {
     initRecording();
 
     levels = malloc(sizeof(levelData) * (DEEPEST_LEVEL+1));
-    levels[0].upStairsLoc[0] = (DCOLS - 1) / 2 - 1;
-    levels[0].upStairsLoc[1] = DROWS - 2;
+    levels[0].upStairsLoc.x = (DCOLS - 1) / 2 - 1;
+    levels[0].upStairsLoc.y = DROWS - 2;
 
     // reset enchant and gain strength frequencies
     rogue.lifePotionFrequency = 0;
@@ -207,16 +207,15 @@ void initializeRogue(uint64_t seed) {
         levels[i].items = NULL;
         levels[i].scentMap = NULL;
         levels[i].visited = false;
-        levels[i].playerExitedVia[0] = 0;
-        levels[i].playerExitedVia[1] = 0;
+        levels[i].playerExitedVia = (pos){ .x = 0, .y = 0 };
         do {
-            levels[i].downStairsLoc[0] = rand_range(1, DCOLS - 2);
-            levels[i].downStairsLoc[1] = rand_range(1, DROWS - 2);
-        } while (distanceBetween(levels[i].upStairsLoc[0], levels[i].upStairsLoc[1],
-                                 levels[i].downStairsLoc[0], levels[i].downStairsLoc[1]) < DCOLS / 3);
+            levels[i].downStairsLoc.x = rand_range(1, DCOLS - 2);
+            levels[i].downStairsLoc.y = rand_range(1, DROWS - 2);
+        } while (distanceBetween(levels[i].upStairsLoc.x, levels[i].upStairsLoc.y,
+                                 levels[i].downStairsLoc.x, levels[i].downStairsLoc.y) < DCOLS / 3);
         if (i < DEEPEST_LEVEL) {
-            levels[i+1].upStairsLoc[0] = levels[i].downStairsLoc[0];
-            levels[i+1].upStairsLoc[1] = levels[i].downStairsLoc[1];
+            levels[i+1].upStairsLoc.x = levels[i].downStairsLoc.x;
+            levels[i+1].upStairsLoc.y = levels[i].downStairsLoc.y;
         }
     }
 
@@ -488,7 +487,7 @@ void updateColors() {
 void startLevel(short oldLevelNumber, short stairDirection) {
     uint64_t oldSeed;
     item *theItem;
-    short loc[2], i, j, x, y, px, py, flying, dir;
+    short i, j, x, y, px, py, flying, dir;
     boolean placedPlayer;
     enum dungeonLayers layer;
     unsigned long timeAway;
@@ -510,20 +509,19 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     rogue.cursorLoc[1] = -1;
     rogue.lastTarget = NULL;
 
-    connectingStairsDiscovered = (pmap[rogue.downLoc[0]][rogue.downLoc[1]].flags & (DISCOVERED | MAGIC_MAPPED) ? true : false);
+    connectingStairsDiscovered = (pmap[rogue.downLoc.x][rogue.downLoc.y].flags & (DISCOVERED | MAGIC_MAPPED) ? true : false);
     if (stairDirection == 0) { // fallen
-        levels[oldLevelNumber-1].playerExitedVia[0] = player.xLoc;
-        levels[oldLevelNumber-1].playerExitedVia[1] = player.yLoc;
+        levels[oldLevelNumber-1].playerExitedVia = (pos){ .x = player.loc.x, .y = player.loc.y };
     }
 
     if (oldLevelNumber != rogue.depthLevel) {
-        px = player.xLoc;
-        py = player.yLoc;
-        if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_AUTO_DESCENT)) {
+        px = player.loc.x;
+        py = player.loc.y;
+        if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_AUTO_DESCENT)) {
             for (i=0; i<8; i++) {
-                if (!cellHasTerrainFlag(player.xLoc+nbDirs[i][0], player.yLoc+nbDirs[i][1], (T_PATHING_BLOCKER))) {
-                    px = player.xLoc+nbDirs[i][0];
-                    py = player.yLoc+nbDirs[i][1];
+                if (!cellHasTerrainFlag(player.loc.x+nbDirs[i][0], player.loc.y+nbDirs[i][1], (T_PATHING_BLOCKER))) {
+                    px = player.loc.x+nbDirs[i][0];
+                    py = player.loc.y+nbDirs[i][1];
                     break;
                 }
             }
@@ -535,8 +533,8 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             calculateDistances(mapToStairs, px, py, (flying ? T_OBSTRUCTS_PASSABILITY : T_PATHING_BLOCKER) | T_SACRED, NULL, true, true);
             for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
                 creature *monst = nextCreature(&it);
-                x = monst->xLoc;
-                y = monst->yLoc;
+                x = monst->loc.x;
+                y = monst->loc.y;
                 if (((monst->creatureState == MONSTER_TRACKING_SCENT && (stairDirection != 0 || monst->status[STATUS_LEVITATING]))
                      || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)
                     && (stairDirection != 0 || monst->currentHP > 10 || monst->status[STATUS_LEVITATING])
@@ -548,9 +546,9 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                     && !(cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY))
                     && !monst->status[STATUS_ENTRANCED]
                     && !monst->status[STATUS_PARALYZED]
-                    && (mapToStairs[monst->xLoc][monst->yLoc] < 30000 || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)) {
+                    && (mapToStairs[monst->loc.x][monst->loc.y] < 30000 || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)) {
 
-                    monst->status[STATUS_ENTERS_LEVEL_IN] = clamp(mapToStairs[monst->xLoc][monst->yLoc] * monst->movementSpeed / 100 + 1, 1, 150);
+                    monst->status[STATUS_ENTERS_LEVEL_IN] = clamp(mapToStairs[monst->loc.x][monst->loc.y] * monst->movementSpeed / 100 + 1, 1, 150);
                     switch (stairDirection) {
                         case 1:
                             monst->bookkeepingFlags |= MB_APPROACHING_DOWNSTAIRS;
@@ -702,10 +700,8 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
         setUpWaypoints();
 
-        rogue.downLoc[0]    = levels[rogue.depthLevel - 1].downStairsLoc[0];
-        rogue.downLoc[1]    = levels[rogue.depthLevel - 1].downStairsLoc[1];
-        rogue.upLoc[0]      = levels[rogue.depthLevel - 1].upStairsLoc[0];
-        rogue.upLoc[1]      = levels[rogue.depthLevel - 1].upStairsLoc[1];
+        rogue.downLoc = levels[rogue.depthLevel - 1].downStairsLoc;
+        rogue.upLoc   = levels[rogue.depthLevel - 1].upStairsLoc;
 
         monsters             = &levels[rogue.depthLevel - 1].monsters;
         dormantMonsters      = &levels[rogue.depthLevel - 1].dormantMonsters;
@@ -722,9 +718,9 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     // Simulate the environment!
     // First bury the player in limbo while we run the simulation,
     // so that any harmful terrain doesn't affect her during the process.
-    px = player.xLoc;
-    py = player.yLoc;
-    player.xLoc = player.yLoc = 0;
+    px = player.loc.x;
+    py = player.loc.y;
+    player.loc.x = player.loc.y = 0;
     unsigned long currentTurnNumber = rogue.absoluteTurnNumber;
     timeAway = min(timeAway, 100);
     while (timeAway--) {
@@ -732,8 +728,8 @@ void startLevel(short oldLevelNumber, short stairDirection) {
         updateEnvironment();
     }
     rogue.absoluteTurnNumber = currentTurnNumber;
-    player.xLoc = px;
-    player.yLoc = py;
+    player.loc.x = px;
+    player.loc.y = py;
 
     // This level is now up-to-date as of the current turn.
     // Get the ticker ready for the *next* environment update.
@@ -751,70 +747,66 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     }
 
     // Position the player.
+    pos loc;
     if (stairDirection == 0) { // fell into the level
-
-        getQualifyingLocNear(loc, player.xLoc, player.yLoc, true, 0,
+        getQualifyingLocNear(&loc, player.loc.x, player.loc.y, true, 0,
                              (T_PATHING_BLOCKER & ~T_IS_DEEP_WATER),
                              (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
 
-        if (cellHasTerrainFlag(loc[0], loc[1], T_IS_DEEP_WATER)) {
+        if (cellHasTerrainFlag(loc.x, loc.y, T_IS_DEEP_WATER)) {
             // Fell into deep water... can we swim out of it?
-            short dryLoc[2];
-            getQualifyingLocNear(dryLoc, player.xLoc, player.yLoc, true, 0,
+            pos dryLoc;
+            getQualifyingLocNear(&dryLoc, player.loc.x, player.loc.y, true, 0,
                                 (T_PATHING_BLOCKER),
                                 (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
 
-            short swimDistance = pathingDistance(loc[0], loc[1], dryLoc[0], dryLoc[1], T_PATHING_BLOCKER & ~T_IS_DEEP_WATER);
+            short swimDistance = pathingDistance(loc.x, loc.y, dryLoc.x, dryLoc.y, T_PATHING_BLOCKER & ~T_IS_DEEP_WATER);
             if (swimDistance == 30000) {
                 // Cannot swim out! This is an enclosed lake.
-                loc[0] = dryLoc[0];
-                loc[1] = dryLoc[1];
+                loc = dryLoc;
             }
         }
 
     } else {
         if (stairDirection == 1) { // heading downward
-            player.xLoc = rogue.upLoc[0];
-            player.yLoc = rogue.upLoc[1];
+            player.loc = rogue.upLoc;
         } else if (stairDirection == -1) { // heading upward
-            player.xLoc = rogue.downLoc[0];
-            player.yLoc = rogue.downLoc[1];
+            player.loc = rogue.downLoc;
         }
 
         placedPlayer = false;
         for (dir=0; dir<4 && !placedPlayer; dir++) {
-            loc[0] = player.xLoc + nbDirs[dir][0];
-            loc[1] = player.yLoc + nbDirs[dir][1];
-            if (!cellHasTerrainFlag(loc[0], loc[1], T_PATHING_BLOCKER)
-                && !(pmap[loc[0]][loc[1]].flags & (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE))) {
+            loc.x = player.loc.x + nbDirs[dir][0];
+            loc.y = player.loc.y + nbDirs[dir][1];
+            if (!cellHasTerrainFlag(loc.x, loc.y, T_PATHING_BLOCKER)
+                && !(pmap[loc.x][loc.y].flags & (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE))) {
                 placedPlayer = true;
             }
         }
         if (!placedPlayer) {
-            getQualifyingPathLocNear(&loc[0], &loc[1],
-                                     player.xLoc, player.yLoc,
+            getQualifyingPathLocNear(&loc.x, &loc.y,
+                                     player.loc.x, player.loc.y,
                                      true,
                                      T_DIVIDES_LEVEL, 0,
                                      T_PATHING_BLOCKER, (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE),
                                      false);
         }
     }
-    player.xLoc = loc[0];
-    player.yLoc = loc[1];
+    player.loc = loc;
 
-    pmap[player.xLoc][player.yLoc].flags |= HAS_PLAYER;
+    pmap[player.loc.x][player.loc.y].flags |= HAS_PLAYER;
 
     if (connectingStairsDiscovered) {
-        for (i = rogue.upLoc[0]-1; i <= rogue.upLoc[0] + 1; i++) {
-            for (j = rogue.upLoc[1]-1; j <= rogue.upLoc[1] + 1; j++) {
+        for (i = rogue.upLoc.x-1; i <= rogue.upLoc.x + 1; i++) {
+            for (j = rogue.upLoc.y-1; j <= rogue.upLoc.y + 1; j++) {
                 if (coordinatesAreInMap(i, j)) {
                     discoverCell(i, j);
                 }
             }
         }
     }
-    if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
-        && !cellHasTerrainFlag(player.xLoc, player.yLoc, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
+    if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
+        && !cellHasTerrainFlag(player.loc.x, player.loc.y, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
         rogue.inWater = true;
     }
 
@@ -823,9 +815,9 @@ void startLevel(short oldLevelNumber, short stairDirection) {
         mapToPit = allocGrid();
         fillGrid(mapToStairs, 0);
         fillGrid(mapToPit, 0);
-        calculateDistances(mapToStairs, player.xLoc, player.yLoc, T_PATHING_BLOCKER, NULL, true, true);
-        calculateDistances(mapToPit, levels[rogue.depthLevel-1].playerExitedVia[0],
-                           levels[rogue.depthLevel-1].playerExitedVia[1], T_PATHING_BLOCKER, NULL, true, true);
+        calculateDistances(mapToStairs, player.loc.x, player.loc.y, T_PATHING_BLOCKER, NULL, true, true);
+        calculateDistances(mapToPit, levels[rogue.depthLevel-1].playerExitedVia.x,
+                           levels[rogue.depthLevel-1].playerExitedVia.y, T_PATHING_BLOCKER, NULL, true, true);
         for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
             creature *monst = nextCreature(&it);
             restoreMonster(monst, mapToStairs, mapToPit);
@@ -1036,7 +1028,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
         blackOutScreen();
     } else {
         copyDisplayBuffer(dbuf, displayBuffer);
-        funkyFade(dbuf, &black, 0, 120, mapToWindowX(player.xLoc), mapToWindowY(player.yLoc), false);
+        funkyFade(dbuf, &black, 0, 120, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
     }
 
     if (useCustomPhrasing) {
@@ -1128,7 +1120,7 @@ void victory(boolean superVictory) {
     if (superVictory) {
         message(    "Light streams through the portal, and you are teleported out of the dungeon.", 0);
         copyDisplayBuffer(dbuf, displayBuffer);
-        funkyFade(dbuf, &superVictoryColor, 0, 240, mapToWindowX(player.xLoc), mapToWindowY(player.yLoc), false);
+        funkyFade(dbuf, &superVictoryColor, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
         displayMoreSign();
         printString("Congratulations; you have transcended the Dungeons of Doom!                 ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
         displayMoreSign();
@@ -1138,7 +1130,7 @@ void victory(boolean superVictory) {
     } else {
         message(    "You are bathed in sunlight as you throw open the heavy doors.", 0);
         copyDisplayBuffer(dbuf, displayBuffer);
-        funkyFade(dbuf, &white, 0, 240, mapToWindowX(player.xLoc), mapToWindowY(player.yLoc), false);
+        funkyFade(dbuf, &white, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
         displayMoreSign();
         printString("Congratulations; you have escaped from the Dungeons of Doom!     ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
         displayMoreSign();
@@ -1269,7 +1261,7 @@ void enableEasyMode() {
         message("An ancient and terrible evil burrows into your willing flesh!", REQUIRE_ACKNOWLEDGMENT);
         player.info.displayChar = '&';
         rogue.easyMode = true;
-        refreshDungeonCell(player.xLoc, player.yLoc);
+        refreshDungeonCell(player.loc.x, player.loc.y);
         refreshSideBar(-1, -1, false);
         message("Wracked by spasms, your body contorts into an ALL-POWERFUL AMPERSAND!!!", 0);
         message("You have a feeling that you will take 20% as much damage from now on.", 0);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -342,7 +342,7 @@ void initializeRogue(uint64_t seed) {
     rogue.monsterSpawnFuse = rand_range(125, 175);
     rogue.ticksTillUpdateEnvironment = 100;
     rogue.mapToShore = NULL;
-    rogue.cursorLoc[0] = rogue.cursorLoc[1] = -1;
+    rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
     rogue.xpxpThisTurn = 0;
 
     rogue.yendorWarden = NULL;
@@ -505,8 +505,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     rogue.updatedAllySafetyMapThisTurn      = false;
     rogue.updatedMapToSafeTerrainThisTurn   = false;
 
-    rogue.cursorLoc[0] = -1;
-    rogue.cursorLoc[1] = -1;
+    rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
     rogue.lastTarget = NULL;
 
     connectingStairsDiscovered = (pmap[rogue.downLoc.x][rogue.downLoc.y].flags & (DISCOVERED | MAGIC_MAPPED) ? true : false);

--- a/src/brogue/SeedCatalog.c
+++ b/src/brogue/SeedCatalog.c
@@ -78,16 +78,16 @@ static void printSeedCatalogItem(item *theItem, creature *theMonster, boolean is
     }
 
     // vaultNumber
-    if (pmap[theItem->xLoc][theItem->yLoc].machineNumber > 0) {
+    if (pmap[theItem->loc.x][theItem->loc.y].machineNumber > 0) {
         //not all machines are "vaults" so we need to exclude some.
-        if (pmap[theItem->xLoc][theItem->yLoc].layers[0] != ALTAR_SWITCH
-            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != ALTAR_SWITCH_RETRACTING
-            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != ALTAR_CAGE_RETRACTABLE
-            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != ALTAR_INERT
-            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != AMULET_SWITCH
-            && pmap[theItem->xLoc][theItem->yLoc].layers[0] != FLOOR) {
+        if (pmap[theItem->loc.x][theItem->loc.y].layers[0] != ALTAR_SWITCH
+            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != ALTAR_SWITCH_RETRACTING
+            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != ALTAR_CAGE_RETRACTABLE
+            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != ALTAR_INERT
+            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != AMULET_SWITCH
+            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != FLOOR) {
 
-            sprintf(vaultNumber, isCsvFormat ? "%i" : " (vault %i)", pmap[theItem->xLoc][theItem->yLoc].machineNumber);
+            sprintf(vaultNumber, isCsvFormat ? "%i" : " (vault %i)", pmap[theItem->loc.x][theItem->loc.y].machineNumber);
         }
     }
 
@@ -118,7 +118,7 @@ static void printSeedCatalogMonster(creature *theMonster, boolean isCsvFormat) {
 
     if (theMonster->bookkeepingFlags & MB_CAPTIVE) {
         strcpy(categoryName,"ally");
-        if (cellHasTMFlag(theMonster->xLoc, theMonster->yLoc, TM_PROMOTES_WITH_KEY)) {
+        if (cellHasTMFlag(theMonster->loc.x, theMonster->loc.y, TM_PROMOTES_WITH_KEY)) {
             strcpy(allyStatusName, isCsvFormat ? "caged" : "A caged ");
         } else {
             strcpy(allyStatusName, isCsvFormat ? "shackled" : "A shackled ");

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -30,14 +30,14 @@ void exposeCreatureToFire(creature *monst) {
         || monst->status[STATUS_IMMUNE_TO_FIRE]
         || (monst->info.flags & MONST_INVULNERABLE)
         || (monst->bookkeepingFlags & MB_SUBMERGED)
-        || ((!monst->status[STATUS_LEVITATING]) && cellHasTMFlag(monst->xLoc, monst->yLoc, TM_EXTINGUISHES_FIRE))) {
+        || ((!monst->status[STATUS_LEVITATING]) && cellHasTMFlag(monst->loc.x, monst->loc.y, TM_EXTINGUISHES_FIRE))) {
         return;
     }
     if (monst->status[STATUS_BURNING] == 0) {
         if (monst == &player) {
             rogue.minersLight.lightColor = &fireForeColor;
             player.info.foreColor = &torchLightColor;
-            refreshDungeonCell(player.xLoc, player.yLoc);
+            refreshDungeonCell(player.loc.x, player.loc.y);
             //updateVision(); // this screws up the firebolt visual effect by erasing it while a message is displayed
             combatMessage("you catch fire", &badMessageColor);
         } else if (canDirectlySeeMonster(monst)) {
@@ -55,22 +55,22 @@ void updateFlavorText() {
         if (rogue.armor
             && (rogue.armor->flags & ITEM_RUNIC)
             && rogue.armor->enchant2 == A_RESPIRATION
-            && tileCatalog[pmap[player.xLoc][player.yLoc].layers[highestPriorityLayer(player.xLoc, player.yLoc, false)]].flags & T_RESPIRATION_IMMUNITIES) {
+            && tileCatalog[pmap[player.loc.x][player.loc.y].layers[highestPriorityLayer(player.loc.x, player.loc.y, false)]].flags & T_RESPIRATION_IMMUNITIES) {
 
             flavorMessage("A pocket of cool, clean air swirls around you.");
         } else if (player.status[STATUS_LEVITATING]) {
-            describeLocation(buf, player.xLoc, player.yLoc);
+            describeLocation(buf, player.loc.x, player.loc.y);
             flavorMessage(buf);
         } else {
-            flavorMessage(tileFlavor(player.xLoc, player.yLoc));
+            flavorMessage(tileFlavor(player.loc.x, player.loc.y));
         }
     }
 }
 
 void updatePlayerUnderwaterness() {
     if (rogue.inWater) {
-        if (!cellHasTerrainFlag(player.xLoc, player.yLoc, T_IS_DEEP_WATER) || player.status[STATUS_LEVITATING]
-            || cellHasTerrainFlag(player.xLoc, player.yLoc, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
+        if (!cellHasTerrainFlag(player.loc.x, player.loc.y, T_IS_DEEP_WATER) || player.status[STATUS_LEVITATING]
+            || cellHasTerrainFlag(player.loc.x, player.loc.y, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
 
             rogue.inWater = false;
             updateMinersLightRadius();
@@ -78,8 +78,8 @@ void updatePlayerUnderwaterness() {
             displayLevel();
         }
     } else {
-        if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
-            && !cellHasTerrainFlag(player.xLoc, player.yLoc, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
+        if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
+            && !cellHasTerrainFlag(player.loc.x, player.loc.y, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
 
             rogue.inWater = true;
             updateMinersLightRadius();
@@ -91,8 +91,8 @@ void updatePlayerUnderwaterness() {
 
 boolean monsterShouldFall(creature *monst) {
     return (!(monst->status[STATUS_LEVITATING])
-            && cellHasTerrainFlag(monst->xLoc, monst->yLoc, T_AUTO_DESCENT)
-            && !cellHasTerrainFlag(monst->xLoc, monst->yLoc, T_ENTANGLES | T_OBSTRUCTS_PASSABILITY)
+            && cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_AUTO_DESCENT)
+            && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_ENTANGLES | T_OBSTRUCTS_PASSABILITY)
             && !(monst->bookkeepingFlags & MB_PREPLACED));
 }
 
@@ -100,7 +100,7 @@ boolean monsterShouldFall(creature *monst) {
 void applyInstantTileEffectsToCreature(creature *monst) {
     char buf[COLS], buf2[COLS], buf3[COLS];
     char *s;
-    short *x = &(monst->xLoc), *y = &(monst->yLoc), damage;
+    short *x = &(monst->loc.x), *y = &(monst->loc.y), damage;
     enum dungeonLayers layer;
     item *theItem;
 
@@ -453,7 +453,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
 
 void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
     short itemCandidates, randItemIndex;
-    short x = monst->xLoc, y = monst->yLoc, damage;
+    short x = monst->loc.x, y = monst->loc.y, damage;
     char buf[COLS * 5], buf2[COLS * 3];
     item *theItem;
     enum dungeonLayers layer;
@@ -571,11 +571,11 @@ void updateClairvoyance() {
         cFlags = CLAIRVOYANT_VISIBLE | DISCOVERED;
     }
 
-    for (i = max(0, player.xLoc - clairvoyanceRadius); i < min(DCOLS, player.xLoc + clairvoyanceRadius + 1); i++) {
-        for (j = max(0, player.yLoc - clairvoyanceRadius); j < min(DROWS, player.yLoc + clairvoyanceRadius + 1); j++) {
+    for (i = max(0, player.loc.x - clairvoyanceRadius); i < min(DCOLS, player.loc.x + clairvoyanceRadius + 1); i++) {
+        for (j = max(0, player.loc.y - clairvoyanceRadius); j < min(DROWS, player.loc.y + clairvoyanceRadius + 1); j++) {
 
-            dx = (player.xLoc - i);
-            dy = (player.yLoc - j);
+            dx = (player.loc.x - i);
+            dy = (player.loc.y - j);
 
             if (dx*dx + dy*dy < clairvoyanceRadius*clairvoyanceRadius + clairvoyanceRadius
                 && (pmap[i][j].layers[DUNGEON] != GRANITE || pmap[i][j].flags & DISCOVERED)) {
@@ -610,17 +610,17 @@ void updateTelepathy() {
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
         if (monsterRevealed(monst)) {
-            getFOVMask(grid, monst->xLoc, monst->yLoc, 2 * FP_FACTOR, T_OBSTRUCTS_VISION, 0, false);
-            pmap[monst->xLoc][monst->yLoc].flags |= TELEPATHIC_VISIBLE;
-            discoverCell(monst->xLoc, monst->yLoc);
+            getFOVMask(grid, monst->loc.x, monst->loc.y, 2 * FP_FACTOR, T_OBSTRUCTS_VISION, 0, false);
+            pmap[monst->loc.x][monst->loc.y].flags |= TELEPATHIC_VISIBLE;
+            discoverCell(monst->loc.x, monst->loc.y);
         }
     }
     for (creatureIterator it = iterateCreatures(dormantMonsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
         if (monsterRevealed(monst)) {
-            getFOVMask(grid, monst->xLoc, monst->yLoc, 2 * FP_FACTOR, T_OBSTRUCTS_VISION, 0, false);
-            pmap[monst->xLoc][monst->yLoc].flags |= TELEPATHIC_VISIBLE;
-            discoverCell(monst->xLoc, monst->yLoc);
+            getFOVMask(grid, monst->loc.x, monst->loc.y, 2 * FP_FACTOR, T_OBSTRUCTS_VISION, 0, false);
+            pmap[monst->loc.x][monst->loc.y].flags |= TELEPATHIC_VISIBLE;
+            discoverCell(monst->loc.x, monst->loc.y);
         }
     }
     for (i = 0; i < DCOLS; i++) {
@@ -647,16 +647,16 @@ void updateScent() {
 
     zeroOutGrid(grid);
 
-    getFOVMask(grid, player.xLoc, player.yLoc, DCOLS * FP_FACTOR, T_OBSTRUCTS_SCENT, 0, false);
+    getFOVMask(grid, player.loc.x, player.loc.y, DCOLS * FP_FACTOR, T_OBSTRUCTS_SCENT, 0, false);
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             if (grid[i][j]) {
-                addScentToCell(i, j, scentDistance(player.xLoc, player.yLoc, i, j));
+                addScentToCell(i, j, scentDistance(player.loc.x, player.loc.y, i, j));
             }
         }
     }
-    addScentToCell(player.xLoc, player.yLoc, 0);
+    addScentToCell(player.loc.x, player.loc.y, 0);
 }
 
 short armorAggroAdjustment(item *theArmor) {
@@ -679,7 +679,7 @@ short currentAggroValue() {
             // In darkness, halve, rounded down.
             stealthVal = stealthVal / 2;
         }
-        if (pmap[player.xLoc][player.yLoc].flags & IS_IN_SHADOW) {
+        if (pmap[player.loc.x][player.loc.y].flags & IS_IN_SHADOW) {
             // When not standing in a lit area, halve, rounded down (stacks with darkness halving).
             stealthVal = stealthVal / 2;
         }
@@ -748,7 +748,7 @@ void updateVision(boolean refreshDisplay) {
 
     // Calculate player's field of view (distinct from what is visible, as lighting hasn't been done yet).
     zeroOutGrid(grid);
-    getFOVMask(grid, player.xLoc, player.yLoc, (DCOLS + DROWS) * FP_FACTOR, (T_OBSTRUCTS_VISION), 0, false);
+    getFOVMask(grid, player.loc.x, player.loc.y, (DCOLS + DROWS) * FP_FACTOR, (T_OBSTRUCTS_VISION), 0, false);
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             if (grid[i][j]) {
@@ -756,10 +756,10 @@ void updateVision(boolean refreshDisplay) {
             }
         }
     }
-    pmap[player.xLoc][player.yLoc].flags |= IN_FIELD_OF_VIEW | VISIBLE;
+    pmap[player.loc.x][player.loc.y].flags |= IN_FIELD_OF_VIEW | VISIBLE;
 
     if (rogue.clairvoyance < 0) {
-        discoverCell(player.xLoc, player.yLoc);
+        discoverCell(player.loc.x, player.loc.y);
     }
 
     if (rogue.clairvoyance != 0) {
@@ -783,14 +783,14 @@ void updateVision(boolean refreshDisplay) {
 
     if (player.status[STATUS_HALLUCINATING] > 0) {
         for (theItem = floorItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
-            if ((pmap[theItem->xLoc][theItem->yLoc].flags & DISCOVERED) && refreshDisplay) {
-                refreshDungeonCell(theItem->xLoc, theItem->yLoc);
+            if ((pmap[theItem->loc.x][theItem->loc.y].flags & DISCOVERED) && refreshDisplay) {
+                refreshDungeonCell(theItem->loc.x, theItem->loc.y);
             }
         }
         for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
             creature *monst = nextCreature(&it);
-            if ((pmap[monst->xLoc][monst->yLoc].flags & DISCOVERED) && refreshDisplay) {
-                refreshDungeonCell(monst->xLoc, monst->yLoc);
+            if ((pmap[monst->loc.x][monst->loc.y].flags & DISCOVERED) && refreshDisplay) {
+                refreshDungeonCell(monst->loc.x, monst->loc.y);
             }
         }
     }
@@ -843,8 +843,8 @@ void burnItem(item *theItem) {
     sprintf(buf2, "%s burn%s up!",
             buf1,
             theItem->quantity == 1 ? "s" : "");
-    x = theItem->xLoc;
-    y = theItem->yLoc;
+    x = theItem->loc.x;
+    y = theItem->loc.y;
     removeItemFromChain(theItem, floorItems);
     deleteItem(theItem);
     pmap[x][y].flags &= ~(HAS_ITEM | ITEM_DETECTED);
@@ -859,12 +859,12 @@ void burnItem(item *theItem) {
 
 void flashCreatureAlert(creature *monst, char msg[200], color *foreColor, color *backColor) {
     short x, y;
-    if (monst->yLoc > DROWS / 2) {
-        y = mapToWindowY(monst->yLoc - 2);
+    if (monst->loc.y > DROWS / 2) {
+        y = mapToWindowY(monst->loc.y - 2);
     } else {
-        y = mapToWindowY(monst->yLoc + 2);
+        y = mapToWindowY(monst->loc.y + 2);
     }
-    x = mapToWindowX(monst->xLoc - strLenWithoutEscapes(msg) / 2);
+    x = mapToWindowX(monst->loc.x - strLenWithoutEscapes(msg) / 2);
     if (x > COLS - strLenWithoutEscapes(msg)) {
         x = COLS - strLenWithoutEscapes(msg);
     }
@@ -969,18 +969,18 @@ void playerFalls() {
     short damage;
     short layer;
 
-    if (cellHasTMFlag(player.xLoc, player.yLoc, TM_IS_SECRET)
-        && playerCanSee(player.xLoc, player.yLoc)) {
+    if (cellHasTMFlag(player.loc.x, player.loc.y, TM_IS_SECRET)
+        && playerCanSee(player.loc.x, player.loc.y)) {
 
-        discover(player.xLoc, player.yLoc);
+        discover(player.loc.x, player.loc.y);
     }
 
     monstersFall(); // Monsters must fall with the player rather than getting suspended on the previous level.
     updateFloorItems(); // Likewise, items should fall with the player rather than getting suspended above.
 
-    layer = layerWithFlag(player.xLoc, player.yLoc, T_AUTO_DESCENT);
+    layer = layerWithFlag(player.loc.x, player.loc.y, T_AUTO_DESCENT);
     if (layer >= 0) {
-        message(tileCatalog[pmap[player.xLoc][player.yLoc].layers[layer]].flavorText, REQUIRE_ACKNOWLEDGMENT);
+        message(tileCatalog[pmap[player.loc.x][player.loc.y].layers[layer]].flavorText, REQUIRE_ACKNOWLEDGMENT);
     } else if (layer == -1) {
         message("You plunge downward!", REQUIRE_ACKNOWLEDGMENT);
     }
@@ -993,10 +993,10 @@ void playerFalls() {
         startLevel(rogue.depthLevel - 1, 0);
         damage = randClumpedRange(FALL_DAMAGE_MIN, FALL_DAMAGE_MAX, 2);
         boolean killed = false;
-        if (terrainFlags(player.xLoc, player.yLoc) & T_IS_DEEP_WATER) {
+        if (terrainFlags(player.loc.x, player.loc.y) & T_IS_DEEP_WATER) {
             messageWithColor("You fall into deep water, unharmed.", &badMessageColor, 0);
         } else {
-            if (cellHasTMFlag(player.xLoc, player.yLoc, TM_ALLOWS_SUBMERGING)) {
+            if (cellHasTMFlag(player.loc.x, player.loc.y, TM_ALLOWS_SUBMERGING)) {
                 damage /= 2; // falling into liquid (shallow water, bog, etc.) hurts less than hitting hard floor
             }
             messageWithColor("You are injured by the fall.", &badMessageColor, 0);
@@ -1012,7 +1012,7 @@ void playerFalls() {
         message("A strange force seizes you as you fall.", 0);
         teleport(&player, -1, -1, true);
     }
-    createFlare(player.xLoc, player.yLoc, GENERIC_FLASH_LIGHT);
+    createFlare(player.loc.x, player.loc.y, GENERIC_FLASH_LIGHT);
     animateFlares(rogue.flares, rogue.flareCount);
     rogue.flareCount = 0;
 }
@@ -1321,7 +1321,7 @@ void updateYendorWardenTracking() {
         return;
     }
     if (!(rogue.yendorWarden->bookkeepingFlags & MB_PREPLACED)) {
-        levels[rogue.yendorWarden->depth - 1].mapStorage[rogue.yendorWarden->xLoc][rogue.yendorWarden->yLoc].flags &= ~HAS_MONSTER;
+        levels[rogue.yendorWarden->depth - 1].mapStorage[rogue.yendorWarden->loc.x][rogue.yendorWarden->loc.y].flags &= ~HAS_MONSTER;
     }
     n = rogue.yendorWarden->depth - 1;
 
@@ -1332,14 +1332,14 @@ void updateYendorWardenTracking() {
         rogue.yendorWarden->depth = rogue.depthLevel + 1;
         n = rogue.yendorWarden->depth - 1;
         rogue.yendorWarden->bookkeepingFlags |= MB_APPROACHING_UPSTAIRS;
-        rogue.yendorWarden->xLoc = levels[n].downStairsLoc[0];
-        rogue.yendorWarden->yLoc = levels[n].downStairsLoc[1];
+        rogue.yendorWarden->loc.x = levels[n].downStairsLoc.x;
+        rogue.yendorWarden->loc.y = levels[n].downStairsLoc.y;
     } else {
         rogue.yendorWarden->depth = rogue.depthLevel - 1;
         n = rogue.yendorWarden->depth - 1;
         rogue.yendorWarden->bookkeepingFlags |= MB_APPROACHING_DOWNSTAIRS;
-        rogue.yendorWarden->xLoc = levels[n].upStairsLoc[0];
-        rogue.yendorWarden->yLoc = levels[n].upStairsLoc[1];
+        rogue.yendorWarden->loc.x = levels[n].upStairsLoc.x;
+        rogue.yendorWarden->loc.y = levels[n].upStairsLoc.y;
     }
     prependCreature(&levels[rogue.yendorWarden->depth - 1].monsters, rogue.yendorWarden);
     rogue.yendorWarden->bookkeepingFlags |= MB_PREPLACED;
@@ -1358,8 +1358,8 @@ void monstersFall() {
         if ((monst->bookkeepingFlags & MB_IS_FALLING) || monsterShouldFall(monst)) {
             monst->bookkeepingFlags |= MB_IS_FALLING;
 
-            x = monst->xLoc;
-            y = monst->yLoc;
+            x = monst->loc.x;
+            y = monst->loc.y;
 
             if (canSeeMonster(monst)) {
                 monsterName(buf, monst, true);
@@ -1539,8 +1539,8 @@ void updateAllySafetyMap() {
         }
     }
 
-    playerCostMap[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
-    monsterCostMap[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
+    playerCostMap[player.loc.x][player.loc.y] = PDS_FORBIDDEN;
+    monsterCostMap[player.loc.x][player.loc.y] = PDS_FORBIDDEN;
 
     dijkstraScan(allySafetyMap, playerCostMap, false);
 
@@ -1662,14 +1662,14 @@ void updateSafetyMap() {
         }
     }
 
-    safetyMap[player.xLoc][player.yLoc] = 0;
-    playerCostMap[player.xLoc][player.yLoc] = 1;
-    monsterCostMap[player.xLoc][player.yLoc] = PDS_FORBIDDEN;
+    safetyMap[player.loc.x][player.loc.y] = 0;
+    playerCostMap[player.loc.x][player.loc.y] = 1;
+    monsterCostMap[player.loc.x][player.loc.y] = PDS_FORBIDDEN;
 
-    playerCostMap[rogue.upLoc[0]][rogue.upLoc[1]] = PDS_FORBIDDEN;
-    monsterCostMap[rogue.upLoc[0]][rogue.upLoc[1]] = PDS_FORBIDDEN;
-    playerCostMap[rogue.downLoc[0]][rogue.downLoc[1]] = PDS_FORBIDDEN;
-    monsterCostMap[rogue.downLoc[0]][rogue.downLoc[1]] = PDS_FORBIDDEN;
+    playerCostMap[rogue.upLoc.x][rogue.upLoc.y] = PDS_FORBIDDEN;
+    monsterCostMap[rogue.upLoc.x][rogue.upLoc.y] = PDS_FORBIDDEN;
+    playerCostMap[rogue.downLoc.x][rogue.downLoc.y] = PDS_FORBIDDEN;
+    monsterCostMap[rogue.downLoc.x][rogue.downLoc.y] = PDS_FORBIDDEN;
 
     dijkstraScan(safetyMap, playerCostMap, false);
 
@@ -1849,7 +1849,7 @@ void extinguishFireOnCreature(creature *monst) {
     if (monst == &player) {
         player.info.foreColor = &white;
         rogue.minersLight.lightColor = &minersLightColor;
-        refreshDungeonCell(player.xLoc, player.yLoc);
+        refreshDungeonCell(player.loc.x, player.loc.y);
         updateVision(true);
         message("you are no longer on fire.", 0);
     }
@@ -1860,19 +1860,16 @@ void monsterEntersLevel(creature *monst, short n) {
     char monstName[COLS], buf[COLS];
     boolean pit = false;
 
-    levels[n].mapStorage[monst->xLoc][monst->yLoc].flags &= ~HAS_MONSTER;
+    levels[n].mapStorage[monst->loc.x][monst->loc.y].flags &= ~HAS_MONSTER;
 
     // place traversing monster near the stairs on this level
     if (monst->bookkeepingFlags & MB_APPROACHING_DOWNSTAIRS) {
-        monst->xLoc = rogue.upLoc[0];
-        monst->yLoc = rogue.upLoc[1];
+        monst->loc = rogue.upLoc;
     } else if (monst->bookkeepingFlags & MB_APPROACHING_UPSTAIRS) {
-        monst->xLoc = rogue.downLoc[0];
-        monst->yLoc = rogue.downLoc[1];
+        monst->loc = rogue.downLoc;
     } else if (monst->bookkeepingFlags & MB_APPROACHING_PIT) { // jumping down pit
         pit = true;
-        monst->xLoc = levels[n].playerExitedVia[0];
-        monst->yLoc = levels[n].playerExitedVia[1];
+        monst->loc = levels[n].playerExitedVia;
     } else {
         brogueAssert(false);
     }
@@ -1880,23 +1877,23 @@ void monsterEntersLevel(creature *monst, short n) {
     monst->targetCorpseLoc[0] = monst->targetCorpseLoc[1] = 0;
 
     if (!pit) {
-        getQualifyingPathLocNear(&(monst->xLoc), &(monst->yLoc), monst->xLoc, monst->yLoc, true,
+        getQualifyingPathLocNear(&(monst->loc.x), &(monst->loc.y), monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
                                  avoidedFlagsForMonster(&(monst->info)), HAS_STAIRS, false);
     }
     if (!pit
-        && (pmap[monst->xLoc][monst->yLoc].flags & (HAS_PLAYER | HAS_MONSTER))
-        && !(terrainFlags(monst->xLoc, monst->yLoc) & avoidedFlagsForMonster(&(monst->info)))) {
+        && (pmap[monst->loc.x][monst->loc.y].flags & (HAS_PLAYER | HAS_MONSTER))
+        && !(terrainFlags(monst->loc.x, monst->loc.y) & avoidedFlagsForMonster(&(monst->info)))) {
         // Monsters using the stairs will displace any creatures already located there, to thwart stair-dancing.
-        creature *prevMonst = monsterAtLoc(monst->xLoc, monst->yLoc);
+        creature *prevMonst = monsterAtLoc(monst->loc.x, monst->loc.y);
         brogueAssert(prevMonst);
-        getQualifyingPathLocNear(&(prevMonst->xLoc), &(prevMonst->yLoc), monst->xLoc, monst->yLoc, true,
+        getQualifyingPathLocNear(&(prevMonst->loc.x), &(prevMonst->loc.y), monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(prevMonst->info)), 0,
                                  avoidedFlagsForMonster(&(prevMonst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS), false);
-        pmap[monst->xLoc][monst->yLoc].flags &= ~(HAS_PLAYER | HAS_MONSTER);
-        pmap[prevMonst->xLoc][prevMonst->yLoc].flags |= (prevMonst == &player ? HAS_PLAYER : HAS_MONSTER);
-        refreshDungeonCell(prevMonst->xLoc, prevMonst->yLoc);
-        //DEBUG printf("\nBumped a creature (%s) from (%i, %i) to (%i, %i).", prevMonst->info.monsterName, monst->xLoc, monst->yLoc, prevMonst->xLoc, prevMonst->yLoc);
+        pmap[monst->loc.x][monst->loc.y].flags &= ~(HAS_PLAYER | HAS_MONSTER);
+        pmap[prevMonst->loc.x][prevMonst->loc.y].flags |= (prevMonst == &player ? HAS_PLAYER : HAS_MONSTER);
+        refreshDungeonCell(prevMonst->loc.x, prevMonst->loc.y);
+        //DEBUG printf("\nBumped a creature (%s) from (%i, %i) to (%i, %i).", prevMonst->info.monsterName, monst->loc.x, monst->loc.y, prevMonst->loc.x, prevMonst->loc.y);
     }
 
     // remove traversing monster from other level monster chain
@@ -1908,9 +1905,9 @@ void monsterEntersLevel(creature *monst, short n) {
     monst->bookkeepingFlags |= MB_PREPLACED;
     monst->bookkeepingFlags &= ~MB_IS_FALLING;
     restoreMonster(monst, NULL, NULL);
-    //DEBUG printf("\nPlaced a creature (%s) at (%i, %i).", monst->info.monsterName, monst->xLoc, monst->yLoc);
+    //DEBUG printf("\nPlaced a creature (%s) at (%i, %i).", monst->info.monsterName, monst->loc.x, monst->loc.y);
     monst->ticksUntilTurn = monst->movementSpeed;
-    refreshDungeonCell(monst->xLoc, monst->yLoc);
+    refreshDungeonCell(monst->loc.x, monst->loc.y);
 
     if (pit) {
         monsterName(monstName, monst, true);
@@ -2029,7 +2026,7 @@ void decrementPlayerStatus() {
         message("you no longer feel immune to fire.", 0);
     }
 
-    if (player.status[STATUS_STUCK] && !cellHasTerrainFlag(player.xLoc, player.yLoc, T_ENTANGLES)) {
+    if (player.status[STATUS_STUCK] && !cellHasTerrainFlag(player.loc.x, player.loc.y, T_ENTANGLES)) {
         player.status[STATUS_STUCK] = 0;
     }
 
@@ -2066,8 +2063,8 @@ boolean dangerChanged(boolean danger[4]) {
     enum directions dir;
     short newX, newY;
     for (dir = 0; dir < 4; dir++) {
-        newX = player.xLoc + nbDirs[dir][0];
-        newY = player.yLoc + nbDirs[dir][1];
+        newX = player.loc.x + nbDirs[dir][0];
+        newY = player.loc.y + nbDirs[dir][1];
         if (danger[dir] != monsterAvoids(&player, newX, newY)) {
             return true;
         }
@@ -2083,14 +2080,14 @@ void autoRest() {
     enum directions dir;
 
     for (dir = 0; dir < 4; dir++) {
-        newX = player.xLoc + nbDirs[dir][0];
-        newY = player.yLoc + nbDirs[dir][1];
+        newX = player.loc.x + nbDirs[dir][0];
+        newY = player.loc.y + nbDirs[dir][1];
         danger[dir] = monsterAvoids(&player, newX, newY);
     }
 
     rogue.disturbed = false;
     rogue.automationActive = true;
-    initiallyEmbedded = cellHasTerrainFlag(player.xLoc, player.yLoc, T_OBSTRUCTS_PASSABILITY);
+    initiallyEmbedded = cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY);
 
     if ((player.currentHP < player.info.maxHP
          || player.status[STATUS_HALLUCINATING]
@@ -2107,9 +2104,9 @@ void autoRest() {
                    || player.status[STATUS_NAUSEOUS]
                    || player.status[STATUS_POISONED]
                    || player.status[STATUS_DARKNESS]
-                   || cellHasTerrainFlag(player.xLoc, player.yLoc, T_OBSTRUCTS_PASSABILITY))
+                   || cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY))
                && !rogue.disturbed
-               && (!initiallyEmbedded || cellHasTerrainFlag(player.xLoc, player.yLoc, T_OBSTRUCTS_PASSABILITY))) {
+               && (!initiallyEmbedded || cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY))) {
 
             recordKeystroke(REST_KEY, false, false);
             rogue.justRested = true;
@@ -2275,10 +2272,10 @@ void playerTurnEnded() {
             }
         }
 
-        if (rogue.awarenessBonus > -30 && !(pmap[player.xLoc][player.yLoc].flags & SEARCHED_FROM_HERE)) {
+        if (rogue.awarenessBonus > -30 && !(pmap[player.loc.x][player.loc.y].flags & SEARCHED_FROM_HERE)) {
             // Low-grade auto-search wherever you step, but only once per tile.
             search(rogue.awarenessBonus + 30);
-            pmap[player.xLoc][player.yLoc].flags |= SEARCHED_FROM_HERE;
+            pmap[player.loc.x][player.loc.y].flags |= SEARCHED_FROM_HERE;
         }
         if (!rogue.justSearched && player.status[STATUS_SEARCHING] > 0) {
             // Searching only "charges up" when done on consecutive turns
@@ -2341,7 +2338,7 @@ void playerTurnEnded() {
 
         for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
             creature *monst = nextCreature(&it);
-            if (D_SAFETY_VISION || monst->creatureState == MONSTER_FLEEING && pmap[monst->xLoc][monst->yLoc].flags & IN_FIELD_OF_VIEW) {
+            if (D_SAFETY_VISION || monst->creatureState == MONSTER_FLEEING && pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW) {
                 updateSafetyMap(); // only if there is a fleeing monster who can see the player
                 break;
             }
@@ -2398,7 +2395,7 @@ void playerTurnEnded() {
                         && !(monst->info.flags & MONST_GETS_TURN_ON_ACTIVATION)
                         && rand_percent(monst->info.DFChance)) {
 
-                        spawnDungeonFeature(monst->xLoc, monst->yLoc, &dungeonFeatureCatalog[monst->info.DFType], true, false);
+                        spawnDungeonFeature(monst->loc.x, monst->loc.y, &dungeonFeatureCatalog[monst->info.DFType], true, false);
                     }
                 }
 
@@ -2477,7 +2474,7 @@ void playerTurnEnded() {
                         //assureCosmeticRNG;
                         monsterName(buf2, monst, false);
                         sprintf(buf, "you %s a%s %s",
-                                playerCanDirectlySee(monst->xLoc, monst->yLoc) ? "see" : "sense",
+                                playerCanDirectlySee(monst->loc.x, monst->loc.y) ? "see" : "sense",
                                 (isVowelish(buf2) ? "n" : ""),
                                 buf2);
                         if (rogue.cautiousMode) {
@@ -2493,10 +2490,10 @@ void playerTurnEnded() {
 
             if (canSeeMonster(monst)) {
                 monst->bookkeepingFlags |= MB_WAS_VISIBLE;
-                if (cellHasTerrainFlag(monst->xLoc, monst->yLoc, T_OBSTRUCTS_PASSABILITY)
-                    && cellHasTMFlag(monst->xLoc, monst->yLoc, TM_IS_SECRET)) {
+                if (cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY)
+                    && cellHasTMFlag(monst->loc.x, monst->loc.y, TM_IS_SECRET)) {
 
-                    discover(monst->xLoc, monst->yLoc);
+                    discover(monst->loc.x, monst->loc.y);
                 }
                 if (canDirectlySeeMonster(monst)) {
                     if (rogue.weapon && rogue.weapon->flags & ITEM_RUNIC
@@ -2575,11 +2572,11 @@ void playerTurnEnded() {
     }
 
     // "point of no return" check
-    if ((player.status[STATUS_LEVITATING] && cellHasTerrainFlag(player.xLoc, player.yLoc, T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT))
-        || (player.status[STATUS_IMMUNE_TO_FIRE] && cellHasTerrainFlag(player.xLoc, player.yLoc, T_LAVA_INSTA_DEATH))) {
+    if ((player.status[STATUS_LEVITATING] && cellHasTerrainFlag(player.loc.x, player.loc.y, T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT))
+        || (player.status[STATUS_IMMUNE_TO_FIRE] && cellHasTerrainFlag(player.loc.x, player.loc.y, T_LAVA_INSTA_DEATH))) {
         if (!rogue.receivedLevitationWarning) {
-            turnsRequiredToShore = rogue.mapToShore[player.xLoc][player.yLoc] * player.movementSpeed / 100;
-            if (cellHasTerrainFlag(player.xLoc, player.yLoc, T_LAVA_INSTA_DEATH)) {
+            turnsRequiredToShore = rogue.mapToShore[player.loc.x][player.loc.y] * player.movementSpeed / 100;
+            if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_LAVA_INSTA_DEATH)) {
                 turnsToShore = max(player.status[STATUS_LEVITATING], player.status[STATUS_IMMUNE_TO_FIRE]) * 100 / player.movementSpeed;
             } else {
                 turnsToShore = player.status[STATUS_LEVITATING] * 100 / player.movementSpeed;

--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -62,7 +62,7 @@ static char glyphToAscii(enum displayGlyph glyph) {
 }
 
 static void curses_plotChar(enum displayGlyph ch,
-              short xLoc, short yLoc,
+              short loc.x, short loc.y,
               short foreRed, short foreGreen, short foreBlue,
               short backRed, short backGreen, short backBlue) {
 
@@ -79,7 +79,7 @@ static void curses_plotChar(enum displayGlyph ch,
     ch = glyphToAscii(ch);
 
     if (ch < ' ' || ch > 127) ch = ' ';
-    Term.put(xLoc, yLoc, ch, &fore, &back);
+    Term.put(loc.x, loc.y, ch, &fore, &back);
 }
 
 

--- a/src/platform/web-platform.c
+++ b/src/platform/web-platform.c
@@ -148,7 +148,7 @@ static unsigned int fixUnicode(unsigned int code) {
 }
 
 static void web_plotChar(enum displayGlyph inputChar,
-                         short xLoc, short yLoc,
+                         short loc.x, short loc.y,
                          short foreRed, short foreGreen, short foreBlue,
                          short backRed, short backGreen, short backBlue) {
     unsigned char outputBuffer[OUTPUT_SIZE];
@@ -161,8 +161,8 @@ static void web_plotChar(enum displayGlyph inputChar,
     firstCharByte = translatedChar >> 8 & 0xff;
     secondCharByte = translatedChar;
 
-    outputBuffer[0] = (unsigned char)xLoc;
-    outputBuffer[1] = (unsigned char)yLoc;
+    outputBuffer[0] = (unsigned char)loc.x;
+    outputBuffer[1] = (unsigned char)loc.y;
     outputBuffer[2] = firstCharByte;
     outputBuffer[3] = secondCharByte;
     outputBuffer[4] = (unsigned char)foreRed * 255 / 100;


### PR DESCRIPTION
This PR is designed to make the intent around "position"-affecting code just a little bit more clear, by introducing a type, `pos`, just for storing positions.

There are a lot of mechanical changes like `monst->xLoc` becoming `monst->loc.x`; though in a few cases we're able to replace

```c
monst->xLoc = blah.xLoc;
monst->yLoc = blah.yLoc;
```

with

```c
monst->loc = blah;
```

this doesn't replace _all_ instances of `x` and `y` on their own. I mostly focused on the cases that are used throughout the codebase (item `loc` and creature `loc`) and many of the instances where `short[2]` was used to represent a location instead of being fields on some larger type.

A second pass would find many/most of the places where `short x, short y` are being asked as parameters, and combine them into one.

---

In addition, I think a grid-access macro like

```c
#define at(grid, p) ((grid)[(p).x][(p).y])
```

could make sense (though that would duplicate `p` if it was some complex expression, though that's so rare it hardly ever happens).

---

And since there are a lot of loops `for(int i = 0; i < DCOLS; i++) { ... }` it could also make sense to have a macro for these cases, something like


```c
void next_pos(pos *p) {
   p->x++;
   if (p.x >= DCOLS) {
     p.x = 0;
     p.y++;
   }
}
#define eachpos(VAR) pos VAR = {0, 0}; VAR.y <DROWS; next_pos(&VAR)

for (eachpos(p)) {
   ...
}
```

this would just reduce some repetition and codify a very common pattern.


---

This PR shouldn't contain any functional changes.