### PR TITLE
Fix two variable warnings

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5710,14 +5710,13 @@ static void tryIdentifyLastItemKinds(enum itemCategory category) {
 
 void identifyItemKind(item *theItem) {
     itemTable *theTable;
-    short tableCount, i, lastItem;
+    short tableCount;
 
     theTable = tableForItemCategory(theItem->category);
     if (theTable) {
         theItem->flags &= ~ITEM_KIND_AUTO_ID;
 
         tableCount = 0;
-        lastItem = -1;
 
         switch (theItem->category) {
             case SCROLL:


### PR DESCRIPTION
```
src/brogue/Items.c: In function ‘identifyItemKind’:
src/brogue/Items.c:5713:26: warning: variable ‘lastItem’ set but not used [-Wunused-but-set-variable]
 5713 |     short tableCount, i, lastItem;
      |                          ^~~~~~~~
src/brogue/Items.c:5713:23: warning: unused variable ‘i’ [-Wunused-variable]
 5713 |     short tableCount, i, lastItem;
      |                       ^
```

Looks like it was introduced in f2bc84a