### PR TITLE
Show correct monster during hallu if telepathic

### DIFF
--- a/changes/telepathy-vs-hallucination.md
+++ b/changes/telepathy-vs-hallucination.md
@@ -1,0 +1,1 @@
+When player is telepathic, show correct monster even when hallucinating.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -685,7 +685,7 @@ void mainInputLoop() {
                     rogue.playbackMode = false;
 
                     focusedOnMonster = true;
-                    if (monst != &player && (!player.status[STATUS_HALLUCINATING] || rogue.playbackOmniscience)) {
+                    if (monst != &player && (!player.status[STATUS_HALLUCINATING] || rogue.playbackOmniscience || player.status[STATUS_TELEPATHIC])) {
                         printMonsterDetails(monst, rbuf);
                         textDisplayed = true;
                     }
@@ -1256,7 +1256,10 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
                    && (playerCanSeeOrSense(x, y) || ((monst->info.flags & MONST_IMMOBILE) && (pmap[x][y].flags & DISCOVERED)))
                    && (!monsterIsHidden(monst, &player) || rogue.playbackOmniscience)) {
             needDistinctness = true;
-            if (player.status[STATUS_HALLUCINATING] > 0 && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE)) && !rogue.playbackOmniscience) {
+            if (player.status[STATUS_HALLUCINATING] > 0
+                    && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))
+                    && !rogue.playbackOmniscience
+                    && !player.status[STATUS_TELEPATHIC]) {
                 cellChar = monsterCatalog[randomAnimateMonster()].displayChar;
                 cellForeColor = *(monsterCatalog[randomAnimateMonster()].foreColor);
             } else {
@@ -1280,7 +1283,7 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
         } else if (monst
                    && monsterRevealed(monst)
                    && !canSeeMonster(monst)) {
-            if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience) {
+            if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience && !player.status[STATUS_TELEPATHIC]) {
                 cellChar = (rand_range(0, 1) ? 'X' : 'x');
             } else {
                 cellChar = (monst->info.isLarge ? 'X' : 'x');
@@ -1336,7 +1339,7 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
                 && !monsterRevealed(monst)
                 && !monsterHiddenBySubmersion(monst, &player)) {
 
-                if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience) {
+                if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience && !player.status[STATUS_TELEPATHIC]) {
                     cellChar = monsterCatalog[randomAnimateMonster()].displayChar;
                 } else {
                     cellChar = monst->info.displayChar;

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -239,7 +239,7 @@ void monsterName(char *buf, creature *monst, boolean includeArticle) {
         return;
     }
     if (canSeeMonster(monst) || rogue.playbackOmniscience) {
-        if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience) {
+        if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience && !player.status[STATUS_TELEPATHIC]) {
 
             oldRNG = rogue.RNG;
             rogue.RNG = RNG_COSMETIC;


### PR DESCRIPTION
Introduce a cute corner case: the player gets correct info about monsters during telepathy, even if also hallucinating.