### PR TITLE
Bloodwort speeds recovery of negative effects (poison, weakness, etc)

### DIFF
--- a/changes/issue-514.md
+++ b/changes/issue-514.md
@@ -1,0 +1,3 @@
+-
+  Bloodwort pods now speed recovery from most ailments; poison, confusion,
+  hallucination, nausea, slowed, weakened, and darkness.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3849,37 +3849,31 @@ void haste(creature *monst, short turns) {
     }
 }
 
+void healStatus(creature *monst, short status, short minStatus, short percent) {
+    short amount = max(1, percent * player.maxStatus[status] / 100);
+    short newStatus = monst->status[status] - amount;
+    monst->status[status] = min( monst->status[status], max( minStatus, newStatus ));
+}
+
 void heal(creature *monst, short percent, boolean panacea) {
     char buf[COLS], monstName[COLS];
-    monst->currentHP = min(monst->info.maxHP, monst->currentHP + percent * monst->info.maxHP / 100);
+    short amount = max(1, percent * monst->info.maxHP / 100);
+    monst->currentHP = min(monst->info.maxHP, monst->currentHP + amount);
     if (panacea) {
-        if (monst->status[STATUS_HALLUCINATING] > 1) {
-            monst->status[STATUS_HALLUCINATING] = 1;
-        }
-        if (monst->status[STATUS_CONFUSED] > 1) {
-            monst->status[STATUS_CONFUSED] = 1;
-        }
-        if (monst->status[STATUS_NAUSEOUS] > 1) {
-            monst->status[STATUS_NAUSEOUS] = 1;
-        }
-        if (monst->status[STATUS_SLOWED] > 1) {
-            monst->status[STATUS_SLOWED] = 1;
-        }
-        if (monst->status[STATUS_WEAKENED] > 1) {
-            monst->weaknessAmount = 0;
-            monst->status[STATUS_WEAKENED] = 0;
-            updateEncumbrance();
-        }
-        if (monst->status[STATUS_POISONED]) {
-            monst->poisonAmount = 0;
-            monst->status[STATUS_POISONED] = 0;
-        }
-        if (monst->status[STATUS_DARKNESS] > 0) {
-            monst->status[STATUS_DARKNESS] = 0;
-            if (monst == &player) {
-                updateMinersLightRadius();
-                updateVision(true);
-            }
+        healStatus( monst, STATUS_HALLUCINATING, 1, percent );
+        healStatus( monst, STATUS_CONFUSED,      1, percent );
+        healStatus( monst, STATUS_NAUSEOUS,      1, percent );
+        healStatus( monst, STATUS_SLOWED,        1, percent );
+        healStatus( monst, STATUS_WEAKENED,      0, percent );
+        healStatus( monst, STATUS_POISONED,      0, percent );
+        healStatus( monst, STATUS_DARKNESS,      0, percent );
+
+        monst->poisonAmount   = monst->status[STATUS_POISONED] > 0 ? monst->poisonAmount   : 0;
+        monst->weaknessAmount = monst->status[STATUS_WEAKENED] > 0 ? monst->weaknessAmount : 0;
+        updateEncumbrance();
+        if (monst == &player) {
+            updateMinersLightRadius();
+            updateVision(true);
         }
     }
     if (canDirectlySeeMonster(monst)

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -537,14 +537,10 @@ void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
         && !(monst->info.flags & MONST_INANIMATE)
         && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
 
-        damage = (monst->info.maxHP / 15) * ticks / 100;
-        damage = max(1, damage);
-        if (monst->currentHP < monst->info.maxHP) {
-            monst->currentHP = min(monst->currentHP + damage, monst->info.maxHP);
-            if (monst == &player) {
-                messageWithColor("you feel much better.", &goodMessageColor, 0);
-            }
+        if (monst == &player && monst->currentHP < monst->info.maxHP) {
+            messageWithColor("you feel much better.", &goodMessageColor, 0);
         }
+        heal(monst, ticks / 15, true);
     }
 }
 


### PR DESCRIPTION
Probably needs play testing/balancing to get the right "feel".

Bloodwort now speeds recovery from negative effects (suggested in #514):
- Hallucination
- Confusion
- Nausea
- Slowed
- Weakened
- Poisoned
- Darkness
