### PR TITLE
Revert wand of plenty halving max HP

### DIFF
--- a/changes/wand-of-plenty.md
+++ b/changes/wand-of-plenty.md
@@ -1,0 +1,1 @@
+Wand of plenty no longer halves the max HP of cloned monsters.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4517,8 +4517,8 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 if (!(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
                     newMonst = cloneMonster(monst, true, true);
                     if (newMonst) {
-                        monst->info.maxHP = newMonst->info.maxHP = (monst->info.maxHP + 1) / 2;
-                        monst->currentHP = newMonst->currentHP = min(monst->currentHP, monst->info.maxHP);
+                        monst->currentHP = (monst->currentHP + 1) / 2;
+                        newMonst->currentHP = (newMonst->currentHP + 1) / 2;
                         if (boltCatalog[BOLT_PLENTY].backColor) {
                             flashMonster(monst, boltCatalog[BOLT_PLENTY].backColor, 100);
                             flashMonster(newMonst, boltCatalog[BOLT_PLENTY].backColor, 100);


### PR DESCRIPTION
This was one of the first ally nerfs we made. Now that other aspects of the build are more balanced, I think we should revert this, as the item is really weak currently.