### PR TITLE
fix a fprintf format string

### DIFF
--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1454,10 +1454,10 @@ void parseFile() {
         numDepths   = recallNumber(4);
         fileLength  = recallNumber(4);
 
-        fprintf(descriptionFile, "Parsed file \"%s\":\n\tVersion: %s\n\tSeed: %li\n\tNumber of turns: %li\n\tNumber of depth changes: %li\n\tFile length: %li\n",
+        fprintf(descriptionFile, "Parsed file \"%s\":\n\tVersion: %s\n\tSeed: %lld\n\tNumber of turns: %lu\n\tNumber of depth changes: %lu\n\tFile length: %lu\n",
                 currentFilePath,
                 versionString,
-                seed,
+                (unsigned long long)seed,
                 numTurns,
                 numDepths,
                 fileLength);


### PR DESCRIPTION
Noticed while building on OpenBSD.  Seed is uint64_t, so `%llu` plus a cast to unsigned long long is better and I believe more portable than assuming it's a long (or use the PRIu64 macro from inttypes.h, but personally I prefer the cast to long long), and while here change the other `%li` to `%lu` since the other variables are `unsigned long`.