### PR TITLE
Negating a monster twice restores traits

### DIFF
--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -1941,21 +1941,21 @@ const monsterWords monsterText[NUMBER_MONSTER_KINDS] = {
 const mutation mutationCatalog[NUMBER_MUTATORS] = {
     //Title         textColor       healthFactor    moveSpdMult attackSpdMult   defMult damMult DF% DFtype  light   monstFlags  abilityFlags    forbiddenFlags      forbiddenAbilities      canBeNegated
     {"explosive",   &orange,        50,             100,        100,            50,     100,    0,  DF_MUTATION_EXPLOSION, EXPLOSIVE_BLOAT_LIGHT, 0, MA_DF_ON_DEATH, MONST_SUBMERGES, 0,
-        "A rare mutation will cause $HIMHER to explode violently when $HESHE dies.",    true},
+        "A rare mutation has infused $HISHER body with explosive energies", "rendered them inert.", true},
     {"infested",    &lichenColor,   50,             100,        100,            50,     100,    0,  DF_MUTATION_LICHEN, 0, 0,   MA_DF_ON_DEATH, 0,               0,
-        "$HESHE has been infested by deadly lichen spores; poisonous fungus will spread from $HISHER corpse when $HESHE dies.", true},
+        "The spores of a deadly lichen have infested $HISHER body to germinate when $HESHE dies", "rendered them inert.", true},
     {"agile",       &lightBlue,     100,            50,         100,            150,    100,    -1, 0,      0,      MONST_FLEES_NEAR_DEATH, 0, MONST_FLEES_NEAR_DEATH, 0,
-        "A rare mutation greatly enhances $HISHER mobility.",   false},
+        "A rare mutation greatly enhances $HISHER mobility",   "", false},
     {"juggernaut",  &brown,         300,            200,        200,            75,     200,    -1, 0,      0,      0,          MA_ATTACKS_STAGGER, MONST_MAINTAINS_DISTANCE, 0,
-        "A rare mutation has hardened $HISHER flesh, increasing $HISHER health and power but compromising $HISHER speed.",  false},
+        "A rare mutation has hardened $HISHER flesh, increasing $HISHER health and power but compromising $HISHER speed",  "", false},
     {"grappling",   &tanColor,      150,            100,        100,            50,     100,    -1, 0,      0,      0,          MA_SEIZES,      MONST_MAINTAINS_DISTANCE, MA_SEIZES,
-        "A rare mutation has caused suckered tentacles to sprout from $HISHER frame, increasing $HISHER health and allowing $HIMHER to grapple with $HISHER prey.", true},
+        "A rare mutation has caused suckered tentacles to sprout from $HISHER frame, increasing $HISHER health and allowing $HIMHER to grapple with $HISHER prey", "left the tentacles paralyzed.", true},
     {"vampiric",    &red,           100,            100,        100,            100,    100,    -1, 0,      0,      0,          MA_TRANSFERENCE, MONST_MAINTAINS_DISTANCE, MA_TRANSFERENCE,
-        "A rare mutation allows $HIMHER to heal $HIMSELFHERSELF with every attack.",    true},
+        "A rare mutation allows $HIMHER to heal $HIMSELFHERSELF with every attack", "stripped $HIMHER of this ability.",    true},
     {"toxic",       &green,         100,            100,        200,            100,    20,     -1, 0,      0,      0,          (MA_CAUSES_WEAKNESS | MA_POISONS), MONST_MAINTAINS_DISTANCE, (MA_CAUSES_WEAKNESS | MA_POISONS),
-        "A rare mutation causes $HIMHER to poison $HISHER victims and sap their strength with every attack.",   true},
+        "A rare mutation causes $HIMHER to poison $HISHER victims and sap their strength with every attack", "stripped $HIMHER of this ability.",   true},
     {"reflective",  &darkTurquoise, 100,            100,        100,            100,    100,    -1, 0,      0,      MONST_REFLECT_4, 0,         (MONST_REFLECT_4 | MONST_ALWAYS_USE_ABILITY), 0,
-        "A rare mutation has coated $HISHER flesh with reflective scales.",     true},
+        "A rare mutation has coated $HISHER flesh with reflective scales", "tarnished their luster.",    true},
 };
 
 const hordeType hordeCatalog[NUMBER_HORDES] = {

--- a/src/brogue/Light.c
+++ b/src/brogue/Light.c
@@ -240,10 +240,10 @@ void updateLighting() {
     for (creatureIterator it = iterateCreatures(monsters); !handledPlayer || hasNextCreature(it);) {
         creature *monst = !handledPlayer ? &player : nextCreature(&it);
         handledPlayer = true;
-        if (monst->info.intrinsicLightType) {
+        if (monst->info.intrinsicLightType && !monst->wasNegated) {
             paintLight(&lightCatalog[monst->info.intrinsicLightType], monst->loc.x, monst->loc.y, false, false);
         }
-        if (monst->mutationIndex >= 0 && mutationCatalog[monst->mutationIndex].light != NO_LIGHT) {
+        if (monst->mutationIndex >= 0 && mutationCatalog[monst->mutationIndex].light != NO_LIGHT && !monst->wasNegated) {
             paintLight(&lightCatalog[mutationCatalog[monst->mutationIndex].light], monst->loc.x, monst->loc.y, false, false);
         }
 

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -4158,15 +4158,31 @@ void monsterDetails(char buf[], creature *monst) {
     }
 
     if (monst->mutationIndex >= 0) {
+        mutation mutationInfo = mutationCatalog[monst->mutationIndex];
+        boolean mutationNegated =
+            monst->wasNegated && mutationInfo.canBeNegated;
         i = strlen(buf);
-        i = encodeMessageColor(buf, i, mutationCatalog[monst->mutationIndex].textColor);
-        strcpy(newText, mutationCatalog[monst->mutationIndex].description);
+        i = encodeMessageColor(buf, i, mutationInfo.textColor);
+        strcpy(newText, mutationInfo.description);
+        if (mutationNegated) {
+            strcat(newText, ", ");
+        } else {
+            strcat(newText, ".");
+        }
         resolvePronounEscapes(newText, monst);
         upperCase(newText);
-        strcat(newText, "\n     ");
         strcat(buf, newText);
         i = strlen(buf);
+        if (mutationNegated) {
+            i = encodeMessageColor(buf, i, &pink);
+            sprintf(newText, "but negation has ");
+            strcat(newText, mutationInfo.negatedDescription);
+            resolvePronounEscapes(newText, monst);
+            strcat(buf, newText);
+        }
+        i = strlen(buf);
         i = encodeMessageColor(buf, i, &white);
+        strcat(buf, "\n     ");
     }
 
     if (!(monst->info.flags & MONST_ATTACKABLE_THRU_WALLS)
@@ -4355,8 +4371,7 @@ void monsterDetails(char buf[], creature *monst) {
     if (monst->wasNegated && monst->newPowerCount == monst->totalPowerCount) {
         i = strlen(buf);
         i = encodeMessageColor(buf, i, &pink);
-        sprintf(newText, "%s is stripped of $HISHER special traits.", capMonstName);
-        resolvePronounEscapes(newText, monst);
+        sprintf(newText, "%s is stripped of any special traits.", capMonstName);
         upperCase(newText);
         strcat(buf, "\n     ");
         strcat(buf, newText);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2127,6 +2127,7 @@ typedef struct mutation {
     unsigned long forbiddenFlags;
     unsigned long forbiddenAbilityFlags;
     char description[1000];
+    char negatedDescription[1000];
     boolean canBeNegated;
 } mutation;
 


### PR DESCRIPTION
In order to make negation less debilitating to ally builds, I've implemented a way to undo it: negate the monster again, and the original negation is negated. This includes all negatable traits and abilities from species and mutations, but not learned powers. Learned powers are removed regardless of whether the monster is being negated or un-negated.

Negation no longer removes mutations but only suppresses their effects. A special message, defined individually for each mutation, is appended to the mutation description to explain this. Negation also darkens glowing monsters; I implemented at first because I thought it was weird that the explosive still caused monsters to glow when even when negated and then decided that it would make sense if other naturally glowing monsters lost their glow when negated as well.