### PR TITLE
Create generic `windowpos` type for window coordinates

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -358,7 +358,8 @@ void addLoops(short **grid, short minimumPathingDistance) {
                         grid[x][y] = 2;             // then turn the tile into a doorway.
                         costMap[x][y] = 1;          // (Cost map also needs updating.)
                         if (D_INSPECT_LEVELGEN) {
-                            plotCharWithColor(G_CLOSED_DOOR, mapToWindowX(x), mapToWindowY(y), &black, &green);
+                            pos p = { x, y };
+                            plotCharWithColor(G_CLOSED_DOOR, mapToWindow(p), &black, &green);
                         }
                         break;
                     }
@@ -761,7 +762,7 @@ void redesignInterior(char interior[DCOLS][DROWS], short originX, short originY,
                 copyGrid(pathingGrid, grid);
                 findReplaceGrid(pathingGrid, -1, -1, 0);
                 hiliteGrid(pathingGrid, &green, 50);
-                plotCharWithColor('X', mapToWindowX(orphanList[n].x), mapToWindowY(orphanList[n].y), &black, &orange);
+                plotCharWithColor('X', mapToWindow(orphanList[n]), &black, &orange);
                 temporaryMessage("Orphan detected:", REQUIRE_ACKNOWLEDGMENT);
             }
 
@@ -803,7 +804,8 @@ void redesignInterior(char interior[DCOLS][DROWS], short originX, short originY,
                 if (D_INSPECT_MACHINES) {
                     dumpLevelToScreen();
                     displayGrid(pathingGrid);
-                    plotCharWithColor('X', mapToWindowX(i), mapToWindowY(j), &black, &orange);
+                    pos p = { i, j };
+                    plotCharWithColor('X', mapToWindow(p), &black, &orange);
                     temporaryMessage("Orphan connecting:", REQUIRE_ACKNOWLEDGMENT);
                 }
             }
@@ -2146,7 +2148,7 @@ void chooseRandomDoorSites(short **roomMap, pos doorSites[4]) {
                         newY += nbDirs[dir][1];
                     }
                     if (!doorSiteFailed) {
-//                        plotCharWithColor(dirChars[dir], mapToWindowX(i), mapToWindowY(j), &black, &green);
+//                        plotCharWithColor(dirChars[dir], mapToWindow((pos){ i, j }), &black, &green);
                         grid[i][j] = dir + 2; // So as not to conflict with 0 or 1, which are used to indicate exterior/interior.
                     }
                 }
@@ -2346,10 +2348,10 @@ void attachRooms(short **grid, const dungeonProfile *theDP, short attempts, shor
         if (D_INSPECT_LEVELGEN) {
             colorOverDungeon(&darkGray);
             hiliteGrid(roomMap, &blue, 100);
-            if (doorSites[0].x != -1) plotCharWithColor('^', mapToWindowX(doorSites[0].x), mapToWindowY(doorSites[0].y), &black, &green);
-            if (doorSites[1].x != -1) plotCharWithColor('v', mapToWindowX(doorSites[1].x), mapToWindowY(doorSites[1].y), &black, &green);
-            if (doorSites[2].x != -1) plotCharWithColor('<', mapToWindowX(doorSites[2].x), mapToWindowY(doorSites[2].y), &black, &green);
-            if (doorSites[3].x != -1) plotCharWithColor('>', mapToWindowX(doorSites[3].x), mapToWindowY(doorSites[3].y), &black, &green);
+            if (doorSites[0].x != -1) plotCharWithColor('^', mapToWindow(doorSites[0]), &black, &green);
+            if (doorSites[1].x != -1) plotCharWithColor('v', mapToWindow(doorSites[1]), &black, &green);
+            if (doorSites[2].x != -1) plotCharWithColor('<', mapToWindow(doorSites[2]), &black, &green);
+            if (doorSites[3].x != -1) plotCharWithColor('>', mapToWindow(doorSites[3]), &black, &green);
             temporaryMessage("Generating this room:", REQUIRE_ACKNOWLEDGMENT);
         }
 
@@ -2584,7 +2586,7 @@ boolean lakeDisruptsPassability(short **grid, short **lakeMap, short dungeonToGr
 //                    dumpLevelToScreen();
 //                    hiliteGrid(lakeMap, &darkBlue, 75);
 //                    hiliteGrid(floodMap, &white, 20);
-//                    plotCharWithColor('X', mapToWindowX(i), mapToWindowY(j), &black, &red);
+//                    plotCharWithColor('X', mapToWindow((pos){ i, j }), &black, &red);
 //                    temporaryMessage("Failed here.", REQUIRE_ACKNOWLEDGMENT);
 //                }
 

--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -114,7 +114,7 @@ void drawButton(brogueButton *button, enum buttonDrawStates highlight, cellDispl
                 plotCharToBuffer(displayCharacter, button->x + i, button->y, &fColor, &bColor, dbuf);
                 dbuf[button->x + i][button->y].opacity = opacity;
             } else {
-                plotCharWithColor(displayCharacter, button->x + i, button->y, &fColor, &bColor);
+                plotCharWithColor(displayCharacter, (windowpos){ button->x + i, button->y }, &fColor, &bColor);
             }
         }
     }

