### PR TITLE
Ally resurrection favors more powerful allies

### DIFF
--- a/changes/resurrection-prio.md
+++ b/changes/resurrection-prio.md
@@ -1,0 +1,1 @@
+Resurrection altars now prioritise allies by number of times empowered, instead of by most recent death. In the case of a tie, they choose the monster type which is found deepest in the dungeon.

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -2807,22 +2807,18 @@ enum directions scentDirection(creature *monst) {
 
 // returns true if the resurrection was successful.
 boolean resurrectAlly(const short x, const short y) {
-    boolean success;
     creatureIterator allyIterator = iterateCreatures(&purgatory);
-    creature *monToCheck, *monToRaise;
-    monToCheck = monToRaise = nextCreature(&allyIterator);
-
-    if (!monToCheck) { // No allies dead yet; fail.
-        return false;
-    }
 
     // Prefer most empowered ally.  In case of tie, prefer ally with greatest monsterID (thus
     // preferring allies found deeper in the dungeon over ones found higher up and preferring
     // legendary allies over everyone else).
+    creature *monToCheck, *monToRaise = NULL;
     while (monToCheck = nextCreature(&allyIterator)) {
-        if (monToCheck->totalPowerCount > monToRaise->totalPowerCount ||
-            (monToCheck->totalPowerCount == monToRaise->totalPowerCount &&
-             monToCheck->info.monsterID > monToRaise->info.monsterID)) {
+        if (monToRaise == NULL
+            || monToCheck->totalPowerCount > monToRaise->totalPowerCount
+            || (monToCheck->totalPowerCount == monToRaise->totalPowerCount
+                && monToCheck->info.monsterID > monToRaise->info.monsterID)) {
+
             monToRaise = monToCheck;
         }
     }
@@ -2847,11 +2843,10 @@ boolean resurrectAlly(const short x, const short y) {
         monToRaise->status[STATUS_DISCORDANT] = 0;
         heal(monToRaise, 100, true);
 
-        success = true;
+        return true;
     } else {
-        success = false;
+        return false;
     }
-    return success;
 }
 
 void unAlly(creature *monst) {

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -881,6 +881,9 @@ static void removeDeadMonstersFromList(creatureList *list) {
                 && !(decedent->info.flags & MONST_INANIMATE)
                 && (decedent->bookkeepingFlags & MB_HAS_SOUL)
                 && !(decedent->bookkeepingFlags & MB_ADMINISTRATIVE_DEATH)) {
+
+                // Unset flag, since the purgatory list should be iterable.
+                decedent->bookkeepingFlags &= ~MB_HAS_DIED;
                 prependCreature(&purgatory, decedent);
             } else {
                 freeCreature(decedent);


### PR DESCRIPTION
The current behavior of resurrection altars (always resurrect most recently deceased ally) makes it a liability to have weak allies on your team. If a strong ally dies before a weak one, then altars will resurrect the weak one first. This change makes it so that allies who have been empowered more times—or, if that is tied, ones with a greater monsterID—will be resurrected first instead. This removes the liability inherent in weak allies and allows ally players to control which allies they get back by rationing their empowerment.