### PR TITLE
Fix control key commands not working in the terminal version

### DIFF
--- a/changes/ctrl-key-in-terminal.md
+++ b/changes/ctrl-key-in-terminal.md
@@ -1,0 +1,1 @@
+Fixed that commands that use the control key (such as ctrl-s for long search) didn't work in the terminal version.

--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -162,7 +162,7 @@ static void curses_nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInpu
             key = rewriteKey(key, textInput);
 
             returnEvent->eventType = KEYSTROKE;
-            returnEvent->controlKey = 0; //(key.rctrl || key.lctrl);
+            returnEvent->controlKey = Term.ctrlPressed(&key); //(key.rctrl || key.lctrl);
             returnEvent->shiftKey = 0; //key.shift;
             returnEvent->param1 = key;
 

--- a/src/platform/term.h
+++ b/src/platform/term.h
@@ -3,7 +3,7 @@
 #define _term_h_
 
 #define TERM_NONE 0
-#define TERM_MOUSE 1
+#define TERM_MOUSE 100000
 
 typedef struct {float r, g, b;} fcolor;
 struct term_t {
@@ -17,6 +17,7 @@ struct term_t {
     void (*title)(const char *);
     void (*resize)(int w, int h);
     int (*keycodeByName)(const char *);
+    int (*ctrlPressed)(int* key);
 
     struct {
         int up, down, left, right, backspace, del, quit;


### PR DESCRIPTION
Fixes #383

I'm using GNOME Terminal for testing, so I can't guarantee this works on other terminals. Someone should probably test on other terminals before merging.