### PR TITLE
Label +0 armor as such

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1407,17 +1407,13 @@ void itemName(item *theItem, char *root, boolean includeDetails, boolean include
                     }
 
                 if ((theItem->flags & ITEM_IDENTIFIED) || rogue.playbackOmniscience) {
-                    if (theItem->enchant1 == 0) {
-                        sprintf(buf, "%s%s [%i]<%i>", root, grayEscapeSequence, theItem->armor/10, theItem->strengthRequired);
-                    } else {
-                        sprintf(buf, "%s%i %s%s [%i]<%i>",
-                                (theItem->enchant1 < 0 ? "" : "+"),
-                                theItem->enchant1,
-                                root,
-                                grayEscapeSequence,
-                                theItem->armor/10 + theItem->enchant1,
-                                theItem->strengthRequired);
-                    }
+                    sprintf(buf, "%s%i %s%s [%i]<%i>",
+                            (theItem->enchant1 < 0 ? "" : "+"),
+                            theItem->enchant1,
+                            root,
+                            grayEscapeSequence,
+                            theItem->armor/10 + theItem->enchant1,
+                            theItem->strengthRequired);
                     strcpy(root, buf);
                 } else {
                     sprintf(buf, "%s%s <%i>", root, grayEscapeSequence, theItem->strengthRequired);


### PR DESCRIPTION
It's harder to tell at a glance that +0 armor has been formally identified when the game doesn't show it out front. It's also inconsistent with the way weapon information is represented.