### PR TITLE
Add pathing updates to magic mapping

### DIFF
--- a/changes/pathing-trusts-magic-map.md
+++ b/changes/pathing-trusts-magic-map.md
@@ -1,0 +1,1 @@
+Optimized pathing through deeper dungeon levels which have been revealed by magic mapping

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -6889,6 +6889,13 @@ void readScroll(item *theItem) {
                     }
                 }
             }
+            for (i=0; i<DCOLS; i++) {
+                for (j=0; j<DROWS; j++) {
+                    if (!(cellHasTerrainFlag(i, j, T_IS_DF_TRAP))) {
+                        pmap[i][j].flags |= KNOWN_TO_BE_TRAP_FREE;
+                    }
+                }
+            }
             colorFlash(&magicMapFlashColor, 0, MAGIC_MAPPED, 15, DCOLS + DROWS, player.xLoc, player.yLoc);
             break;
         case SCROLL_AGGRAVATE_MONSTER:


### PR DESCRIPTION
Currently, player pathing in deep dungeon levels prefers tiles which the player has stepped on or seen a monster step on, since these tiles cannot contain traps. This is not necessary if the level has been magic mapped, since the player knows the location of all traps. We can safely add the KNOWN_TO_BE_TRAP_FREE flag to all non-trap tiles when magic mapping, improving pathing through those levels.

Resolves #226