### PR TITLE
Fix for lunging at invisible enemies

### DIFF
--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1032,7 +1032,7 @@ boolean playerMoves(short direction) {
             if (coordinatesAreInMap(newestX, newestY) && (pmap[newestX][newestY].flags & HAS_MONSTER)) {
                 tempMonst = monsterAtLoc(newestX, newestY);
                 if (tempMonst
-                    && canSeeMonster(tempMonst)
+                    && (canSeeMonster(tempMonst) || monsterRevealed(tempMonst))
                     && monstersAreEnemies(&player, tempMonst)
                     && tempMonst->creatureState != MONSTER_ALLY
                     && !(tempMonst->bookkeepingFlags & MB_IS_DYING)


### PR DESCRIPTION
Minimum fix.

In my analysis of this code, the actual error stems from 'canSeeMonster' (Monsters.c @ 211).  The logic goes roughly like this:
```
IF (the monster is NOT hidden)
     AND (the player can see the monster's loc OR the monster is revealed)
THEN the monster is visible
```
But this logic does not make sense - if the monster IS hidden, then it does not matter if the monster is revealed it will still not be visible.

It seems more likely that the intention was for the following logic:
```
IF (the monster is NOT hidden AND the player can see the monster's loc)
    OR (the monster is revealed)
THEN the monster is visible
```

However, making this change breaks a lot of other code.  Various parts of the code use "canSeeMonster" with different expectations, and some expect it to return FALSE when monsters are hidden, then separately call 'monsterRevealed' to check visibility.  Fixing all of these cases seems excessive, but it should probably be done at some point.
