### PR TITLE
Fix for Jellies splitting before being slain by jelly slaying/quietus.

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -344,14 +344,6 @@ void moralAttack(creature *attacker, creature *defender) {
 
             alertMonster(defender); // this alerts the monster that you're nearby
         }
-
-        if ((defender->info.abilityFlags & MA_CLONE_SELF_ON_DEFEND) && alliedCloneCount(defender) < 100) {
-            if (distanceBetween(defender->loc.x, defender->loc.y, attacker->loc.x, attacker->loc.y) <= 1) {
-                splitMonster(defender, attacker->loc.x, attacker->loc.y);
-            } else {
-                splitMonster(defender, 0, 0);
-            }
-        }
     }
 }
 
@@ -1197,6 +1189,14 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
 
         if (attacker == &player && rogue.weapon && (rogue.weapon->flags & ITEM_RUNIC)) {
             magicWeaponHit(defender, rogue.weapon, sneakAttack || defenderWasAsleep || defenderWasParalyzed);
+        }
+        
+        if (!(defender->bookkeepingFlags & MB_IS_DYING) && (defender->info.abilityFlags & MA_CLONE_SELF_ON_DEFEND) && alliedCloneCount(defender) < 100) {
+            if (distanceBetween(defender->loc.x, defender->loc.y, attacker->loc.x, attacker->loc.y) <= 1) {
+                splitMonster(defender, attacker->loc.x, attacker->loc.y);
+            } else {
+                splitMonster(defender, 0, 0);
+            }
         }
 
         if (attacker == &player


### PR DESCRIPTION
Moved the chunk of code that handles jellies splitting out of moralattack and placed it after the check that will run magicweaponhit if the weapon is a runic. Also added a check to ensure the split does not occur if the jelly is dying as this initially caused a crash as this change seems to allow the jelly to be marked dead before this piece of code runs.

This will logically have the effect of allowing weapons of confusion's confusion to propogate to jellies produced by splitting, and having jellies split after being repelled by weapons of force, as the on-hit effects of runics will now trigger before the split.

This should close Issue #91.

Testing:
The seed 1000391 has a +1 Spear of Jelly Slaying on Depth 2 for all your testing needs, I carried out a quick test by killing a Pink Jelly, the jelly was instantly slain and did not split, I have not tested quietus though have no reason to believe the behaviour would be different as quietus simply trades 100% proc chance for lower chance to proc on any enemy but otherwise works the same way.