### PR TITLE
Show lit/dark highlights when stealth range is shown

### DIFF
--- a/changes/stealth-range-display-shows-lit-and-dark.md
+++ b/changes/stealth-range-display-shows-lit-and-dark.md
@@ -1,0 +1,1 @@
+Stealth range display shows lit and dark areas.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -1486,7 +1486,7 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
         }
     }
 
-    if (rogue.trueColorMode
+    if ((rogue.trueColorMode || rogue.displayStealthRangeMode)
         && playerCanSeeOrSense(x, y)) {
 
         if (displayDetail[x][y] == DV_DARK) {

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -339,11 +339,11 @@ short actionMenu(short x, boolean playingBack) {
         takeActionOurselves[buttonCount] = true;
         buttonCount++;
         if (KEYBOARD_LABELS) {
-            sprintf(buttons[buttonCount].text, "  %s]: %s[%s] Display stealth range  ", yellowColorEscape, whiteColorEscape, rogue.displayAggroRangeMode ? "X" : " ");
+            sprintf(buttons[buttonCount].text, "  %s]: %s[%s] Display stealth range  ", yellowColorEscape, whiteColorEscape, rogue.displayStealthRangeMode ? "X" : " ");
         } else {
-            sprintf(buttons[buttonCount].text, "  [%s] Show stealth range  ",   rogue.displayAggroRangeMode ? "X" : " ");
+            sprintf(buttons[buttonCount].text, "  [%s] Show stealth range  ",   rogue.displayStealthRangeMode ? "X" : " ");
         }
-        buttons[buttonCount].hotkey[0] = AGGRO_DISPLAY_KEY;
+        buttons[buttonCount].hotkey[0] = STEALTH_RANGE_KEY;
         takeActionOurselves[buttonCount] = true;
         buttonCount++;
 
@@ -1476,9 +1476,9 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
 
     bakeTerrainColors(&cellForeColor, &cellBackColor, x, y);
 
-    if (rogue.displayAggroRangeMode && (pmap[x][y].flags & IN_FIELD_OF_VIEW)) {
+    if (rogue.displayStealthRangeMode && (pmap[x][y].flags & IN_FIELD_OF_VIEW)) {
         distance = min(rogue.scentTurnNumber - scentMap[x][y], scentDistance(x, y, player.loc.x, player.loc.y));
-        if (distance > rogue.aggroRange * 2) {
+        if (distance > rogue.stealthRange * 2) {
             applyColorAverage(&cellForeColor, &orange, 12);
             applyColorAverage(&cellBackColor, &orange, 12);
             applyColorAugment(&cellForeColor, &orange, 12);
@@ -2611,11 +2611,11 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
                                  &teal, 0);
             }
             break;
-        case AGGRO_DISPLAY_KEY:
-            rogue.displayAggroRangeMode = !rogue.displayAggroRangeMode;
+        case STEALTH_RANGE_KEY:
+            rogue.displayStealthRangeMode = !rogue.displayStealthRangeMode;
             displayLevel();
             refreshSideBar(-1, -1, false);
-            if (rogue.displayAggroRangeMode) {
+            if (rogue.displayStealthRangeMode) {
                 messageWithColor(KEYBOARD_LABELS ? "Stealth range displayed. Press ']' again to hide." : "Stealth range displayed.",
                                  &teal, 0);
             } else {
@@ -4855,7 +4855,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 tempColorEscape[0] = '\0';
                 grayColorEscape[0] = '\0';
                 tempColor = playerInShadowColor;
-                percent = (rogue.aggroRange - 2) * 100 / 28;
+                percent = (rogue.stealthRange - 2) * 100 / 28;
                 applyColorAverage(&tempColor, &black, percent);
                 applyColorAugment(&tempColor, &playerInLightColor, percent);
                 if (dim) {
@@ -4865,7 +4865,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 encodeMessageColor(grayColorEscape, 0, (dim ? &darkGray : &gray));
                 sprintf(buf, "%sStealth range: %i%s",
                         tempColorEscape,
-                        rogue.aggroRange,
+                        rogue.stealthRange,
                         grayColorEscape);
                 printString("                    ", 0, y, &white, &black, 0);
                 printString(buf, 1, y++, (dim ? &darkGray : &gray), &black, 0);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2047,14 +2047,14 @@ void itemDetails(char *buf, item *theItem) {
             }
 
             // heavy armor?
-            current = armorAggroAdjustment(rogue.armor);
+            current = armorStealthAdjustment(rogue.armor);
             if ((theItem->category & ARMOR)
                 && !(theItem->flags & ITEM_EQUIPPED)
-                && (current != armorAggroAdjustment(theItem))) {
+                && (current != armorStealthAdjustment(theItem))) {
 
-                new = armorAggroAdjustment(theItem);
+                new = armorStealthAdjustment(theItem);
                 if (rogue.armor) {
-                    new -= armorAggroAdjustment(rogue.armor);
+                    new -= armorStealthAdjustment(rogue.armor);
                 }
                 sprintf(buf2, "Equipping the %s will %s%s your stealth range by %i%s. ",
                         theName,
@@ -3271,7 +3271,7 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
 
     if (player.loc.x == x && player.loc.y == y) {
         player.status[STATUS_AGGRAVATING] = player.maxStatus[STATUS_AGGRAVATING] = distance;
-        rogue.aggroRange = currentAggroValue();
+        rogue.stealthRange = currentStealthRange();
     }
 
     if (grid[player.loc.x][player.loc.y] >= 0 && grid[player.loc.x][player.loc.y] <= distance) {

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1619,7 +1619,7 @@ short awarenessDistance(creature *observer, creature *target) {
 // takes into account whether it is ALREADY aware of the target.
 boolean awareOfTarget(creature *observer, creature *target) {
     short perceivedDistance = awarenessDistance(observer, target);
-    short awareness = rogue.aggroRange * 2;
+    short awareness = rogue.stealthRange * 2;
     boolean retval;
 
     brogueAssert(perceivedDistance >= 0 && awareness >= 0);

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -667,7 +667,7 @@ static void resetPlayback() {
     boolean omniscient, stealth, trueColors;
 
     omniscient = rogue.playbackOmniscience;
-    stealth = rogue.displayAggroRangeMode;
+    stealth = rogue.displayStealthRangeMode;
     trueColors = rogue.trueColorMode;
 
     freeEverything();
@@ -676,7 +676,7 @@ static void resetPlayback() {
     initializeRogue(0); // Seed argument is ignored because we're in playback.
 
     rogue.playbackOmniscience = omniscient;
-    rogue.displayAggroRangeMode = stealth;
+    rogue.displayStealthRangeMode = stealth;
     rogue.trueColorMode = trueColors;
 
     rogue.playbackFastForward = false;
@@ -1002,11 +1002,11 @@ boolean executePlaybackInput(rogueEvent *recordingInput) {
                                      &teal, 0);
                 }
                 return true;
-            case AGGRO_DISPLAY_KEY:
-                rogue.displayAggroRangeMode = !rogue.displayAggroRangeMode;
+            case STEALTH_RANGE_KEY:
+                rogue.displayStealthRangeMode = !rogue.displayStealthRangeMode;
                 displayLevel();
                 refreshSideBar(-1, -1, false);
-                if (rogue.displayAggroRangeMode) {
+                if (rogue.displayStealthRangeMode) {
                     messageWithColor(KEYBOARD_LABELS ? "Stealth range displayed. Press ']' again to hide." : "Stealth range displayed.",
                                      &teal, 0);
                 } else {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1160,7 +1160,7 @@ enum tileFlags {
 #define RELABEL_KEY         'R'
 #define SWAP_KEY            'w'
 #define TRUE_COLORS_KEY     '\\'
-#define AGGRO_DISPLAY_KEY   ']'
+#define STEALTH_RANGE_KEY   ']'
 #define DROP_KEY            'd'
 #define CALL_KEY            'c'
 #define QUIT_KEY            'Q'
@@ -2292,7 +2292,7 @@ typedef struct playerCharacter {
     boolean alreadyFell;                // so the player can fall only one depth per turn
     boolean eligibleToUseStairs;        // so the player uses stairs only when he steps onto them
     boolean trueColorMode;              // whether lighting effects are disabled
-    boolean displayAggroRangeMode;      // whether your stealth range is displayed
+    boolean displayStealthRangeMode;    // whether your stealth range is displayed
     boolean quit;                       // to skip the typical end-game theatrics when the player quits
     uint64_t seed;                      // the master seed for generating the entire dungeon
     short RNG;                          // which RNG are we currently using?
@@ -2322,7 +2322,7 @@ typedef struct playerCharacter {
     unsigned long absoluteTurnNumber;   // number of turns since the beginning of time. Always increments.
     signed long milliseconds;           // milliseconds since launch, to decide whether to engage cautious mode
     short xpxpThisTurn;                 // how many squares the player explored this turn
-    short aggroRange;                   // distance from which monsters will notice you
+    short stealthRange;                 // distance from which monsters will notice you
 
     short previousPoisonPercent;        // and your poison proportion, to display percentage alerts for each.
 
@@ -3224,8 +3224,8 @@ extern "C" {
     void autoPlayLevel(boolean fastForward);
     void updateClairvoyance();
     short scentDistance(short x1, short y1, short x2, short y2);
-    short armorAggroAdjustment(item *theArmor);
-    short currentAggroValue();
+    short armorStealthAdjustment(item *theArmor);
+    short currentStealthRange();
 
     void initRecording();
     void flushBufferToFile();

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -143,7 +143,7 @@ void welcome() {
 void initializeRogue(uint64_t seed) {
     short i, j, k;
     item *theItem;
-    boolean playingback, playbackFF, playbackPaused, wizard, displayAggroRangeMode;
+    boolean playingback, playbackFF, playbackPaused, wizard, displayStealthRangeMode;
     boolean trueColorMode;
     short oldRNG;
 
@@ -151,14 +151,14 @@ void initializeRogue(uint64_t seed) {
     playbackPaused = rogue.playbackPaused;
     playbackFF = rogue.playbackFastForward;
     wizard = rogue.wizard;
-    displayAggroRangeMode = rogue.displayAggroRangeMode;
+    displayStealthRangeMode = rogue.displayStealthRangeMode;
     trueColorMode = rogue.trueColorMode;
     memset((void *) &rogue, 0, sizeof( playerCharacter )); // the flood
     rogue.playbackMode = playingback;
     rogue.playbackPaused = playbackPaused;
     rogue.playbackFastForward = playbackFF;
     rogue.wizard = wizard;
-    rogue.displayAggroRangeMode = displayAggroRangeMode;
+    rogue.displayStealthRangeMode = displayStealthRangeMode;
     rogue.trueColorMode = trueColorMode;
 
     rogue.gameHasEnded = false;
@@ -827,7 +827,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
     updateMapToShore();
     updateVision(true);
-    rogue.aggroRange = currentAggroValue();
+    rogue.stealthRange = currentStealthRange();
 
     // update monster states so none are hunting if there is no scent and they can't see the player
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -659,7 +659,7 @@ void updateScent() {
     addScentToCell(player.loc.x, player.loc.y, 0);
 }
 
-short armorAggroAdjustment(item *theArmor) {
+short armorStealthAdjustment(item *theArmor) {
     if (!theArmor
         || !(theArmor->category & ARMOR)) {
 
@@ -668,46 +668,46 @@ short armorAggroAdjustment(item *theArmor) {
     return max(0, armorTable[theArmor->kind].strengthRequired - 12);
 }
 
-short currentAggroValue() {
+short currentStealthRange() {
     // Default value of 14 in the light.
-    short stealthVal = 14;
+    short stealthRange = 14;
 
     if (player.status[STATUS_INVISIBLE]) {
-        stealthVal = 1; // Invisibility means stealth range of 1, no matter what.
+        stealthRange = 1; // Invisibility means stealth range of 1, no matter what.
     } else {
         if (playerInDarkness()) {
             // In darkness, halve, rounded down.
-            stealthVal = stealthVal / 2;
+            stealthRange = stealthRange / 2;
         }
         if (pmap[player.loc.x][player.loc.y].flags & IS_IN_SHADOW) {
             // When not standing in a lit area, halve, rounded down (stacks with darkness halving).
-            stealthVal = stealthVal / 2;
+            stealthRange = stealthRange / 2;
         }
 
         // Add 1 for each point of your armor's natural (unenchanted) strength requirement above 12.
-        stealthVal += armorAggroAdjustment(rogue.armor);
+        stealthRange += armorStealthAdjustment(rogue.armor);
 
         // Halve (rounded up) if you just rested.
         if (rogue.justRested) {
-            stealthVal = (stealthVal + 1) / 2;
+            stealthRange = (stealthRange + 1) / 2;
         }
 
         if (player.status[STATUS_AGGRAVATING] > 0) {
-            stealthVal += player.status[STATUS_AGGRAVATING];
+            stealthRange += player.status[STATUS_AGGRAVATING];
         }
 
         // Subtract your bonuses from rings of stealth.
         // (Cursed rings of stealth will end up adding here.)
-        stealthVal -= rogue.stealthBonus;
+        stealthRange -= rogue.stealthBonus;
 
         // Can't go below 2 unless you just rested.
-        if (stealthVal < 2 && !rogue.justRested) {
-            stealthVal = 2;
-        } else if (stealthVal < 1) { // Can't go below 1, ever.
-            stealthVal = 1;
+        if (stealthRange < 2 && !rogue.justRested) {
+            stealthRange = 2;
+        } else if (stealthRange < 1) { // Can't go below 1, ever.
+            stealthRange = 1;
         }
     }
-    return stealthVal;
+    return stealthRange;
 }
 
 void demoteVisibility() {
@@ -2329,8 +2329,8 @@ void playerTurnEnded() {
 
         updateScent();
 //      updateVision(true);
-//        rogue.aggroRange = currentAggroValue();
-//        if (rogue.displayAggroRangeMode) {
+//        rogue.stealthRange = currentStealthRange();
+//        if (rogue.displayStealthRangeMode) {
 //            displayLevel();
 //        }
         rogue.updatedSafetyMapThisTurn          = false;
@@ -2459,8 +2459,8 @@ void playerTurnEnded() {
         //checkForDungeonErrors();
 
         updateVision(true);
-        rogue.aggroRange = currentAggroValue();
-        if (rogue.displayAggroRangeMode) {
+        rogue.stealthRange = currentStealthRange();
+        if (rogue.displayStealthRangeMode) {
             displayLevel();
         }
 

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     rogue.nextGamePath[0] = '\0';
     rogue.nextGameSeed = 0;
     rogue.wizard = false;
-    rogue.displayAggroRangeMode = false;
+    rogue.displayStealthRangeMode = false;
     rogue.trueColorMode = false;
 
     enum graphicsModes initialGraphics = TEXT_GRAPHICS;
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
 #endif
 
         if (strcmp(argv[i], "--stealth") == 0 || strcmp(argv[i], "-S") == 0) {
-            rogue.displayAggroRangeMode = true;
+            rogue.displayStealthRangeMode = true;
             continue;
         }
 


### PR DESCRIPTION
* Internally rename "aggro range" to "stealth range"
* Clearer display of lit and dark areas now follows stealth range display mode, rather than true color display mode
* Tweak light and dark coloring

![toggle](https://user-images.githubusercontent.com/71227107/143820131-3e5a1dd7-0e13-4d46-b239-51112fdfebd7.gif)

Closes #56 