### PR TITLE
prefer throw/cast paths that don't use unknown cells

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3373,6 +3373,7 @@ short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2],
         // evaluate this path; we will return the path with the highest score
         score = 0;
 
+        boolean passesThroughUnknown = false;
         for (int i = 0; i < listLength; i++) {
             short x = listOfCoordinates[i][0], y = listOfCoordinates[i][1];
 
@@ -3401,15 +3402,21 @@ short getLineCoordinates(short listOfCoordinates[][2], const short originLoc[2],
                     (targetsEnemies && isMonster && isEnemyOfCaster) ||
                     (targetsAllies && isMonster && isAllyOfCaster)) {
 
-                    // big bonus for hitting the target
-                    score += 5000;
+                    // Big bonus for hitting the target, but that bonus
+                    // is lower if this path uses an unknown tile.
+                    score += passesThroughUnknown ? 2500 : 5000;
                 }
 
                 break; // we don't care about anything beyond the target--if the player did, they would have selected a farther target
             }
 
             // if the caster is the player, undiscovered cells don't count (lest we reveal something about them)
-            if (isCastByPlayer && !(pmap[x][y].flags & (DISCOVERED | MAGIC_MAPPED))) continue;
+            if (isCastByPlayer && !(pmap[x][y].flags & (DISCOVERED | MAGIC_MAPPED))) {
+                // Remember that this path used an unknown cell, so that a
+                // less-risky path can be used instead if one is known.
+                passesThroughUnknown = true;
+                continue;
+            }
 
             // nothing can get through impregnable obstacles
             if (isImpassable && pmap[x][y].flags & IMPREGNABLE) {


### PR DESCRIPTION
The auto-adjustment for lines considers whether the play knows about a tile, to avoid giving away secret information. However, it ignores the tile a little _too_ much, since it will happily use a path through an unknown cell even if a perfectly-good path no-risk path exists.

Here's an example of the new behavior in action. Standing in the same place, targeting the same cell, we get two different paths based on the available information, where when we don't know for sure what the cell is, the path avoids it (and then random tie-breaking happens to make it preferred in the second case).

<img width="188" alt="Screen Shot 2021-07-03 at 9 31 45 PM" src="https://user-images.githubusercontent.com/6179181/124373355-9032c580-dc46-11eb-915d-fe007f79f625.png">

<img width="208" alt="Screen Shot 2021-07-03 at 9 31 56 PM" src="https://user-images.githubusercontent.com/6179181/124373358-945ee300-dc46-11eb-8e01-5d77558460b1.png">

I think the main question is whether the adjustment from a bonus from 5000 to 2500 is the "right" one. Maybe it should be less severe, like 4900 or 4000. Or, maybe it should depend on the number of unknown cells that the path uses.

This is likely slightly better than the status quo, but it's not clear which route would be the best in general.

Also, this will break replays, since it affects which path a projectile will take in some cases.