### PR TITLE
Fix an issue Valgrind identified in `getInputTextString`

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2804,7 +2804,9 @@ boolean getInputTextString(char *inputText,
     maxLength = min(maxLength, COLS - x);
 
 
-    strcpy(inputText, defaultEntry);
+    if (inputText != defaultEntry) {
+        strcpy(inputText, defaultEntry);
+    }
     charNum = strLenWithoutEscapes(inputText);
     for (i = charNum; i < maxLength; i++) {
         inputText[i] = ' ';


### PR DESCRIPTION
I'm not sure if this could cause any issues in practice, but with this change, Valgrind reports no errors when running the terminal version of Brogue (except when it crashes for an unrelated reason).