### PR TITLE
Remove double 'the' in monster description when a staff kills in one hit

### DIFF
--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -4105,7 +4105,7 @@ boolean staffOrWandEffectOnMonsterDescription(char *newText, item *theItem, crea
                     successfulDescription = true;
                 } else if (theItem->flags & (ITEM_MAX_CHARGES_KNOWN | ITEM_IDENTIFIED)) {
                     if (staffDamageLow(enchant) >= monst->currentHP) {
-                        sprintf(newText, "\n     Your %s (%c) will %s the %s in one hit.",
+                        sprintf(newText, "\n     Your %s (%c) will %s %s in one hit.",
                                 theItemName,
                                 theItem->inventoryLetter,
                                 (monst->info.flags & MONST_INANIMATE) ? "destroy" : "kill",


### PR DESCRIPTION
The monster's name already has an article prefix as per the call to `monsterName()`, resulting in duplicated `the`s.

Fixes #483