--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -110,11 +110,10 @@ void drawButton(brogueButton *button, enum buttonDrawStates highlight, cellDispl
         }
 
         if (coordinatesAreInWindow(button->x + i, button->y)) {
+            plotCharToBuffer(displayCharacter, (windowpos){ button->x + i, button->y }, &fColor, &bColor, dbuf);
             if (dbuf) {
-                plotCharToBuffer(displayCharacter, button->x + i, button->y, &fColor, &bColor, dbuf);
+                // Only buffers can have opacity set.
                 dbuf[button->x + i][button->y].opacity = opacity;
-            } else {
-                plotCharWithColor(displayCharacter, (windowpos){ button->x + i, button->y }, &fColor, &bColor);
             }
         }
     }

--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -109,7 +109,7 @@ void drawButton(brogueButton *button, enum buttonDrawStates highlight, cellDispl
             symbolNumber++;
         }
 
-        if (coordinatesAreInWindow(button->x + i, button->y)) {
+        if (locIsInWindow((windowpos){ button->x + i, button->y })) {
             plotCharToBuffer(displayCharacter, (windowpos){ button->x + i, button->y }, &fColor, &bColor, dbuf);
             if (dbuf) {
                 // Only buffers can have opacity set.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -1840,27 +1840,29 @@ void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *
     restoreRNG;
 }
 
-void plotCharToBuffer(enum displayGlyph inputChar, short x, short y, color *foreColor, color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]) {
+void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, color *foreColor, color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]) {
     short oldRNG;
 
     if (!dbuf) {
-        plotCharWithColor(inputChar, (windowpos){ x, y }, foreColor, backColor);
+        plotCharWithColor(inputChar, loc, foreColor, backColor);
         return;
     }
 
-    brogueAssert(coordinatesAreInWindow(x, y));
+    brogueAssert(coordinatesAreInWindow(loc.x, loc.y));
 
     oldRNG = rogue.RNG;
     rogue.RNG = RNG_COSMETIC;
     //assureCosmeticRNG;
-    dbuf[x][y].foreColorComponents[0] = foreColor->red + rand_range(0, foreColor->redRand) + rand_range(0, foreColor->rand);
-    dbuf[x][y].foreColorComponents[1] = foreColor->green + rand_range(0, foreColor->greenRand) + rand_range(0, foreColor->rand);
-    dbuf[x][y].foreColorComponents[2] = foreColor->blue + rand_range(0, foreColor->blueRand) + rand_range(0, foreColor->rand);
-    dbuf[x][y].backColorComponents[0] = backColor->red + rand_range(0, backColor->redRand) + rand_range(0, backColor->rand);
-    dbuf[x][y].backColorComponents[1] = backColor->green + rand_range(0, backColor->greenRand) + rand_range(0, backColor->rand);
-    dbuf[x][y].backColorComponents[2] = backColor->blue + rand_range(0, backColor->blueRand) + rand_range(0, backColor->rand);
-    dbuf[x][y].character = inputChar;
-    dbuf[x][y].opacity = 100;
+
+    cellDisplayBuffer* cell = &dbuf[loc.window_x][loc.window_y];
+    cell->foreColorComponents[0] = foreColor->red + rand_range(0, foreColor->redRand) + rand_range(0, foreColor->rand);
+    cell->foreColorComponents[1] = foreColor->green + rand_range(0, foreColor->greenRand) + rand_range(0, foreColor->rand);
+    cell->foreColorComponents[2] = foreColor->blue + rand_range(0, foreColor->blueRand) + rand_range(0, foreColor->rand);
+    cell->backColorComponents[0] = backColor->red + rand_range(0, backColor->redRand) + rand_range(0, backColor->rand);
+    cell->backColorComponents[1] = backColor->green + rand_range(0, backColor->greenRand) + rand_range(0, backColor->rand);
+    cell->backColorComponents[2] = backColor->blue + rand_range(0, backColor->blueRand) + rand_range(0, backColor->rand);
+    cell->character = inputChar;
+    cell->opacity = 100;
     restoreRNG;
 }
 
