### PR TITLE
Auto-id hallucination when thrown, where possible

### DIFF
--- a/changes/smart-id-hallucination.md
+++ b/changes/smart-id-hallucination.md
@@ -1,0 +1,1 @@
+A potion of hallucination is identified when thrown if all benevolent potions are either identified or magic detected

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -6031,8 +6031,12 @@ void throwItem(item *theItem, creature *thrower, short targetLoc[2], short maxDi
             sprintf(buf, "the flask shatters and %s liquid splashes harmlessly %s %s.",
                     potionTable[theItem->kind].flavor, buf2, tileText(x, y));
             message(buf, 0);
-            if (theItem->kind == POTION_HALLUCINATION && (theItem->flags & ITEM_MAGIC_DETECTED)) {
-                autoIdentify(theItem);
+            // hallucination is the only malevolent potion that splashes harmlessly when thrown
+            if (theItem->kind == POTION_HALLUCINATION) {
+                if (theItem->flags & ITEM_MAGIC_DETECTED
+                    || (BROGUE_VERSION_ATLEAST(1,10,2) && magicPolarityRevealedItemKindCount(theItem->category, 1) == NUMBER_GOOD_POTION_KINDS)) {
+                    autoIdentify(theItem);
+                }
             }
         }
         deleteItem(theItem);


### PR DESCRIPTION
A potion of hallucination is identified when thrown if all benevolent potions are either identified or magic detected