### PR TITLE
Use bolt magnitude for duration of invisibility bolt effect

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4409,7 +4409,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 }
                 break;
             case BE_INVISIBILITY:
-                if (imbueInvisibility(monst, 150) && autoID) {
+                if (imbueInvisibility(monst, theBolt->magnitude * 15) && autoID) {
                     *autoID = true;
                 }
                 break;


### PR DESCRIPTION
Most bolts use `magnitude` for the sizeof the effect. This allows the size of the effect to be controlled in Globals.c. `magnitude` is also used for some graphical niceties which change with the scale but basically look fine with various magnitudes in my testing.