@@ -3944,11 +3946,7 @@ void printString(const char *theString, short x, short y, color *foreColor, colo
             }
         }
 
-        if (dbuf) {
-            plotCharToBuffer(theString[i], x, y, &fColor, backColor, dbuf);
-        } else {
-            plotCharWithColor(theString[i], (windowpos) { x, y }, &fColor, backColor);
-        }
+        plotCharToBuffer(theString[i], (windowpos){ x, y }, &fColor, backColor, dbuf);
     }
 }
 
@@ -4068,14 +4066,8 @@ short printStringWithWrapping(char *theString, short x, short y, short width, co
             continue;
         }
 
-        if (dbuf) {
-            if (coordinatesAreInWindow(px, py)) {
-                plotCharToBuffer(printString[i], px, py, &fColor, backColor, dbuf);
-            }
-        } else {
-            if (coordinatesAreInWindow(px, py)) {
-                plotCharWithColor(printString[i], (windowpos) { px, py }, &fColor, backColor);
-            }
+        if (coordinatesAreInWindow(px, py)) {
+            plotCharToBuffer(printString[i], (windowpos){ px, py }, &fColor, backColor, dbuf);
         }
 
         px++;
@@ -4185,14 +4177,14 @@ void printDiscoveries(short category, short count, unsigned short itemCharacter,
     for (i = 0; i < count; i++) {
         if (theTable[i].identified) {
             theColor = &white;
-            plotCharToBuffer(itemCharacter, x, y + i, &itemColor, &black, dbuf);
+            plotCharToBuffer(itemCharacter, (windowpos){ x, y + i }, &itemColor, &black, dbuf);
         } else {
             theColor = &darkGray;
             magic = magicCharDiscoverySuffix(category, i);
             if (magic == 1) {
-                plotCharToBuffer(G_GOOD_MAGIC, x, y + i, &goodColor, &black, dbuf);
+                plotCharToBuffer(G_GOOD_MAGIC, (windowpos){ x, y + i }, &goodColor, &black, dbuf);
             } else if (magic == -1) {
-                plotCharToBuffer(G_BAD_MAGIC, x, y + i, &badColor, &black, dbuf);
+                plotCharToBuffer(G_BAD_MAGIC, (windowpos){ x, y + i }, &badColor, &black, dbuf);
             }
         }
         strcpy(buf, theTable[i].name);

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -1794,7 +1794,7 @@ void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *
 
     foreRand, backRand;
 
-    brogueAssert(coordinatesAreInWindow(loc.window_x, loc.window_y));
+    brogueAssert(locIsInWindow(loc));
 
     if (rogue.gameHasEnded || rogue.playbackFastForward) {
         return;
@@ -1848,7 +1848,7 @@ void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, color *foreCol
         return;
     }
 
-    brogueAssert(coordinatesAreInWindow(loc.x, loc.y));
+    brogueAssert(locIsInWindow(loc));
 
     oldRNG = rogue.RNG;
     rogue.RNG = RNG_COSMETIC;
@@ -2455,7 +2455,7 @@ void nextBrogueEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsD
         }
         do {
             nextKeyOrMouseEvent(returnEvent, textInput, colorsDance); // No mouse clicks outside of the window will register.
-        } while (returnEvent->eventType == MOUSE_UP && !coordinatesAreInWindow(returnEvent->param1, returnEvent->param2));
+        } while (returnEvent->eventType == MOUSE_UP && !locIsInWindow((windowpos){ returnEvent->param1, returnEvent->param2 }));
         // recording done elsewhere
     }
 
@@ -4066,7 +4066,7 @@ short printStringWithWrapping(char *theString, short x, short y, short width, co
             continue;
         }
 
