### PR TITLE
Give player feedback when a scroll burns up

### DIFF
--- a/changes/noisy-scroll-voices.md
+++ b/changes/noisy-scroll-voices.md
@@ -1,0 +1,1 @@
+When a scroll is out of line of sight, it "screams" upon being destroyed.

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -851,9 +851,10 @@ void burnItem(item *theItem) {
     if (pmap[x][y].flags & (ANY_KIND_OF_VISIBLE | DISCOVERED | ITEM_DETECTED)) {
         refreshDungeonCell(x, y);
     }
-    if (playerCanSee(x, y)) {
-        messageWithColor(buf2, &itemMessageColor, 0);
+    if (!playerCanSee(x, y)) {
+        sprintf(buf2, "Somewhere, a scream emanates from a burning scroll.");
     }
+    messageWithColor(buf2, &itemMessageColor, 0);
     spawnDungeonFeature(x, y, &(dungeonFeatureCatalog[DF_ITEM_FIRE]), true, false);
 }
 


### PR DESCRIPTION
Outside of LoS, fire can potentially destroy scrolls without the
player's knowledge. Like distant explosions, make a "sound" so the
player can be informed, not be in a limbo of uncertain stress.