### PR TITLE
Cursed items add long-duration debuf, then uncurse

### DIFF
--- a/changes/issue-499.md
+++ b/changes/issue-499.md
@@ -1,0 +1,4 @@
+-
+  Cursed items cannot be unequipped for 1000 turns, or until a remove curse is used.
+  Curses also stack, so equipping two cursed items in quick succession would require
+  2000 turns before either item can be unequipped.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4598,6 +4598,8 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
         "Lifespan",
         "Shielded",
         "Invisible",
+        "",
+        "Cursed",
     };
 
     if (y >= ROWS - 1) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -6900,6 +6900,7 @@ void readScroll(item *theItem) {
                 }
             }
             if (hadEffect) {
+                player.status[STATUS_CURSED] = 0;
                 message("your pack glows with a cleansing light, and a malevolent energy disperses.", 0);
             } else {
                 message("your pack glows with a cleansing light, but nothing happens.", 0);
@@ -7649,6 +7650,8 @@ boolean equipItem(item *theItem, boolean force, item *unequipHint) {
                     break;
             }
             messageWithColor(buf1, &itemMessageColor, 0);
+            player.status[STATUS_CURSED] += CURSED_ITEM_DURATION;
+            player.maxStatus[STATUS_CURSED] = player.status[STATUS_CURSED];
         }
     }
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -182,6 +182,7 @@ typedef struct pos {
 #define WEAPON_KILLS_TO_AUTO_ID 20
 #define ARMOR_DELAY_TO_AUTO_ID  1000
 #define RING_DELAY_TO_AUTO_ID   1500
+#define CURSED_ITEM_DURATION    1000
 
 #define FALL_DAMAGE_MIN         8
 #define FALL_DAMAGE_MAX         10
@@ -1960,6 +1961,7 @@ enum statusEffects {
     STATUS_SHIELDED,
     STATUS_INVISIBLE,
     STATUS_AGGRAVATING,
+    STATUS_CURSED,
     NUMBER_OF_STATUS_EFFECTS,
 };
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -2104,6 +2104,7 @@ void autoRest() {
          || player.status[STATUS_NAUSEOUS]
          || player.status[STATUS_POISONED]
          || player.status[STATUS_DARKNESS]
+         || player.status[STATUS_CURSED]
          || initiallyEmbedded)
         && !rogue.disturbed) {
         while (i++ < TURNS_FOR_FULL_REGEN
@@ -2113,6 +2114,7 @@ void autoRest() {
                    || player.status[STATUS_NAUSEOUS]
                    || player.status[STATUS_POISONED]
                    || player.status[STATUS_DARKNESS]
+                   || player.status[STATUS_CURSED]
                    || cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY))
                && !rogue.disturbed
                && (!initiallyEmbedded || cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY))) {
@@ -2317,6 +2319,18 @@ void playerTurnEnded() {
             }
             if (!--player.status[STATUS_BURNING]) {
                 extinguishFireOnCreature(&player);
+            }
+        }
+
+        // Countdown curse
+        if (player.status[STATUS_CURSED] > 0) {
+            player.status[STATUS_CURSED]--;
+            if (player.status[STATUS_CURSED] == 0) {
+                // When curse debuf ends, uncurse all equipment
+                if (rogue.weapon    != NULL) rogue.weapon->flags    &= ~ITEM_CURSED;
+                if (rogue.armor     != NULL) rogue.armor->flags     &= ~ITEM_CURSED;
+                if (rogue.ringLeft  != NULL) rogue.ringLeft->flags  &= ~ITEM_CURSED;
+                if (rogue.ringRight != NULL) rogue.ringRight->flags &= ~ITEM_CURSED;
             }
         }
 


### PR DESCRIPTION
Suggested in #499 - this is an implementation of the "debuf" variant.  Equipping cursed items adds time to the "Cursed" debuf.  Cursed items cannot be removed until the curse ends.

Not sure if 1000 turns is the right number for duration though.