-        if (coordinatesAreInWindow(px, py)) {
+        if (locIsInWindow((windowpos){ px, py })) {
             plotCharToBuffer(printString[i], (windowpos){ px, py }, &fColor, backColor, dbuf);
         }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -683,7 +683,7 @@ void populateItems(short upstairsX, short upstairsY) {
             dumpLevelToScreen();
             displayGrid(map);
             freeGrid(map);
-            plotCharWithColor(theItem->displayChar, mapToWindowX(x), mapToWindowY(y), &black, &purple);
+            plotCharWithColor(theItem->displayChar, mapToWindow((pos){ x, y }), &black, &purple);
             temporaryMessage("Added an item.", REQUIRE_ACKNOWLEDGMENT);
         }
     }
@@ -4906,9 +4906,9 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
 
                         colorMultiplierFromDungeonLight(x2, y2, &multColor);
                         applyColorMultiplier(&foreColor, &multColor);
-                        plotCharWithColor(theChar, mapToWindowX(x2), mapToWindowY(y2), &foreColor, &backColor);
+                        plotCharWithColor(theChar, mapToWindow((pos){ x2, y2 }), &foreColor, &backColor);
                     } else if (boltColor) {
-                        plotCharWithColor(theChar, mapToWindowX(x2), mapToWindowY(y2), &foreColor, &backColor);
+                        plotCharWithColor(theChar, mapToWindow((pos){ x2, y2 }), &foreColor, &backColor);
                     } else if (k == 1
                                && theBolt->foreColor
                                && theBolt->theChar) {
@@ -5990,7 +5990,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
             } else { // clairvoyant visible
                 applyColorMultiplier(&foreColor, &clairvoyanceColor);
             }
-            plotCharWithColor(theItem->displayChar, mapToWindowX(x), mapToWindowY(y), &foreColor, &backColor);
+            plotCharWithColor(theItem->displayChar, mapToWindow((pos){ x, y }), &foreColor, &backColor);
 
             if (!fastForward) {
                 fastForward = rogue.playbackFastForward || pauseAnimation(25);

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -161,7 +161,7 @@ void antiAlias(unsigned char mask[COLS][ROWS]) {
                 for (dir=0; dir<4; dir++) {
                     x = i + nbDirs[dir][0];
                     y = j + nbDirs[dir][1];
-                    if (coordinatesAreInWindow(x, y) && mask[x][y] == 100) {
+                    if (locIsInWindow((windowpos){ x, y }) && mask[x][y] == 100) {
                         nbCount++;
                     }
                 }

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -58,7 +58,7 @@ void drawMenuFlames(signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3
             }
 
             if (mask[i][j] == 100) {
-                plotCharWithColor(dchar, i, j, &veryDarkGray, maskColor);
+                plotCharWithColor(dchar, (windowpos){ i, j }, &veryDarkGray, maskColor);
             } else {
                 tempColor = black;
                 tempColor.red   = flames[i][j][0] / MENU_FLAME_PRECISION_FACTOR;
@@ -67,7 +67,7 @@ void drawMenuFlames(signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3
                 if (mask[i][j] > 0) {
                     applyColorAverage(&tempColor, maskColor, mask[i][j]);
                 }
-                plotCharWithColor(dchar, i, j, &veryDarkGray, &tempColor);
+                plotCharWithColor(dchar, (windowpos){ i, j }, &veryDarkGray, &tempColor);
             }
         }
     }
@@ -657,7 +657,7 @@ void mainBrogueJunction() {
                 displayBuffer[i][j].foreColorComponents[k] = 0;
                 displayBuffer[i][j].backColorComponents[k] = 0;
             }
-            plotCharWithColor(' ', i, j, &black, &black);
+            plotCharWithColor(' ', (windowpos){ i, j }, &black, &black);
         }
     }
 

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1071,7 +1071,7 @@ boolean getRandomMonsterSpawnLocation(short *x, short *y) {
     //    DEBUG {
     //        dumpLevelToScreen();
     //        hiliteGrid(grid, &orange, 50);
-    //        plotCharWithColor('X', mapToWindowX(x), mapToWindowY(y), &black, &white);
+    //        plotCharWithColor('X', mapToWindow((pos){ x, y }), &black, &white);
     //        temporaryMessage("Horde spawn location possibilities:", REQUIRE_ACKNOWLEDGMENT);
     //    }
     freeGrid(grid);
@@ -1147,7 +1147,7 @@ void teleport(creature *monst, short x, short y, boolean respectTerrainAvoidance
 //        DEBUG {
 //            dumpLevelToScreen();
 //            hiliteGrid(grid, &orange, 50);
-//            plotCharWithColor('X', mapToWindowX(x), mapToWindowY(y), &white, &red);
+//            plotCharWithColor('X', mapToWindow((pos){ x, y }), &white, &red);
 //            temporaryMessage("Teleport candidate locations:", REQUIRE_ACKNOWLEDGMENT);
 //        }
         freeGrid(grid);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1257,7 +1257,10 @@ boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask);
                                                 && cellHasTerrainFlag((x), (y), T_OBSTRUCTS_PASSABILITY)))
 
 #define coordinatesAreInMap(x, y)           ((x) >= 0 && (x) < DCOLS    && (y) >= 0 && (y) < DROWS)
