### PR TITLE
Ensure builds depend on variables and recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin/*.brogue*
 bin/BrogueHighScores.txt
 bin/brogue*
 bin/*.png
+vars
 
 # Release dirs and archives
 BrogueCE-*

--- a/Makefile
+++ b/Makefile
@@ -44,70 +44,22 @@ else
 	cflags += -O2
 endif
 
+# Add user-provided flags.
+cflags += $(CFLAGS)
+cppflags += $(CPPFLAGS)
+libs += $(LDLIBS)
+
 objects := $(sources:.c=.o)
 
-.PHONY: clean
+include recipes/*.mk
 
-%.o: %.c src/brogue/Rogue.h src/brogue/IncludeGlobals.h
-	$(CC) $(cppflags) $(CPPFLAGS) $(cflags) $(CFLAGS) -c $< -o $@
-
-bin/brogue: $(objects)
-	$(CC) $(cflags) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(libs) $(LDLIBS)
-
-windows/icon.o: windows/icon.rc
-	windres $< $@
-
-bin/brogue.exe: $(objects) windows/icon.o
-	$(CC) $(cflags) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(libs) $(LDLIBS)
-	mt -manifest windows/brogue.exe.manifest '-outputresource:bin/brogue.exe;1'
-
-clean:
-	$(RM) src/brogue/*.o src/platform/*.o windows/icon.o bin/brogue{,.exe}
+escape = $(subst ','\'',$(1))
+vars:
+	mkdir vars
+# Write the value to a temporary file and only overwrite if it's different.
+vars/%: vars FORCE
+	@echo '$(call escape,$($*))' > vars/$*.tmp
+	@if cmp --quiet vars/$*.tmp vars/$*; then :; else cp vars/$*.tmp vars/$*; fi
 
 
-# Release archives
-
-common_bin := bin/assets bin/keymap.txt
-
-define make_release_base
-	mkdir $@
-	cp README.md $@/README.txt
-	cp CHANGELOG.md $@/CHANGELOG.txt
-	cp LICENSE.txt $@
-endef
-
-# Flatten bin/ in the Windows archive
-BrogueCE-windows: bin/brogue.exe
-	$(make_release_base)
-	cp -r $(common_bin) bin/{brogue.exe,brogue-cmd.bat} $@
-
-BrogueCE-macos: Brogue.app
-	$(make_release_base)
-	cp -r Brogue.app $@/"Brogue CE.app"
-
-BrogueCE-linux: bin/brogue
-	$(make_release_base)
-	cp brogue $@
-	cp -r --parents $(common_bin) bin/brogue $@
-	cp linux/make-link-for-desktop.sh $@
-
-
-# macOS app bundle
-
-# $* is the matched %
-icon_%.png: bin/assets/icon.png
-	convert $< -resize $* $@
-
-macos/Brogue.icns: icon_32.png icon_128.png icon_256.png icon_512.png
-	png2icns $@ $^
-	$(RM) $^
-
-Brogue.app: bin/brogue
-	mkdir -p $@/Contents/{MacOS,Resources}
-	cp macos/Info.plist $@/Contents
-	cp bin/brogue $@/Contents/MacOS
-	cp -r macos/Brogue.icns bin/assets $@/Contents/Resources
-
-macos/sdl2.rb:
-	curl -L 'https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/sdl2.rb' >$@
-	patch $@ macos/sdl2-deployment-target.patch
+FORCE:

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ objects := $(sources:.c=.o)
 
 include recipes/*.mk
 
+clean:
+	$(warning 'make clean' is no longer needed in many situations, so is not supported. Use 'make -B' to force rebuild something.)
+
 escape = $(subst ','\'',$(1))
 vars:
 	mkdir vars

--- a/recipes/brogue.mk
+++ b/recipes/brogue.mk
@@ -1,0 +1,2 @@
+bin/brogue: $(objects) vars/cflags vars/LDFLAGS vars/libs vars/objects recipes/brogue.mk
+	$(CC) $(cflags) $(LDFLAGS) -o $@ $(objects) $(libs)

--- a/recipes/brogue_windows.mk
+++ b/recipes/brogue_windows.mk
@@ -1,0 +1,6 @@
+windows/icon.o: windows/icon.rc recipes/brogue_windows.mk
+	windres $< $@
+
+bin/brogue.exe: $(objects) windows/icon.o vars/cflags vars/LDFLAGS vars/libs vars/objects recipes/brogue_windows.mk
+	$(CC) $(cflags) $(LDFLAGS) -o $@ $(objects) windows/icon.o $(libs)
+	mt -manifest windows/brogue.exe.manifest '-outputresource:bin/brogue.exe;1'

--- a/recipes/o.mk
+++ b/recipes/o.mk
@@ -1,0 +1,2 @@
+$(objects): %.o: %.c src/brogue/Rogue.h src/brogue/IncludeGlobals.h vars/cppflags vars/cflags recipes/o.mk
+	$(CC) $(cppflags) $(cflags) -c $< -o $@

--- a/recipes/releases.mk
+++ b/recipes/releases.mk
@@ -1,0 +1,46 @@
+# Release archives
+
+common_bin := bin/assets bin/keymap.txt
+
+define make_release_base
+	mkdir $@
+	cp README.md $@/README.txt
+	cp CHANGELOG.md $@/CHANGELOG.txt
+	cp LICENSE.txt $@
+endef
+
+# Flatten bin/ in the Windows archive
+BrogueCE-windows: bin/brogue.exe
+	$(make_release_base)
+	cp -r $(common_bin) bin/{brogue.exe,brogue-cmd.bat} $@
+
+BrogueCE-macos: Brogue.app
+	$(make_release_base)
+	cp -r Brogue.app $@/"Brogue CE.app"
+
+BrogueCE-linux: bin/brogue
+	$(make_release_base)
+	cp brogue $@
+	cp -r --parents $(common_bin) bin/brogue $@
+	cp linux/make-link-for-desktop.sh $@
+
+
+# macOS app bundle
+
+# $* is the matched %
+icon_%.png: bin/assets/icon.png
+	convert $< -resize $* $@
+
+macos/Brogue.icns: icon_32.png icon_128.png icon_256.png icon_512.png
+	png2icns $@ $^
+	$(RM) $^
+
+Brogue.app: bin/brogue
+	mkdir -p $@/Contents/{MacOS,Resources}
+	cp macos/Info.plist $@/Contents
+	cp bin/brogue $@/Contents/MacOS
+	cp -r macos/Brogue.icns bin/assets $@/Contents/Resources
+
+macos/sdl2.rb:
+	curl -L 'https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/sdl2.rb' >$@
+	patch $@ macos/sdl2-deployment-target.patch


### PR DESCRIPTION
This is a bit experimental, but it should mean you don't have to remember to do `make clean` when changing build options. In fact, `make clean` has been removed; use `make -B <target>` if you need to force a rebuild.