### PR TITLE
Items falling from previous level will depress triggers

### DIFF
--- a/changes/issue-481.md
+++ b/changes/issue-481.md
@@ -1,0 +1,2 @@
+-
+  Items falling from the previous level will now trigger any traps they land on

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2758,7 +2758,7 @@ extern "C" {
                          boolean superpriority);
     boolean spawnDungeonFeature(short x, short y, dungeonFeature *feat, boolean refreshCell, boolean abortIfBlocking);
     void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit);
-    void restoreItem(item *theItem);
+    void restoreItems();
     void refreshWaypoint(short wpIndex);
     void setUpWaypoints();
     void zeroOutGrid(char grid[DCOLS][DROWS]);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -711,9 +711,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
         levels[rogue.depthLevel-1].items           = NULL;
 
-        for (theItem = floorItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
-            restoreItem(theItem);
-        }
+        restoreItems();
 
     }
 


### PR DESCRIPTION
Reusing the `placeItem()` function for items falling from above so they work like any other item that lands on that space.

Also checked that monsters dropping items (on death or as an ally) also use `placeItem()`.

Fixing #481 