### PR TITLE
Add a note to items which were found atop an altar

### DIFF
--- a/changes/denote-altar-items.md
+++ b/changes/denote-altar-items.md
@@ -1,0 +1,1 @@
+Items which were checked out of a cage-and-altar "library" have a note indicating this in their item description.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1888,7 +1888,7 @@ void itemDetails(char *buf, item *theItem) {
         sprintf(buf2, " (You found %s on depth %i%s.) ",
                 singular ? "it" : "them",
                 theItem->originDepth,
-                theItem->flags & ITEM_IS_KEY ? " atop a candle-lit altar" : "");
+                theItem->flags & ITEM_IS_KEY ? " in a room of candle-lit altars" : "");
         strcat(buf, buf2);
     }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1884,7 +1884,7 @@ void itemDetails(char *buf, item *theItem) {
         strcat(buf, buf2);
     }
 
-    if (carried && theItem->originDepth > 0) {
+    if (carried && theItem->originDepth > 0 && !(theItem->category & KEY)) {
         sprintf(buf2, " (You found %s on depth %i%s.) ",
                 singular ? "it" : "them",
                 theItem->originDepth,

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1885,9 +1885,10 @@ void itemDetails(char *buf, item *theItem) {
     }
 
     if (carried && theItem->originDepth > 0) {
-        sprintf(buf2, " (You found %s on depth %i.) ",
+        sprintf(buf2, " (You found %s on depth %i%s.) ",
                 singular ? "it" : "them",
-                theItem->originDepth);
+                theItem->originDepth,
+                theItem->flags & ITEM_IS_KEY ? " atop a candle-lit altar" : "");
         strcat(buf, buf2);
     }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1885,13 +1885,14 @@ void itemDetails(char *buf, item *theItem) {
     }
 
     if (carried && theItem->originDepth > 0) {
-        sprintf(buf2, " (You found %s on depth %i%s.) ",
-                singular ? "it" : "them",
-                theItem->originDepth,
-                // items in an item-choice vault are "keys", but are not a KEY
-                // we ignore any actual KEY, as those might not be on an altar
-                theItem->flags & ITEM_IS_KEY && !(theItem->category & KEY)
-                    ? " in a room of candle-lit altars" : "");
+        sprintf(buf2, " (You found %s%s on depth %i.) ",
+            singular ? "it" : "them",
+            // items in an item-choice vault are "keys", but are not a KEY
+            // we ignore any actual KEY, as those might not be on an altar
+            theItem->flags & ITEM_IS_KEY && !(theItem->category & KEY)
+                ? " in a vault" : "",
+            theItem->originDepth
+        );
         strcat(buf, buf2);
     }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1884,11 +1884,14 @@ void itemDetails(char *buf, item *theItem) {
         strcat(buf, buf2);
     }
 
-    if (carried && theItem->originDepth > 0 && !(theItem->category & KEY)) {
+    if (carried && theItem->originDepth > 0) {
         sprintf(buf2, " (You found %s on depth %i%s.) ",
                 singular ? "it" : "them",
                 theItem->originDepth,
-                theItem->flags & ITEM_IS_KEY ? " in a room of candle-lit altars" : "");
+                // items in an item-choice vault are "keys", but are not a KEY
+                // we ignore any actual KEY, as those might not be on an altar
+                theItem->flags & ITEM_IS_KEY && !(theItem->category & KEY)
+                    ? " in a room of candle-lit altars" : "");
         strcat(buf, buf2);
     }
 


### PR DESCRIPTION
This can help players remember which of their items were checked out
from a library/vestibule type location.

The note is also added to door keys, but that doesn't seem to be a problem to me, as they were indeed found atop an altar.
The alternative would be to create a new member in struct theItem?

Closes #434 