### PR TITLE
Fix monster state when a discorded ally loses a stolen item in deep water

### DIFF
--- a/changes/discordant-monkey-ally.md
+++ b/changes/discordant-monkey-ally.md
@@ -1,0 +1,1 @@
+Fixed a bug which prevented a discorded ally from returning to normal after losing a stolen item in deep water

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1760,7 +1760,13 @@ void updateMonsterState(creature *monst) {
                && !(monst->carriedItem)) {
 
         monst->creatureMode = MODE_NORMAL;
-        alertMonster(monst);
+
+        if (BROGUE_VERSION_ATLEAST(1,10,2) && monst->leader == &player) {
+            monst->creatureState = MONSTER_ALLY; // Reset state if a discorded ally steals an item and then loses it (probably in deep water)
+        } else {
+            alertMonster(monst);
+        }
+
     } else if (monst->creatureMode == MODE_NORMAL
                && monst->creatureState == MONSTER_FLEEING
                && (monst->info.flags & MONST_FLEES_NEAR_DEATH)


### PR DESCRIPTION
Closes #378 