### PR TITLE
Create defines for minimum levels for lava and brimstone liquids

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -2484,8 +2484,8 @@ void finishWalls(boolean includingDiagonals) {
 void liquidType(short *deep, short *shallow, short *shallowWidth) {
     short randMin, randMax, rand;
 
-    randMin = (rogue.depthLevel < 4 ? 1 : 0); // no lava before level 4
-    randMax = (rogue.depthLevel < 17 ? 2 : 3); // no brimstone before level 18
+    randMin = (rogue.depthLevel < MINIMUM_LAVA_LEVEL ? 1 : 0);
+    randMax = (rogue.depthLevel < MINIMUM_BRIMSTONE_LEVEL ? 2 : 3);
     rand = rand_range(randMin, randMax);
     if (rogue.depthLevel == DEEPEST_LEVEL) {
         rand = 1;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -169,6 +169,9 @@ typedef struct pos {
 #define AMULET_LEVEL            26          // how deep before the amulet appears
 #define DEEPEST_LEVEL           40          // how deep the universe goes
 
+#define MINIMUM_LAVA_LEVEL      4           // how deep before lava can be generated
+#define MINIMUM_BRIMSTONE_LEVEL 17          // how deep before brimstone can be generated
+
 #define MACHINES_FACTOR         FP_FACTOR   // use this to adjust machine frequency
 
 #define MACHINES_BUFFER_LENGTH  200


### PR DESCRIPTION
These could alternatively be scaled to the `AMULET_LEVEL` but precise control is useful in shorter games. e.g. in RB if you just divide by 4, the first level would have lava, whereas it should have water for thematic reasons.