### PR TITLE
Print monster death messages in the correct order

### DIFF
--- a/changes/message-order.md
+++ b/changes/message-order.md
@@ -1,0 +1,1 @@
+Monster death messages are now printed in the correct order. For instance, "The dart killed the bloat" is now printed before the message about the bloat bursting.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1564,7 +1564,7 @@ boolean inflictDamage(creature *attacker, creature *defender,
     if (defender->currentHP <= damage) { // killed
         return true;
     } else { // survived
-        if (damage < 0 && defender->currentHP - damage > defender->info.maxHP, false) {
+        if (damage < 0 && defender->currentHP - damage > defender->info.maxHP) {
             defender->currentHP = max(defender->currentHP, defender->info.maxHP);
         } else {
             defender->currentHP -= damage; // inflict the damage!

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3546,7 +3546,7 @@ boolean tunnelize(short x, short y) {
             monst = monsterAtLoc(x, y);
             if (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS) {
                 inflictLethalDamage(NULL, monst);
-                killCreatureAfterInflictDamage(monst);
+                killCreature(monst, false);
             }
         }
     }
@@ -4087,7 +4087,7 @@ void crystalize(short radius) {
                         monst = monsterAtLoc(i, j);
                         if (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS) {
                             inflictLethalDamage(NULL, monst);
-                            killCreatureAfterInflictDamage(monst);
+                            killCreature(monst, false);
                         } else {
                             freeCaptivesEmbeddedAt(i, j);
                         }
@@ -4324,7 +4324,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 } else if (inflictDamage(caster, monst, staffDamage(theBolt->magnitude * FP_FACTOR), theBolt->backColor, false)) {
                     // killed monster
                     if (player.currentHP <= 0) {
-                        killCreatureAfterInflictDamage(monst);
+                        killCreature(monst, false);
                         if (caster == &player) {
                             sprintf(buf, "Killed by a reflected %s", theBolt->name);
                             gameOver(buf, true);
@@ -4343,7 +4343,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                         sprintf(buf, "you hear %s %s", monstName, ((monst->info.flags & MONST_INANIMATE) ? "get destroyed" : "die"));
                         combatMessage(buf, 0);
                     }
-                    killCreatureAfterInflictDamage(monst);
+                    killCreature(monst, false);
                 } else {
                     // monster lives
                     if (monst->creatureMode != MODE_PERM_FLEEING
@@ -5871,7 +5871,7 @@ boolean hitMonsterWithProjectileWeapon(creature *thrower, creature *monst, item 
                     (monst->info.flags & MONST_INANIMATE) ? "destroyed" : "killed",
                     targetName);
             messageWithColor(buf, messageColorFromVictim(monst), 0);
-            killCreatureAfterInflictDamage(monst);
+            killCreature(monst, false);
         } else {
             sprintf(buf, "the %s hit %s.", theItemName, targetName);
             if (theItem->flags & ITEM_RUNIC) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3546,6 +3546,7 @@ boolean tunnelize(short x, short y) {
             monst = monsterAtLoc(x, y);
             if (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS) {
                 inflictLethalDamage(NULL, monst);
+                killCreatureAfterInflictDamage(monst);
             }
         }
     }
@@ -4086,6 +4087,7 @@ void crystalize(short radius) {
                         monst = monsterAtLoc(i, j);
                         if (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS) {
                             inflictLethalDamage(NULL, monst);
+                            killCreatureAfterInflictDamage(monst);
                         } else {
                             freeCaptivesEmbeddedAt(i, j);
                         }
@@ -4322,6 +4324,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                 } else if (inflictDamage(caster, monst, staffDamage(theBolt->magnitude * FP_FACTOR), theBolt->backColor, false)) {
                     // killed monster
                     if (player.currentHP <= 0) {
+                        killCreatureAfterInflictDamage(monst);
                         if (caster == &player) {
                             sprintf(buf, "Killed by a reflected %s", theBolt->name);
                             gameOver(buf, true);
@@ -4340,6 +4343,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                         sprintf(buf, "you hear %s %s", monstName, ((monst->info.flags & MONST_INANIMATE) ? "get destroyed" : "die"));
                         combatMessage(buf, 0);
                     }
+                    killCreatureAfterInflictDamage(monst);
                 } else {
                     // monster lives
                     if (monst->creatureMode != MODE_PERM_FLEEING
@@ -5867,6 +5871,7 @@ boolean hitMonsterWithProjectileWeapon(creature *thrower, creature *monst, item 
                     (monst->info.flags & MONST_INANIMATE) ? "destroyed" : "killed",
                     targetName);
             messageWithColor(buf, messageColorFromVictim(monst), 0);
+            killCreatureAfterInflictDamage(monst);
         } else {
             sprintf(buf, "the %s hit %s.", theItemName, targetName);
             if (theItem->flags & ITEM_RUNIC) {

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1854,6 +1854,7 @@ void decrementMonsterStatus(creature *monst) {
                                     (monst->info.flags & MONST_INANIMATE) ? "up" : "to death");
                             messageWithColor(buf2, messageColorFromVictim(monst), 0);
                         }
+                        killCreatureAfterInflictDamage(monst);
                         return;
                     }
                     if (monst->status[i] <= 0) {
@@ -1884,6 +1885,7 @@ void decrementMonsterStatus(creature *monst) {
                             sprintf(buf2, "%s dies of poison.", buf);
                             messageWithColor(buf2, messageColorFromVictim(monst), 0);
                         }
+                        killCreatureAfterInflictDamage(monst);
                         return;
                     }
                     if (!monst->status[i]) {

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1854,7 +1854,7 @@ void decrementMonsterStatus(creature *monst) {
                                     (monst->info.flags & MONST_INANIMATE) ? "up" : "to death");
                             messageWithColor(buf2, messageColorFromVictim(monst), 0);
                         }
-                        killCreatureAfterInflictDamage(monst);
+                        killCreature(monst, false);
                         return;
                     }
                     if (monst->status[i] <= 0) {
@@ -1885,7 +1885,7 @@ void decrementMonsterStatus(creature *monst) {
                             sprintf(buf2, "%s dies of poison.", buf);
                             messageWithColor(buf2, messageColorFromVictim(monst), 0);
                         }
-                        killCreatureAfterInflictDamage(monst);
+                        killCreature(monst, false);
                         return;
                     }
                     if (!monst->status[i]) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3053,6 +3053,7 @@ extern "C" {
     void inflictLethalDamage(creature *attacker, creature *defender);
     boolean inflictDamage(creature *attacker, creature *defender,
                           short damage, const color *flashColor, boolean ignoresProtectionShield);
+    void killCreatureAfterInflictDamage(creature *defender);
     void addPoison(creature *monst, short totalDamage, short concentrationIncrement);
     void killCreature(creature *decedent, boolean administrativeDeath);
     void buildHitList(creature **hitList, const creature *attacker, creature *defender, const boolean sweep);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3053,7 +3053,6 @@ extern "C" {
     void inflictLethalDamage(creature *attacker, creature *defender);
     boolean inflictDamage(creature *attacker, creature *defender,
                           short damage, const color *flashColor, boolean ignoresProtectionShield);
-    void killCreatureAfterInflictDamage(creature *defender);
     void addPoison(creature *monst, short totalDamage, short concentrationIncrement);
     void killCreature(creature *decedent, boolean administrativeDeath);
     void buildHitList(creature **hitList, const creature *attacker, creature *defender, const boolean sweep);

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -312,7 +312,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
                 messageWithColor(buf, &goodMessageColor, 0);
                 autoIdentify(rogue.armor);
             } else if (inflictDamage(NULL, &player, damage, &yellow, false)) {
-                killCreatureAfterInflictDamage(&player);
+                killCreature(&player, false);
                 strcpy(buf2, tileCatalog[pmap[*x][*y].layers[layerWithFlag(*x, *y, T_CAUSES_EXPLOSIVE_DAMAGE)]].description);
                 sprintf(buf, "Killed by %s", buf2);
                 gameOver(buf, true);
@@ -332,7 +332,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
                         (monst->info.flags & MONST_INANIMATE) ? "is destroyed by" : "dies in",
                         buf3);
                 messageWithColor(buf2, messageColorFromVictim(monst), 0);
-                killCreatureAfterInflictDamage(monst);
+                killCreature(monst, false);
                 refreshDungeonCell(*x, *y);
                 return;
             } else {
@@ -510,7 +510,7 @@ void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
                 rogue.disturbed = true;
                 messageWithColor(tileCatalog[pmap[x][y].layers[layer]].flavorText, &badMessageColor, 0);
                 if (inflictDamage(NULL, &player, damage, tileCatalog[pmap[x][y].layers[layer]].backColor, true)) {
-                    killCreatureAfterInflictDamage(&player);
+                    killCreature(&player, false);
                     sprintf(buf, "Killed by %s", tileCatalog[pmap[x][y].layers[layer]].description);
                     gameOver(buf, true);
                     return;
@@ -526,7 +526,7 @@ void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
                     sprintf(buf2, "%s dies.", buf);
                     messageWithColor(buf2, messageColorFromVictim(monst), 0);
                 }
-                killCreatureAfterInflictDamage(monst);
+                killCreature(monst, false);
                 refreshDungeonCell(x, y);
                 return;
             }
@@ -1006,7 +1006,7 @@ void playerFalls() {
             }
             messageWithColor("You are injured by the fall.", &badMessageColor, 0);
             if (inflictDamage(NULL, &player, damage, &red, false)) {
-                killCreatureAfterInflictDamage(&player);
+                killCreature(&player, false);
                 gameOver("Killed by a fall", true);
                 killed = true;
             }
@@ -1396,7 +1396,7 @@ void monstersFall() {
                     updateYendorWardenTracking();
                 }
             } else {
-                killCreatureAfterInflictDamage(monst);
+                killCreature(monst, false);
             }
 
             pmap[x][y].flags &= ~HAS_MONSTER;
@@ -1925,7 +1925,7 @@ void monsterEntersLevel(creature *monst, short n) {
                     sprintf(buf, "%s plummets from above and splatters against the ground!", monstName);
                     messageWithColor(buf, messageColorFromVictim(monst), 0);
                 }
-                killCreatureAfterInflictDamage(monst);
+                killCreature(monst, false);
             } else {
                 if (canSeeMonster(monst)) {
                     sprintf(buf, "%s falls from above and crashes to the ground!", monstName);
@@ -2312,7 +2312,7 @@ void playerTurnEnded() {
         if (player.status[STATUS_BURNING] > 0) {
             damage = rand_range(1, 3);
             if (!(player.status[STATUS_IMMUNE_TO_FIRE]) && inflictDamage(NULL, &player, damage, &orange, true)) {
-                killCreatureAfterInflictDamage(&player);
+                killCreature(&player, false);
                 gameOver("Burned to death", true);
             }
             if (!--player.status[STATUS_BURNING]) {
@@ -2323,7 +2323,7 @@ void playerTurnEnded() {
         if (player.status[STATUS_POISONED] > 0) {
             player.status[STATUS_POISONED]--;
             if (inflictDamage(NULL, &player, player.poisonAmount, &green, true)) {
-                killCreatureAfterInflictDamage(&player);
+                killCreature(&player, false);
                 gameOver("Died from poison", true);
             }
             if (!player.status[STATUS_POISONED]) {

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -312,6 +312,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
                 messageWithColor(buf, &goodMessageColor, 0);
                 autoIdentify(rogue.armor);
             } else if (inflictDamage(NULL, &player, damage, &yellow, false)) {
+                killCreatureAfterInflictDamage(&player);
                 strcpy(buf2, tileCatalog[pmap[*x][*y].layers[layerWithFlag(*x, *y, T_CAUSES_EXPLOSIVE_DAMAGE)]].description);
                 sprintf(buf, "Killed by %s", buf2);
                 gameOver(buf, true);
@@ -331,6 +332,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
                         (monst->info.flags & MONST_INANIMATE) ? "is destroyed by" : "dies in",
                         buf3);
                 messageWithColor(buf2, messageColorFromVictim(monst), 0);
+                killCreatureAfterInflictDamage(monst);
                 refreshDungeonCell(*x, *y);
                 return;
             } else {
@@ -508,6 +510,7 @@ void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
                 rogue.disturbed = true;
                 messageWithColor(tileCatalog[pmap[x][y].layers[layer]].flavorText, &badMessageColor, 0);
                 if (inflictDamage(NULL, &player, damage, tileCatalog[pmap[x][y].layers[layer]].backColor, true)) {
+                    killCreatureAfterInflictDamage(&player);
                     sprintf(buf, "Killed by %s", tileCatalog[pmap[x][y].layers[layer]].description);
                     gameOver(buf, true);
                     return;
@@ -523,6 +526,7 @@ void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
                     sprintf(buf2, "%s dies.", buf);
                     messageWithColor(buf2, messageColorFromVictim(monst), 0);
                 }
+                killCreatureAfterInflictDamage(monst);
                 refreshDungeonCell(x, y);
                 return;
             }
@@ -1002,6 +1006,7 @@ void playerFalls() {
             }
             messageWithColor("You are injured by the fall.", &badMessageColor, 0);
             if (inflictDamage(NULL, &player, damage, &red, false)) {
+                killCreatureAfterInflictDamage(&player);
                 gameOver("Killed by a fall", true);
                 killed = true;
             }
@@ -1390,6 +1395,8 @@ void monstersFall() {
                 if (monst == rogue.yendorWarden) {
                     updateYendorWardenTracking();
                 }
+            } else {
+                killCreatureAfterInflictDamage(monst);
             }
 
             pmap[x][y].flags &= ~HAS_MONSTER;
@@ -1918,6 +1925,7 @@ void monsterEntersLevel(creature *monst, short n) {
                     sprintf(buf, "%s plummets from above and splatters against the ground!", monstName);
                     messageWithColor(buf, messageColorFromVictim(monst), 0);
                 }
+                killCreatureAfterInflictDamage(monst);
             } else {
                 if (canSeeMonster(monst)) {
                     sprintf(buf, "%s falls from above and crashes to the ground!", monstName);
@@ -2304,6 +2312,7 @@ void playerTurnEnded() {
         if (player.status[STATUS_BURNING] > 0) {
             damage = rand_range(1, 3);
             if (!(player.status[STATUS_IMMUNE_TO_FIRE]) && inflictDamage(NULL, &player, damage, &orange, true)) {
+                killCreatureAfterInflictDamage(&player);
                 gameOver("Burned to death", true);
             }
             if (!--player.status[STATUS_BURNING]) {
@@ -2314,6 +2323,7 @@ void playerTurnEnded() {
         if (player.status[STATUS_POISONED] > 0) {
             player.status[STATUS_POISONED]--;
             if (inflictDamage(NULL, &player, player.poisonAmount, &green, true)) {
+                killCreatureAfterInflictDamage(&player);
                 gameOver("Died from poison", true);
             }
             if (!player.status[STATUS_POISONED]) {


### PR DESCRIPTION
Currently, the message when, for example, a bloat bursts is printed before the message saying what killed it. This reorders the messages in cases like this, so that they're printed in the correct order.

Fixes part (but not all) of #371.