### PR TITLE
Fix format-truncation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include config.mk
 
 cflags := -Isrc/brogue -Isrc/platform -std=c99 \
 	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-unused-result \
-	-Wformat -Werror=format-security -Wformat-overflow=0 -Wformat-truncation=0
+	-Wformat -Werror=format-security -Wformat-overflow=0
 libs := -lm
 cppflags := -DDATADIR=$(DATADIR)
 

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1263,7 +1263,7 @@ short strLenWithoutEscapes(const char *str) {
 // Messages in the buffer are delimited by newlines.
 void combatMessage(char *theMsg, color *theColor) {
     short length;
-    char newMsg[COLS * 2];
+    char newMsg[COLS * 2 - 1]; // -1 for the newline when appending later
 
     if (theColor == 0) {
         theColor = &white;
@@ -1271,7 +1271,8 @@ void combatMessage(char *theMsg, color *theColor) {
 
     newMsg[0] = '\0';
     encodeMessageColor(newMsg, 0, theColor);
-    strcat(newMsg, theMsg);
+    length = strlen(newMsg);
+    strncat(&newMsg[length], theMsg, (COLS * 2 - 1) - length - 1);
 
     length = strlen(combatText);
 

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1163,7 +1163,7 @@ void saveGameNoPrompt() {
 }
 
 void saveGame() {
-    char filePathWithoutSuffix[BROGUE_FILENAME_MAX], filePath[BROGUE_FILENAME_MAX], defaultPath[BROGUE_FILENAME_MAX];
+    char filePathWithoutSuffix[BROGUE_FILENAME_MAX - sizeof(GAME_SUFFIX)], filePath[BROGUE_FILENAME_MAX], defaultPath[BROGUE_FILENAME_MAX];
     boolean askAgain;
 
     if (rogue.playbackMode) {


### PR DESCRIPTION
Generally by shortening input buffers.
    
Also replace a strcat with strncat.
