### PR TITLE
Unpopular item: improve Armor of Absorption

### DIFF
--- a/changes/improve-absorption.md
+++ b/changes/improve-absorption.md
@@ -1,0 +1,1 @@
+Increase absorption's minimum roll to 1, helping the runic to be less mediocre, and also to give it a stronger identity: it now makes the player effectively immune to goblin conjurers, and strong against jellies or packs of weak enemies.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -897,7 +897,7 @@ void applyArmorRunicEffect(char returnString[DCOLS], creature *attacker, short *
             }
             break;
         case A_ABSORPTION:
-            *damage -= rand_range(0, armorAbsorptionMax(enchant));
+            *damage -= rand_range(1, armorAbsorptionMax(enchant));
             if (*damage <= 0) {
                 *damage = 0;
                 runicDiscovered = true;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2251,7 +2251,7 @@ void itemDetails(char *buf, item *theItem) {
                                 break;
                             case A_ABSORPTION:
                                 if (theItem->flags & ITEM_IDENTIFIED) {
-                                    sprintf(buf2, "It will reduce the damage of inbound attacks by a random amount between 0 and %i, which is %i%% of your current maximum health. (If the %s is enchanted, this maximum amount will %s %i.) ",
+                                    sprintf(buf2, "It will reduce the damage of inbound attacks by a random amount between 1 and %i, which is %i%% of your current maximum health. (If the %s is enchanted, this maximum amount will %s %i.) ",
                                             (int) armorAbsorptionMax(enchant),
                                             (int) (100 * armorAbsorptionMax(enchant) / player.info.maxHP),
                                             theName,


### PR DESCRIPTION
Increase absorption's minimum roll to 1.
This helps the runic to be less mediocre, and also to give it a stronger identity:
it now makes the player effectively immune to goblin conjurers,
and strong against jellies or packs of weak enemies.

Inspired by: #373 