### PR TITLE
Fix build errors when compiling with TERMINAL=YES or WEBBROGUE=YES

### DIFF
--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -62,7 +62,7 @@ static char glyphToAscii(enum displayGlyph glyph) {
 }
 
 static void curses_plotChar(enum displayGlyph ch,
-              short loc.x, short loc.y,
+              short xLoc, short yLoc,
               short foreRed, short foreGreen, short foreBlue,
               short backRed, short backGreen, short backBlue) {
 
@@ -79,7 +79,7 @@ static void curses_plotChar(enum displayGlyph ch,
     ch = glyphToAscii(ch);
 
     if (ch < ' ' || ch > 127) ch = ' ';
-    Term.put(loc.x, loc.y, ch, &fore, &back);
+    Term.put(xLoc, yLoc, ch, &fore, &back);
 }
 
 

--- a/src/platform/web-platform.c
+++ b/src/platform/web-platform.c
@@ -81,7 +81,7 @@ static void closeLogfile() {
 }
 
 static void writeToLog(const char *msg) {
-    fprintf(logfile, msg);
+    fprintf(logfile, "%s", msg);
     fflush(logfile);
 }
 
@@ -148,7 +148,7 @@ static unsigned int fixUnicode(unsigned int code) {
 }
 
 static void web_plotChar(enum displayGlyph inputChar,
-                         short loc.x, short loc.y,
+                         short xLoc, short yLoc,
                          short foreRed, short foreGreen, short foreBlue,
                          short backRed, short backGreen, short backBlue) {
     unsigned char outputBuffer[OUTPUT_SIZE];
@@ -161,8 +161,8 @@ static void web_plotChar(enum displayGlyph inputChar,
     firstCharByte = translatedChar >> 8 & 0xff;
     secondCharByte = translatedChar;
 
-    outputBuffer[0] = (unsigned char)loc.x;
-    outputBuffer[1] = (unsigned char)loc.y;
+    outputBuffer[0] = (unsigned char)xLoc;
+    outputBuffer[1] = (unsigned char)yLoc;
     outputBuffer[2] = firstCharByte;
     outputBuffer[3] = secondCharByte;
     outputBuffer[4] = (unsigned char)foreRed * 255 / 100;


### PR DESCRIPTION
Commit 5d2b549414d4c0c4d36bdcc952deb1440b1ff6f1 appears to have
introduced a find-and-replace error, incorrectly substituting the xLoc
and yLoc parameters of curses_plotChar and web_plotChar with loc.x and
loc.y, respectively. This changeset reverts these parameter names in
order to un-break the build when compiling with TERMINAL=YES or
WEBBROGUE=YES.

Additionally this changeset fixes a format-security error in
web-platform.c which was also causing a build failure.