### PR TITLE
Label +0 armor as such

### DIFF
--- a/changes/+0-armor.md
+++ b/changes/+0-armor.md
@@ -1,0 +1,1 @@
+Identified +0 armor is now prefixed with a +0, as is the case with weapons.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1407,17 +1407,13 @@ void itemName(item *theItem, char *root, boolean includeDetails, boolean include
                     }
 
                 if ((theItem->flags & ITEM_IDENTIFIED) || rogue.playbackOmniscience) {
-                    if (theItem->enchant1 == 0) {
-                        sprintf(buf, "%s%s [%i]<%i>", root, grayEscapeSequence, theItem->armor/10, theItem->strengthRequired);
-                    } else {
-                        sprintf(buf, "%s%i %s%s [%i]<%i>",
-                                (theItem->enchant1 < 0 ? "" : "+"),
-                                theItem->enchant1,
-                                root,
-                                grayEscapeSequence,
-                                theItem->armor/10 + theItem->enchant1,
-                                theItem->strengthRequired);
-                    }
+                    sprintf(buf, "%s%i %s%s [%i]<%i>",
+                            (theItem->enchant1 < 0 ? "" : "+"),
+                            theItem->enchant1,
+                            root,
+                            grayEscapeSequence,
+                            theItem->armor/10 + theItem->enchant1,
+                            theItem->strengthRequired);
                     strcpy(root, buf);
                 } else {
                     sprintf(buf, "%s%s <%i>", root, grayEscapeSequence, theItem->strengthRequired);


### PR DESCRIPTION
When +0 armor is identified as +0, prefix its name with the string "+0" to make it clearer that the armor is formally identified. (This non-gameplay change was previously based on the master branch rather than the release branch. This version is based on the release branch instead as desired.)