### PR TITLE
Clarify description of negation charm

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2649,7 +2649,7 @@ void itemDetails(char *buf, item *theItem) {
                             charmRechargeDelay(theItem->kind, theItem->enchant1 + 1));
                     break;
                 case CHARM_NEGATION:
-                    sprintf(buf2, "\n\nWhen used, the charm will negate all magical effects on the creatures in your field of view and the items on the ground up to %i spaces away, and recharge in %i turns. (If the charm is enchanted, it will reach up to %i spaces and recharge in %i turns.)",
+                    sprintf(buf2, "\n\nWhen used, the charm will emit a wave of anti-magic up to %i spaces away, negating all magical effects on you and on creatures and dropped items in your field of view. It will recharge in %i turns. (If the charm is enchanted, it will reach up to %i spaces and recharge in %i turns.)",
                             charmNegationRadius(enchant),
                             charmRechargeDelay(theItem->kind, theItem->enchant1),
                             charmNegationRadius(enchant + FP_FACTOR),


### PR DESCRIPTION
The previous description was easy to misread as "the charm will negate all magical effects on (the creatures in your field of view) and (the items on the ground up to 7 spaces away)", which makes it sound like it affects all creatures in your field of view. This rewords the description to hopefully avoid this issue.