### PR TITLE
Fix rounding when predicting armor ratings

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4550,6 +4550,8 @@ void highlightScreenCell(short x, short y, color *highlightColor, short strength
     storeColorComponents(displayBuffer[x][y].backColorComponents, &tempColor);
 }
 
+// Like `armorValueIfUnenchanted` for the currently-equipped armor, but takes the penalty from
+// donning into account.
 static short estimatedArmorValue() {
     short retVal = armorValueIfUnenchanted(rogue.armor) - player.status[STATUS_DONNING];
     return max(0, retVal);

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4550,13 +4550,8 @@ void highlightScreenCell(short x, short y, color *highlightColor, short strength
     storeColorComponents(displayBuffer[x][y].backColorComponents, &tempColor);
 }
 
-short estimatedArmorValue() {
-    short retVal;
-
-    retVal = ((armorTable[rogue.armor->kind].range.upperBound + armorTable[rogue.armor->kind].range.lowerBound) / 2) / 10;
-    retVal += strengthModifier(rogue.armor) / FP_FACTOR;
-    retVal -= player.status[STATUS_DONNING];
-
+static short estimatedArmorValue() {
+    short retVal = armorValueIfUnenchanted(rogue.armor) - player.status[STATUS_DONNING];
     return max(0, retVal);
 }
 
@@ -4573,7 +4568,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
     char buf[COLS * 2], buf2[COLS * 2], monstName[COLS], tempColorEscape[5], grayColorEscape[5];
     enum displayGlyph monstChar;
     color monstForeColor, monstBackColor, healthBarColor, tempColor;
-    short initialY, i, j, highlightStrength, displayedArmor, percent;
+    short initialY, i, j, highlightStrength, percent;
     boolean inPath;
     short oldRNG;
 
@@ -4828,15 +4823,13 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                     encodeMessageColor(grayColorEscape, 0, (dim ? &darkGray : &gray));
                 }
 
-                displayedArmor = displayedArmorValue();
-
                 if (!rogue.armor || rogue.armor->flags & ITEM_IDENTIFIED || rogue.playbackOmniscience) {
 
                     sprintf(buf, "Str: %s%i%s  Armor: %i",
                             tempColorEscape,
                             rogue.strength - player.weaknessAmount,
                             grayColorEscape,
-                            displayedArmor);
+                            displayedArmorValue());
                 } else {
                     sprintf(buf, "Str: %s%i%s  Armor: %i?",
                             tempColorEscape,

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2024,11 +2024,11 @@ void itemDetails(char *buf, item *theItem) {
                     new = 0;
 
                     if ((theItem->flags & ITEM_IDENTIFIED) || rogue.playbackOmniscience) {
-                        new = theItem->armor / 10;
-                        new += netEnchant(theItem) / FP_FACTOR;
+                        new = theItem->armor;
+                        new += 10 * netEnchant(theItem) / FP_FACTOR;
+                        new /= 10;
                     } else {
-                        new = ((armorTable[theItem->kind].range.upperBound + armorTable[theItem->kind].range.lowerBound) / 2) / 10;
-                        new += strengthModifier(theItem) / FP_FACTOR;
+                        new = armorValueIfUnenchanted(theItem);
                     }
 
                     new = max(0, new);
@@ -3072,12 +3072,19 @@ void updateEncumbrance() {
     recalculateEquipmentBonuses();
 }
 
+// Estimates the armor value of the given item, assuming the item is unenchanted.
+short armorValueIfUnenchanted(item *theItem) {
+    short averageValue = (armorTable[theItem->kind].range.upperBound + armorTable[theItem->kind].range.lowerBound) / 2;
+    short strengthAdjusted = averageValue + 10 * strengthModifier(theItem) / FP_FACTOR;
+    return max(0, strengthAdjusted / 10);
+}
+
+// Calculates the armor value to display to the player (estimated if the item is unidentified).
 short displayedArmorValue() {
     if (!rogue.armor || (rogue.armor->flags & ITEM_IDENTIFIED)) {
         return player.info.defense / 10;
     } else {
-        return ((armorTable[rogue.armor->kind].range.upperBound + armorTable[rogue.armor->kind].range.lowerBound) * FP_FACTOR / 2 / 10
-                + strengthModifier(rogue.armor)) / FP_FACTOR;
+        return armorValueIfUnenchanted(rogue.armor);
     }
 }
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3107,6 +3107,7 @@ extern "C" {
     item *makeItemInto(item *theItem, unsigned long itemCategory, short itemKind);
     void updateEncumbrance();
     short displayedArmorValue();
+    short armorValueIfUnenchanted();
     void strengthCheck(item *theItem, boolean noisy);
     void recalculateEquipmentBonuses();
     boolean equipItem(item *theItem, boolean force, item *unequipHint);


### PR DESCRIPTION
For instance, when equipping an unenchanted chain mail at 12 strength, this makes sure the displayed armor rating is always '2' instead of '3', whether it's identified or not. This also merges a few duplicate calculations together so they're less likely to be inconsistent in the future (though there's still some duplication).

Fixes #385.