-#define coordinatesAreInWindow(x, y)        ((x) >= 0 && (x) < COLS     && (y) >= 0 && (y) < ROWS)
+
+inline static boolean locIsInWindow(windowpos w) {
+    return w.window_x >= 0 && w.window_x < COLS && w.window_y >= 0 && w.window_y < ROWS;
+}
 
 inline static pos windowToMap(windowpos w) {
     return (pos) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2860,7 +2860,7 @@ extern "C" {
     void hiliteCell(short x, short y, const color *hiliteColor, short hiliteStrength, boolean distinctColors);
     void colorMultiplierFromDungeonLight(short x, short y, color *editColor);
     void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *cellForeColor, const color *cellBackColor);
-    void plotCharToBuffer(enum displayGlyph inputChar, short x, short y, color *foreColor, color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]);
+    void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, color *foreColor, color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]);
     void plotForegroundChar(enum displayGlyph inputChar, short x, short y, color *foreColor, boolean affectedByLighting);
     void commitDraws();
     void dumpLevelToScreen();

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -142,10 +142,21 @@ typedef long long fixpt;
 #define COLS                    100
 #define ROWS                    (31 + MESSAGE_LINES)
 
+// A location within the dungeon.
+// Typically, 0 <= x < DCOLS and 0 <= y < DROWS,
+// but occasionally coordinates are used which point outside of this region.
 typedef struct pos {
     short x;
     short y;
 } pos;
+
+// A location within the window.
+// Convert between `windowpos` and `pos` with `mapToWindow` and
+// `windowToMap`
+typedef struct windowpos {
+    short window_x;
+    short window_y;
+} windowpos;
 
 // Size of the portion of the terminal window devoted to displaying the dungeon:
 #define DCOLS                   (COLS - STAT_BAR_WIDTH - 1) // n columns on the left for the sidebar;
@@ -1247,9 +1258,28 @@ boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask);
 
 #define coordinatesAreInMap(x, y)           ((x) >= 0 && (x) < DCOLS    && (y) >= 0 && (y) < DROWS)
 #define coordinatesAreInWindow(x, y)        ((x) >= 0 && (x) < COLS     && (y) >= 0 && (y) < ROWS)
+
+inline static pos windowToMap(windowpos w) {
+    return (pos) {
+        .x = w.window_x - STAT_BAR_WIDTH - 1,
+        .y = w.window_y - MESSAGE_LINES,
+    };
+}
+
+inline static windowpos mapToWindow(pos p) {
+    return (windowpos) {
+        .window_x = p.x + STAT_BAR_WIDTH + 1,
+        .window_y = p.y + MESSAGE_LINES,
+    };
+}
+
+// Prefer using `mapToWindow` to combine both coordinates together.
 #define mapToWindowX(x)                     ((x) + STAT_BAR_WIDTH + 1)
+// Prefer using `mapToWindow` to combine both coordinates together.
 #define mapToWindowY(y)                     ((y) + MESSAGE_LINES)
+// Prefer using `windowToMap` to combine both coordinates together.
 #define windowToMapX(x)                     ((x) - STAT_BAR_WIDTH - 1)
+// Prefer using `windowToMap` to combine both coordinates together.
 #define windowToMapY(y)                     ((y) - MESSAGE_LINES)
 
 #define playerCanDirectlySee(x, y)          (pmap[x][y].flags & VISIBLE)
