### PR TITLE
Fix crash when an explosive monster dies from poison or burning damage

### DIFF
--- a/changes/fix-poison-crash.md
+++ b/changes/fix-poison-crash.md
@@ -1,0 +1,1 @@
+Fixed a crash that can happen when an explosive monster dies from poison or burning damage.

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3453,7 +3453,6 @@ boolean spawnDungeonFeature(short x, short y, dungeonFeature *feat, boolean refr
                 if (monst->loc.x == x && monst->loc.y == y || blockingMap[monst->loc.x][monst->loc.y]) {
                     // found it!
                     toggleMonsterDormancy(monst);
-                    restartIterator(&it);
                 }
             }
         }

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1606,15 +1606,15 @@ void addPoison(creature *monst, short durationIncrement, short concentrationIncr
 }
 
 
-// Removes the decedent from the screen and from the monster chain; inserts it into the graveyard chain; does NOT free the memory.
-// Or, if the decedent is a player ally at the moment of death, insert it into the purgatory chain for possible future resurrection.
+// Marks the decedent as dying, but does not remove it from the monster chain to avoid iterator invalidation;
+// that is done in `removeDeadMonsters`.
 // Use "administrativeDeath" if the monster is being deleted for administrative purposes, as opposed to dying as a result of physical actions.
 // AdministrativeDeath means the monster simply disappears, with no messages, dropped item, DFs or other effect.
 void killCreature(creature *decedent, boolean administrativeDeath) {
     short x, y;
     char monstName[DCOLS], buf[DCOLS * 3];
 
-    if (decedent->bookkeepingFlags & MB_IS_DYING) {
+    if (decedent->bookkeepingFlags & (MB_IS_DYING | MB_HAS_DIED)) {
         // monster has already been killed; let's avoid overkill
         return;
     }
@@ -1670,17 +1670,12 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
         } else {
             pmap[x][y].flags &= ~HAS_MONSTER;
         }
-        removeCreature(dormantMonsters, decedent);
-        removeCreature(monsters, decedent);
 
-        if (decedent->leader == &player
-            && !(decedent->info.flags & MONST_INANIMATE)
-            && (decedent->bookkeepingFlags & MB_HAS_SOUL)
-            && !administrativeDeath) {
-            prependCreature(&purgatory, decedent);
-        } else {
-            prependCreature(&graveyard, decedent);
-
+        // This must be done at the same time as removing the HAS_MONSTER flag, or game state might
+        // end up inconsistent.
+        decedent->bookkeepingFlags |= MB_HAS_DIED;
+        if (administrativeDeath) {
+            decedent->bookkeepingFlags |= MB_ADMINISTRATIVE_DEATH;
         }
 
         if (!administrativeDeath && !(decedent->bookkeepingFlags & MB_IS_DORMANT)) {

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -39,7 +39,6 @@ creature player;
 playerCharacter rogue;
 creatureList *monsters;
 creatureList *dormantMonsters;
-creatureList graveyard;
 creatureList purgatory;
 item *floorItems;
 item *packItems;

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -37,7 +37,6 @@ extern creature player;
 extern playerCharacter rogue;
 extern creatureList *monsters;
 extern creatureList *dormantMonsters;
-extern creatureList graveyard;
 extern creatureList purgatory;
 extern item *floorItems;
 extern item *packItems;

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -887,6 +887,10 @@ creatureIterator iterateCreatures(creatureList *list) {
     creatureIterator iter;
     iter.list = list;
     iter.next = list->head;
+    // Skip monsters that have died.
+    while (iter.next != NULL && iter.next->creature->bookkeepingFlags & MB_HAS_DIED) {
+        iter.next = iter.next->nextCreature;
+    }
     return iter;
 }
 boolean hasNextCreature(creatureIterator iter) {
@@ -898,10 +902,18 @@ creature *nextCreature(creatureIterator *iter) {
     }
     creature *result = iter->next->creature;
     iter->next = iter->next->nextCreature;
+    // Skip monsters that have died.
+    while (iter->next != NULL && iter->next->creature->bookkeepingFlags & MB_HAS_DIED) {
+        iter->next = iter->next->nextCreature;
+    }
     return result;
 }
 void restartIterator(creatureIterator *iter) {
     iter->next = iter->list->head;
+    // Skip monsters that have died.
+    while (iter->next != NULL && iter->next->creature->bookkeepingFlags & MB_HAS_DIED) {
+        iter->next = iter->next->nextCreature;
+    }
 }
 void prependCreature(creatureList *list, creature *add) {
     creatureListNode *node = calloc(1, sizeof(creatureListNode));
@@ -2800,7 +2812,7 @@ boolean resurrectAlly(const short x, const short y) {
         pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
 
         // Restore health etc.
-        monst->bookkeepingFlags &= ~(MB_IS_DYING | MB_IS_FALLING);
+        monst->bookkeepingFlags &= ~(MB_IS_DYING | MB_ADMINISTRATIVE_DEATH | MB_HAS_DIED | MB_IS_FALLING);
         if (!(monst->info.flags & MONST_FIERY)
             && monst->status[STATUS_BURNING]) {
 

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -908,13 +908,6 @@ creature *nextCreature(creatureIterator *iter) {
     }
     return result;
 }
-void restartIterator(creatureIterator *iter) {
-    iter->next = iter->list->head;
-    // Skip monsters that have died.
-    while (iter->next != NULL && iter->next->creature->bookkeepingFlags & MB_HAS_DIED) {
-        iter->next = iter->next->nextCreature;
-    }
-}
 void prependCreature(creatureList *list, creature *add) {
     creatureListNode *node = calloc(1, sizeof(creatureListNode));
     node->creature = add;

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -481,20 +481,12 @@ void moveEntrancedMonsters(enum directions dir) {
 
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        monst->bookkeepingFlags &= ~MB_HAS_ENTRANCED_MOVED;
-    }
-
-    for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
-        creature *monst = nextCreature(&it);
-        if (!(monst->bookkeepingFlags & MB_HAS_ENTRANCED_MOVED)
-            && monst->status[STATUS_ENTRANCED]
+        if (monst->status[STATUS_ENTRANCED]
             && !monst->status[STATUS_STUCK]
             && !monst->status[STATUS_PARALYZED]
             && !(monst->bookkeepingFlags & MB_CAPTIVE)) {
 
             moveMonster(monst, nbDirs[dir][0], nbDirs[dir][1]);
-            monst->bookkeepingFlags |= MB_HAS_ENTRANCED_MOVED;
-            restartIterator(&it); // loop through from the beginning to be safe
         }
     }
 }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2063,9 +2063,8 @@ enum monsterBookkeepingFlags {
     MB_IS_DORMANT               = Fl(21),   // lurking, waiting to burst out
     MB_HAS_SOUL                 = Fl(22),   // slaying the monster will count toward weapon auto-ID
     MB_ALREADY_SEEN             = Fl(23),   // seeing this monster won't interrupt exploration
-    MB_HAS_ENTRANCED_MOVED      = Fl(24),   // has already moved while entranced and should not move again
-    MB_ADMINISTRATIVE_DEATH     = Fl(25),   // like the `administrativeDeath` parameter to `killCreature`
-    MB_HAS_DIED                 = Fl(26)    // monster has already been killed but not yet removed from `monsters`
+    MB_ADMINISTRATIVE_DEATH     = Fl(24),   // like the `administrativeDeath` parameter to `killCreature`
+    MB_HAS_DIED                 = Fl(25)    // monster has already been killed but not yet removed from `monsters`
 };
 
 // Defines all creatures, which include monsters and the player:
@@ -2955,7 +2954,6 @@ extern "C" {
     creatureIterator iterateCreatures(creatureList *list);
     boolean hasNextCreature(creatureIterator iter);
     creature *nextCreature(creatureIterator *iter);
-    void restartIterator(creatureIterator *iter);
     void prependCreature(creatureList *list, creature *add);
     boolean removeCreature(creatureList *list, creature *remove);
     creature *firstCreature(creatureList *list);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2058,12 +2058,14 @@ enum monsterBookkeepingFlags {
     MB_ABSORBING                = Fl(16),   // currently learning a skill by absorbing an enemy corpse
     MB_DOES_NOT_TRACK_LEADER    = Fl(17),   // monster will not follow its leader around
     MB_IS_FALLING               = Fl(18),   // monster is plunging downward at the end of the turn
-    MB_IS_DYING                 = Fl(19),   // monster has already been killed and is awaiting the end-of-turn graveyard sweep (or in purgatory)
+    MB_IS_DYING                 = Fl(19),   // monster is currently dying; the death is still being processed
     MB_GIVEN_UP_ON_SCENT        = Fl(20),   // to help the monster remember that the scent map is a dead end
     MB_IS_DORMANT               = Fl(21),   // lurking, waiting to burst out
     MB_HAS_SOUL                 = Fl(22),   // slaying the monster will count toward weapon auto-ID
     MB_ALREADY_SEEN             = Fl(23),   // seeing this monster won't interrupt exploration
-    MB_HAS_ENTRANCED_MOVED      = Fl(24)    // has already moved while entranced and should not move again
+    MB_HAS_ENTRANCED_MOVED      = Fl(24),   // has already moved while entranced and should not move again
+    MB_ADMINISTRATIVE_DEATH     = Fl(25),   // like the `administrativeDeath` parameter to `killCreature`
+    MB_HAS_DIED                 = Fl(26)    // monster has already been killed but not yet removed from `monsters`
 };
 
 // Defines all creatures, which include monsters and the player:
@@ -2839,7 +2841,7 @@ extern "C" {
     void updateMinersLightRadius();
     void freeCreature(creature *monst);
     void freeCreatureList(creatureList *list);
-    void emptyGraveyard();
+    void removeDeadMonsters();
     void freeEverything();
     boolean randomMatchingLocation(short *x, short *y, short dungeonType, short liquidType, short terrainType);
     enum dungeonLayers highestPriorityLayer(short x, short y, boolean skipGas);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -279,7 +279,6 @@ void initializeRogue(uint64_t seed) {
 
     monsters = &levels[0].monsters;
     dormantMonsters = &levels[0].dormantMonsters;
-    graveyard = createCreatureList();
     purgatory = createCreatureList();
 
     scentMap            = NULL;
@@ -884,20 +883,17 @@ static void removeDeadMonstersFromList(creatureList *list) {
                 && !(decedent->bookkeepingFlags & MB_ADMINISTRATIVE_DEATH)) {
                 prependCreature(&purgatory, decedent);
             } else {
-                prependCreature(&graveyard, decedent);
+                freeCreature(decedent);
             }
         }
     }
 }
 
-// Removes dead monsters from `monsters`/`dormantMonsters` and inserts them into `graveyard` or
-// `purgatory`; if the decedent is a player ally at the moment of death, inserts it into the
-// purgatory chain for possible future resurrection.
-// Also empties the graveyard.
+// Removes dead monsters from `monsters`/`dormantMonsters`, and inserts them into `purgatory` if
+// the decedent is a player ally at the moment of death, for possible future resurrection.
 void removeDeadMonsters() {
     removeDeadMonstersFromList(monsters);
     removeDeadMonstersFromList(dormantMonsters);
-    freeCreatureList(&graveyard);
 }
 
 void freeEverything() {
@@ -929,7 +925,6 @@ void freeEverything() {
         }
     }
     scentMap = NULL;
-    freeCreatureList(&graveyard);
     freeCreatureList(&purgatory);
 
     for (theItem = floorItems; theItem != NULL; theItem = theItem2) {

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -2444,7 +2444,6 @@ void playerTurnEnded() {
                             break;
                         }
                     }
-                    restartIterator(&it); // loop through from the beginning to be safe
                 }
             }
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -2594,7 +2594,7 @@ void playerTurnEnded() {
         rogue.receivedLevitationWarning = false;
     }
 
-    emptyGraveyard();
+    removeDeadMonsters();
     rogue.playbackBetweenTurns = true;
     RNGCheck();
     handleHealthAlerts();


### PR DESCRIPTION
This crash happened with seed 500500500; if you get the staff of poison from depth 7 and use it on the explosive goblin on depth 11 twice, the game crashes when the goblin dies. It can also happen with burning damage.

This fixes the crash by not removing monsters from `monsters` or `dormantMonsters` until `emptyGraveyard`, as well as modifying `iterateCreatures` to skip dying monsters. This approach should hopefully fix not only this crash, but also any similar crashes that haven't been seen yet.

Also fix an issue Valgrind identified in `getInputTextString`.

Fixes #404.

~~I've played a couple short games to look for issues, but I haven't played enough to be sure there aren't any issues. Also, I'm not sure whether this breaks save/replay compatibility or not; an early version did for some saves, but I've made several changes since then.~~