### PR TITLE
Replace enum messageFlags sets with int types

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -3418,7 +3418,7 @@ void displayMessageArchive() {
 // Clears the message area and prints the given message in the area.
 // It will disappear when messages are refreshed and will not be archived.
 // This is primarily used to display prompts.
-void temporaryMessage(const char *msg, enum messageFlags flags) {
+void temporaryMessage(const char *msg, unsigned long flags) {
     char message[COLS];
     short i, j;
 
@@ -3446,7 +3446,7 @@ void temporaryMessage(const char *msg, enum messageFlags flags) {
     restoreRNG;
 }
 
-void messageWithColor(char *msg, color *theColor, enum messageFlags flags) {
+void messageWithColor(char *msg, color *theColor, unsigned long flags) {
     char buf[COLS*2] = "";
     short i;
 
@@ -3481,7 +3481,7 @@ void flavorMessage(char *msg) {
 // arrived on the same turn, they may collapse.  Alternately, they may collapse
 // if the older message is the latest one in the archive and the new one is not
 // semi-colon foldable (such as a combat message.)
-void message(const char *msg, enum messageFlags flags) {
+void message(const char *msg, unsigned long flags) {
     short i;
     archivedMessage *archiveEntry;
     boolean newMessage;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2658,7 +2658,7 @@ typedef struct archivedMessage {
     char message[COLS*2];
     unsigned char count;          // how many times this message appears
     unsigned long turn;           // player turn of the first occurrence
-    enum messageFlags flags;
+    unsigned long flags;
 } archivedMessage;
 
 extern boolean serverMode;
@@ -2917,10 +2917,10 @@ extern "C" {
     void formatRecentMessages(char buf[][COLS*2], size_t height, short *linesFormatted, short *latestMessageLines);
     void displayRecentMessages();
     void displayMessageArchive();
-    void temporaryMessage(const char *msg1, enum messageFlags flags);
-    void messageWithColor(char *msg, color *theColor, enum messageFlags flags);
+    void temporaryMessage(const char *msg1, unsigned long flags);
+    void messageWithColor(char *msg, color *theColor, unsigned long flags);
     void flavorMessage(char *msg);
-    void message(const char *msg, enum messageFlags flags);
+    void message(const char *msg, unsigned long flags);
     void displayMoreSignWithoutWaitingForAcknowledgment();
     void displayMoreSign();
     short encodeMessageColor(char *msg, short i, const color *theColor);


### PR DESCRIPTION
Apple's iOS compiler (correctly) complains that sets / bitwise unions of flag
enums are not always values in that enum. This commit replaces the enum type in
these cases with unsigned long, as is used elsewhere for flag sets.

See sethhoward/iBrogueCE#1.

@withinwheels look ok?