### PR TITLE
button: use return instead of out-parameter to initialize

### DIFF
--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -269,7 +269,6 @@ void titleMenu() {
     boolean controlKeyWasDown = false;
 
     short i, b, x, y, button;
-    buttonState state;
     brogueButton buttons[6];
     char whiteColorEscape[10] = "";
     char goldColorEscape[10] = "";
@@ -295,31 +294,31 @@ void titleMenu() {
     b = 0;
     button = -1;
 
-    initializeButton(&(buttons[b]));
+    buttons[b] = defaultButton();
     strcpy(buttons[b].text, newGameText);
     buttons[b].hotkey[0] = 'n';
     buttons[b].hotkey[1] = 'N';
     b++;
 
-    initializeButton(&(buttons[b]));
+    buttons[b] = defaultButton();
     sprintf(buttons[b].text, "     %sO%spen Game      ", goldColorEscape, whiteColorEscape);
     buttons[b].hotkey[0] = 'o';
     buttons[b].hotkey[1] = 'O';
     b++;
 
-    initializeButton(&(buttons[b]));
+    buttons[b] = defaultButton();
     sprintf(buttons[b].text, "   %sV%siew Recording   ", goldColorEscape, whiteColorEscape);
     buttons[b].hotkey[0] = 'v';
     buttons[b].hotkey[1] = 'V';
     b++;
 
-    initializeButton(&(buttons[b]));
+    buttons[b] = defaultButton();
     sprintf(buttons[b].text, "    %sH%sigh Scores     ", goldColorEscape, whiteColorEscape);
     buttons[b].hotkey[0] = 'h';
     buttons[b].hotkey[1] = 'H';
     b++;
 
-    initializeButton(&(buttons[b]));
+    buttons[b] = defaultButton();
     sprintf(buttons[b].text, "        %sQ%suit        ", goldColorEscape, whiteColorEscape);
     buttons[b].hotkey[0] = 'q';
     buttons[b].hotkey[1] = 'Q';
@@ -337,7 +336,7 @@ void titleMenu() {
 
     blackOutScreen();
     clearDisplayBuffer(shadowBuf);
-    initializeButtonState(&state, buttons, b, x, y, 20, b*2-1);
+    buttonState state = createButtonState(buttons, b, x, y, 20, b*2-1);
     rectangularShading(x, y, 20, b*2-1, &black, INTERFACE_OPACITY, shadowBuf);
     drawButtonsInState(&state);
 
@@ -412,8 +411,7 @@ void quitImmediately() {
 void dialogAlert(char *message) {
     cellDisplayBuffer rbuf[COLS][ROWS];
 
-    brogueButton OKButton;
-    initializeButton(&OKButton);
+    brogueButton OKButton = defaultButton();
     strcpy(OKButton.text, "     OK     ");
     OKButton.hotkey[0] = RETURN_KEY;
     OKButton.hotkey[1] = ACKNOWLEDGE_KEY;
@@ -506,7 +504,7 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
         again = false;
 
         for (i=0; i<min(count - currentPageStart, FILES_ON_PAGE_MAX); i++) {
-            initializeButton(&(buttons[i]));
+            buttons[i] = defaultButton();
             buttons[i].flags &= ~(B_WIDE_CLICK_AREA | B_GRADIENT);
             buttons[i].buttonColor = *dialogColor;
             if (KEYBOARD_LABELS) {
@@ -549,7 +547,7 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
 
         if (count > FILES_ON_PAGE_MAX) {
             // Create up and down arrows.
-            initializeButton(&(buttons[i]));
+            buttons[i] = defaultButton();
             strcpy(buttons[i].text, "     *     ");
             buttons[i].symbol[0] = G_UP_ARROW;
             if (currentPageStart <= 0) {
@@ -563,7 +561,7 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
             buttons[i].y = y;
 
             i++;
-            initializeButton(&(buttons[i]));
+            buttons[i] = defaultButton();
             strcpy(buttons[i].text, "     *     ");
             buttons[i].symbol[0] = G_DOWN_ARROW;
             if (currentPageStart + FILES_ON_PAGE_MAX >= count) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3274,15 +3274,16 @@ extern "C" {
     void mainBrogueJunction();
     void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat);
 
-    void initializeButton(brogueButton *button);
+    brogueButton defaultButton(void);
     void drawButtonsInState(buttonState *state);
-    void initializeButtonState(buttonState *state,
-                               brogueButton *buttons,
-                               short buttonCount,
-                               short winX,
-                               short winY,
-                               short winWidth,
-                               short winHeight);
+    buttonState createButtonState(
+        brogueButton *buttons,
+        short buttonChosen,
+        short winX,
+        short winY,
+        short winWidth,
+        short winHeight
+    );
     short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event);
     short smoothHiliteGradient(const short currentXValue, const short maxXValue);
     void drawButton(brogueButton *button, enum buttonDrawStates highlight, cellDisplayBuffer dbuf[COLS][ROWS]);


### PR DESCRIPTION
This change refactors `initializeButton` to instead simply create and return a new `brogueButton` object, instead of asking for an out-parameter.

The same change can be made for `buttonState` because it's treated similarly. 

## Impact on stack frame sizes

The ABI on most systems requires implementing struct-return via passing an additional out-parameter to the function. So usually you should expect this to not change the stack size required.




However, this does change things a little bit. Using Clang's `-Wframe-larger-than=1` flag, you can get a warning that describes the stack frame size for ever function. There are three changes:

```
actionMenu:
  109_560 bytes -> 110_392 bytes
  + 832 bytes

initializeMenuButtons->createMenuButtonState:
  120 bytes -> 920 bytes
  + 800 bytes

dialogChooseFile:
  146_280 bytes -> 146_264 bytes
  - 16 bytes
```

None of these functions are recursive, so the general impact is likely pretty small, but small changes like this could add up. I'm exactly sure _why_ `actionMenu` has gotten 800 bytes larger.
