### PR TITLE
Fix rounding errors when estimating value of unidentified armor

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2042,14 +2042,18 @@ void itemDetails(char *buf, item *theItem) {
                             abs((short) damageChange),
                             whiteColorEscape);
                 } else {
-                    new = theItem->armor;
+                    new = 0;
+
                     if ((theItem->flags & ITEM_IDENTIFIED) || rogue.playbackOmniscience) {
-                        new += 10 * netEnchant(theItem) / FP_FACTOR;
+                        new = theItem->armor / 10;
+                        new += netEnchant(theItem) / FP_FACTOR;
                     } else {
-                        new += 10 * strengthModifier(theItem) / FP_FACTOR;
+                        new = ((armorTable[theItem->kind].range.upperBound + armorTable[theItem->kind].range.lowerBound) / 2) / 10;
+                        new += strengthModifier(theItem) / FP_FACTOR;
                     }
+
                     new = max(0, new);
-                    new /= 10;
+
                     sprintf(buf2, "Wearing the %s%s will result in an armor rating of %s%i%s. ",
                             theName,
                             ((theItem->flags & ITEM_IDENTIFIED) || rogue.playbackOmniscience) ? "" : ", assuming it has no hidden properties,",


### PR DESCRIPTION
When the armor rating is displayed in the info dialog, the previous
process of estimating the armor rating is something like this:

    estimated = <armor_rating>                                    // => 50
    estimated = estimated + (10 * strength_modifier / FP_FACTOR)  // => 50 - 25 = 25
    estimated = estimated / 10                                    // => 25 / 10 = 2

But when it's equipped, the process ( IO.c:estimatedArmorValue ) is more
like:

    estimated = <average_armor_rating> / 10                       // => 5
    estimated = estimated + (strength_modifier / FP_FACTOR)       // => 5 + 2 = 3

Note, `10 * strength_modifier / FP_FACTOR` is 25 but
`strength_modifier / FP_FACTOR` is 2.

This commit modifies the process to estimate the value of unidentified,
unequipped armor to be exactly the same as the process to estimate
unidentified but equipped armor. The average value of armor is used
(instead of the exact value), and the rounding issues are fixed.

 Fixes #385.