### PR TITLE
Add omniscence mode for wizard, defaulted to off

### DIFF
--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -80,6 +80,7 @@ strings, but they are equal (rogue.patchLevel is set to 0).
 #define D_SAFETY_VISION                 (rogue.wizard && 0)
 #define D_SCENT_VISION                  (rogue.wizard && 0)
 #define D_DISABLE_BACKGROUND_COLORS     (rogue.wizard && 0)
+#define D_OMNISCENCE                    (rogue.wizard && 0)
 
 #define D_INSPECT_LEVELGEN              (rogue.wizard && 0)
 #define D_INSPECT_MACHINES              (rogue.wizard && 0)

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -383,6 +383,10 @@ void initializeRogue(uint64_t seed) {
 
     recalculateEquipmentBonuses();
 
+    if (D_OMNISCENCE) {
+        rogue.playbackOmniscience = 1;
+    }
+
     DEBUG {
         theItem = generateItem(RING, RING_CLAIRVOYANCE);
         theItem->enchant1 = max(DROWS, DCOLS);


### PR DESCRIPTION
I find this super handy. Nice I guess to be able to turn it on and off but this implementation follows the current style.