### PR TITLE
Don't create .broguesave files when using --print-seed-catalog

### DIFF
--- a/changes/print-seed-catalog.md
+++ b/changes/print-seed-catalog.md
@@ -1,0 +1,1 @@
+The --print-seed-catalog option no longer creates unnecessary .broguesave files

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -216,6 +216,10 @@ void writeHeaderInfo(char *path) {
 }
 
 void flushBufferToFile() {
+    if (currentFilePath[0] == '\0') {
+        return;
+    }
+
     short i;
     FILE *recordFile;
 
@@ -458,6 +462,10 @@ static boolean getPatchVersion(char *versionString, unsigned short *patchVersion
 // creates a game recording file, or if in playback mode,
 // initializes based on and starts reading from the recording file
 void initRecording() {
+    if (currentFilePath[0] == '\0') {
+        return;
+    }
+
     short i;
     boolean wizardMode;
     unsigned short recPatch;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -118,7 +118,6 @@ typedef long long fixpt;
 #define FP_DIV(x, y)  ((x) * FP_FACTOR / (y))
 
 // recording and save filenames
-#define LAST_GAME_PATH          "LastGame.broguesave"
 #define LAST_GAME_NAME          "LastGame"
 #define LAST_RECORDING_NAME     "LastRecording"
 #define RECORDING_SUFFIX        ".broguerec"

--- a/src/brogue/SeedCatalog.c
+++ b/src/brogue/SeedCatalog.c
@@ -253,12 +253,8 @@ static void printSeedCatalogAltars(boolean isCsvFormat) {
 void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth,
                       boolean isCsvFormat) {
     uint64_t theSeed;
-    char path[BROGUE_FILENAME_MAX];
     char message[1000] = "";
     rogue.nextGame = NG_NOTHING;
-
-    getAvailableFilePath(path, LAST_GAME_NAME, GAME_SUFFIX);
-    strcat(path, GAME_SUFFIX);
 
     sprintf(message, "Brogue seed catalog, seeds %llu to %llu, through depth %u.\n"
                      "Generated with %s. Dungeons unchanged since %s.\n\n"
@@ -286,7 +282,7 @@ void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsig
         rogue.playbackFastForward = false;
         rogue.playbackBetweenTurns = false;
 
-        strcpy(currentFilePath, path);
+        currentFilePath[0] = '\0';
         initializeRogue(theSeed);
         rogue.playbackOmniscience = true;
         for (rogue.depthLevel = 1; rogue.depthLevel <= scanThroughDepth; rogue.depthLevel++) {
@@ -304,7 +300,6 @@ void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsig
         }
 
         freeEverything();
-        remove(currentFilePath); // Don't add a spurious LastGame file to the brogue folder.
     }
 
 }


### PR DESCRIPTION
This avoids creating a bunch of unnecessary files, and avoids leaving these files behind when the program is interrupted partway through.

Fixes #393.