### PR TITLE
Update gitignore to ignore screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin/*.brogue*
 bin/BrogueHighScores.txt
 bin/brogue*
+bin/*.png
 
 # Release dirs and archives
 BrogueCE-*


### PR DESCRIPTION
Saved screenshots aren't included in the gitignore, so git keeps thinking I want to commit them. No more.