@@ -2829,7 +2859,7 @@ extern "C" {
     void colorBlendCell(short x, short y, color *hiliteColor, short hiliteStrength);
     void hiliteCell(short x, short y, const color *hiliteColor, short hiliteStrength, boolean distinctColors);
     void colorMultiplierFromDungeonLight(short x, short y, color *editColor);
-    void plotCharWithColor(enum displayGlyph inputChar, short xLoc, short yLoc, const color *cellForeColor, const color *cellBackColor);
+    void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *cellForeColor, const color *cellBackColor);
     void plotCharToBuffer(enum displayGlyph inputChar, short x, short y, color *foreColor, color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]);
     void plotForegroundChar(enum displayGlyph inputChar, short x, short y, color *foreColor, boolean affectedByLighting);
     void commitDraws();

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -113,7 +113,7 @@ void benchmark() {
         for (i=0; i<COLS; i++) {
             for (j=0; j<ROWS; j++) {
                 theChar = rand_range('!', '~');
-                plotCharWithColor(theChar, i, j, &sparklesauce, &sparklesauce);
+                plotCharWithColor(theChar, (windowpos){ i, j }, &sparklesauce, &sparklesauce);
             }
         }
         pauseBrogue(1);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1172,7 +1172,7 @@ void victory(boolean superVictory) {
     //
     printString(displayedMessage[0], mapToWindowX(0), mapToWindowY(-1), &white, &black, dbuf);
 
-    plotCharToBuffer(G_GOLD, mapToWindowX(2), mapToWindowY(1), &yellow, &black, dbuf);
+    plotCharToBuffer(G_GOLD, mapToWindow((pos){ 2, 1 }), &yellow, &black, dbuf);
     printString("Gold", mapToWindowX(4), mapToWindowY(1), &white, &black, dbuf);
     sprintf(buf, "%li", rogue.gold);
     printString(buf, mapToWindowX(60), mapToWindowY(1), &itemMessageColor, &black, dbuf);
@@ -1183,7 +1183,7 @@ void victory(boolean superVictory) {
             gemCount += theItem->quantity;
         }
         if (theItem->category == AMULET && superVictory) {
-            plotCharToBuffer(G_AMULET, mapToWindowX(2), min(ROWS-1, i + 1), &yellow, &black, dbuf);
+            plotCharToBuffer(G_AMULET, (windowpos){ mapToWindowX(2), min(ROWS-1, i + 1) }, &yellow, &black, dbuf);
             printString("The Birthright of Yendor", mapToWindowX(4), min(ROWS-1, i + 1), &itemMessageColor, &black, dbuf);
             sprintf(buf, "%li", max(0, itemValue(theItem) * 2));
             printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &itemMessageColor, &black, dbuf);
@@ -1194,7 +1194,7 @@ void victory(boolean superVictory) {
             itemName(theItem, buf, true, true, &white);
             upperCase(buf);
 
-            plotCharToBuffer(theItem->displayChar, mapToWindowX(2), min(ROWS-1, i + 1), &yellow, &black, dbuf);
+            plotCharToBuffer(theItem->displayChar, (windowpos){ mapToWindowX(2), min(ROWS-1, i + 1) }, &yellow, &black, dbuf);
             printString(buf, mapToWindowX(4), min(ROWS-1, i + 1), &white, &black, dbuf);
 
             if (itemValue(theItem) > 0) {

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -777,9 +777,9 @@ void updateVision(boolean refreshDisplay) {
     //  for (i=0; i<DCOLS; i++) {
     //      for (j=0; j<DROWS; j++) {
     //          if (pmap[i][j].flags & VISIBLE) {
-    //              plotCharWithColor(' ', mapToWindowX(i), mapToWindowY(j), &yellow, &yellow);
+    //              plotCharWithColor(' ', mapToWindow((pos){ i, j }), &yellow, &yellow);
     //          } else if (pmap[i][j].flags & IN_FIELD_OF_VIEW) {
-    //              plotCharWithColor(' ', mapToWindowX(i), mapToWindowY(j), &blue, &blue);
+    //              plotCharWithColor(' ', mapToWindow((pos){ i, j }), &blue, &blue);
     //          }
     //      }
     //  }


### PR DESCRIPTION
Some previous PRs added the `pos` type, for locations in the dungeon. This PR adds the `windowpos` type, for positions in the window.

The main reason for this is to prevent confusion (or ambiguity) between "dungeon" coordinates and "window" coordinates. It bakes the distinction into function signatures and allows for more helpful helper functions.

For example, the new `mapToWindow` function converts from `pos` to `window`, so you can write `mapToWindow(p)` instead of `mapToWindowX(p.x), mapToWindowY(p.y)` -- though the old macros are still around, as this doesn't apply to all uses.

This PR updates `plotCharWithColor` and `plotCharToBuffer` to ask for a `windowpos` instead of an `x` and `y` -- right now, these are the only functions which actually use the new `windowpos`.

