### PR TITLE
create pmapAt and tmapAt helper functions

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -1579,7 +1579,7 @@ boolean buildAMachine(enum machineTypes bp,
                             monst = generateMonster(feature->monsterID, true, true);
                             if (monst) {
                                 monst->loc = (pos){ .x = featX, .y = featY };
-                                pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
+                                pmapAt(monst->loc)->flags |= HAS_MONSTER;
                                 monst->bookkeepingFlags |= MB_JUST_SUMMONED;
                             }
                         }
@@ -3314,7 +3314,7 @@ void evacuateCreatures(char blockingMap[DCOLS][DROWS]) {
                                      false);
                 monst->loc = newLoc;
                 pmap[i][j].flags &= ~(HAS_MONSTER | HAS_PLAYER);
-                pmap[newLoc.x][newLoc.y].flags |= (monst == &player ? HAS_PLAYER : HAS_MONSTER);
+                pmapAt(newLoc)->flags |= (monst == &player ? HAS_PLAYER : HAS_MONSTER);
             }
         }
     }
@@ -3539,9 +3539,9 @@ void restoreItem(item *theItem) {
 
         theItem->loc = loc;
     }
-    pmap[theItem->loc.x][theItem->loc.y].flags |= HAS_ITEM;
+    pmapAt(theItem->loc)->flags |= HAS_ITEM;
     if (theItem->flags & ITEM_MAGIC_DETECTED && itemMagicPolarity(theItem)) {
-        pmap[theItem->loc.x][theItem->loc.y].flags |= ITEM_DETECTED;
+        pmapAt(theItem->loc)->flags |= ITEM_DETECTED;
     }
 }
 
@@ -3665,12 +3665,12 @@ void initializeLevel() {
     }
 
     if (rogue.depthLevel == DEEPEST_LEVEL) {
-        pmap[downLoc.x][downLoc.y].layers[DUNGEON] = DUNGEON_PORTAL;
+        pmapAt(downLoc)->layers[DUNGEON] = DUNGEON_PORTAL;
     } else {
-        pmap[downLoc.x][downLoc.y].layers[DUNGEON] = DOWN_STAIRS;
+        pmapAt(downLoc)->layers[DUNGEON] = DOWN_STAIRS;
     }
-    pmap[downLoc.x][downLoc.y].layers[LIQUID]     = NOTHING;
-    pmap[downLoc.x][downLoc.y].layers[SURFACE]    = NOTHING;
+    pmapAt(downLoc)->layers[LIQUID]     = NOTHING;
+    pmapAt(downLoc)->layers[SURFACE]    = NOTHING;
 
     if (!levels[n+1].visited) {
         levels[n+1].upStairsLoc = downLoc;
@@ -3689,17 +3689,17 @@ void initializeLevel() {
     levels[n].upStairsLoc = upLoc;
 
     if (rogue.depthLevel == 1) {
-        pmap[upLoc.x][upLoc.y].layers[DUNGEON] = DUNGEON_EXIT;
+        pmapAt(upLoc)->layers[DUNGEON] = DUNGEON_EXIT;
     } else {
-        pmap[upLoc.x][upLoc.y].layers[DUNGEON] = UP_STAIRS;
+        pmapAt(upLoc)->layers[DUNGEON] = UP_STAIRS;
     }
-    pmap[upLoc.x][upLoc.y].layers[LIQUID] = NOTHING;
-    pmap[upLoc.x][upLoc.y].layers[SURFACE] = NOTHING;
+    pmapAt(upLoc)->layers[LIQUID] = NOTHING;
+    pmapAt(upLoc)->layers[SURFACE] = NOTHING;
 
     rogue.downLoc = downLoc;
-    pmap[downLoc.x][downLoc.y].flags |= HAS_STAIRS;
+    pmapAt(downLoc)->flags |= HAS_STAIRS;
     rogue.upLoc = upLoc;
-    pmap[upLoc.x][upLoc.y].flags |= HAS_STAIRS;
+    pmapAt(upLoc)->flags |= HAS_STAIRS;
 
     if (!levels[rogue.depthLevel-1].visited) {
 

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -500,7 +500,7 @@ boolean forceWeaponHit(creature *defender, item *theItem) {
     };
     if (canDirectlySeeMonster(defender)
         && !cellHasTerrainFlag(newLoc.x, newLoc.y, T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION)
-        && !(pmap[newLoc.x][newLoc.y].flags & (HAS_MONSTER | HAS_PLAYER))) {
+        && !(pmapAt(newLoc)->flags & (HAS_MONSTER | HAS_PLAYER))) {
         sprintf(buf, "you launch %s backward with the force of your blow", monstName);
         buf[DCOLS] = '\0';
         combatMessage(buf, messageColorFromVictim(defender));
@@ -718,7 +718,7 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
                                 break;
                         }
                     }
-                    pmap[newMonst->loc.x][newMonst->loc.y].flags |= HAS_MONSTER;
+                    pmapAt(newMonst->loc)->flags |= HAS_MONSTER;
                     fadeInMonster(newMonst);
                 }
                 updateVision(true);

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -810,7 +810,7 @@ void mainInputLoop() {
                 } else if (abs(player.loc.x - rogue.cursorLoc.x) + abs(player.loc.y - rogue.cursorLoc.y) == 1 // horizontal or vertical
                            || (distanceBetween(player.loc.x, player.loc.y, rogue.cursorLoc.x, rogue.cursorLoc.y) == 1 // includes diagonals
                                && (!diagonalBlocked(player.loc.x, player.loc.y, rogue.cursorLoc.x, rogue.cursorLoc.y, !rogue.playbackOmniscience)
-                                   || ((pmap[rogue.cursorLoc.x][rogue.cursorLoc.y].flags & HAS_MONSTER) && (monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y)->info.flags & MONST_ATTACKABLE_THRU_WALLS)) // there's a turret there
+                                   || ((pmapAt(rogue.cursorLoc)->flags & HAS_MONSTER) && (monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y)->info.flags & MONST_ATTACKABLE_THRU_WALLS)) // there's a turret there
                                    || ((terrainFlags(rogue.cursorLoc.x, rogue.cursorLoc.y) & T_OBSTRUCTS_PASSABILITY) && (terrainMechFlags(rogue.cursorLoc.x, rogue.cursorLoc.y) & TM_PROMOTES_ON_PLAYER_ENTRY))))) { // there's a lever there
                                                                                                                                                                                       // Clicking one space away will cause the player to try to move there directly irrespective of path.
                                    for (dir=0;
@@ -4605,13 +4605,13 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
         printString("                    ", 0, y, &white, &black, 0); // Start with a blank line
 
         // Unhighlight if it's highlighted as part of the path.
-        inPath = (pmap[monst->loc.x][monst->loc.y].flags & IS_IN_PATH) ? true : false;
-        pmap[monst->loc.x][monst->loc.y].flags &= ~IS_IN_PATH;
+        inPath = (pmapAt(monst->loc)->flags & IS_IN_PATH) ? true : false;
+        pmapAt(monst->loc)->flags &= ~IS_IN_PATH;
         getCellAppearance(monst->loc.x, monst->loc.y, &monstChar, &monstForeColor, &monstBackColor);
         applyColorBounds(&monstForeColor, 0, 100);
         applyColorBounds(&monstBackColor, 0, 100);
         if (inPath) {
-            pmap[monst->loc.x][monst->loc.y].flags |= IS_IN_PATH;
+            pmapAt(monst->loc)->flags |= IS_IN_PATH;
         }
 
         if (dim) {
@@ -4638,7 +4638,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 //encodeMessageColor(monstName, strlen(monstName) - 4, &playerInDarknessColor);
                 encodeMessageColor(monstName, strlen(monstName) - 4, &monstForeColor);
                 strcat(monstName, "(dark)");
-            } else if (!(pmap[player.loc.x][player.loc.y].flags & IS_IN_SHADOW)) {
+            } else if (!(pmapAt(player.loc)->flags & IS_IN_SHADOW)) {
                 strcat(monstName, " xxxx");
                 //encodeMessageColor(monstName, strlen(monstName) - 4, &playerInLightColor);
                 encodeMessageColor(monstName, strlen(monstName) - 4, &monstForeColor);
@@ -4890,13 +4890,13 @@ short printItemInfo(item *theItem, short y, boolean dim, boolean highlight) {
 
     if (y < ROWS - 1) {
         // Unhighlight if it's highlighted as part of the path.
-        inPath = (pmap[theItem->loc.x][theItem->loc.y].flags & IS_IN_PATH) ? true : false;
-        pmap[theItem->loc.x][theItem->loc.y].flags &= ~IS_IN_PATH;
+        inPath = (pmapAt(theItem->loc)->flags & IS_IN_PATH) ? true : false;
+        pmapAt(theItem->loc)->flags &= ~IS_IN_PATH;
         getCellAppearance(theItem->loc.x, theItem->loc.y, &itemChar, &itemForeColor, &itemBackColor);
         applyColorBounds(&itemForeColor, 0, 100);
         applyColorBounds(&itemBackColor, 0, 100);
         if (inPath) {
-            pmap[theItem->loc.x][theItem->loc.y].flags |= IS_IN_PATH;
+            pmapAt(theItem->loc)->flags |= IS_IN_PATH;
         }
         if (dim) {
             applyColorAverage(&itemForeColor, &black, 50);

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -20,9 +20,23 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include "Rogue.h"
 
 extern tcell tmap[DCOLS][DROWS];                        // grids with info about the map
 extern pcell pmap[DCOLS][DROWS];                        // grids with info about the map
+
+// Returns a pointer to the `tcell` at the given position. The position must be in-bounds.
+static inline tcell* tmapAt(pos p) {
+  brogueAssert(p.x >= 0 && p.x < DCOLS && p.y >= 0 && p.y < DROWS);
+  return &tmap[p.x][p.y];
+}
+
+// Returns a pointer to the `pcell` at the given position. The position must be in-bounds.
+static inline pcell* pmapAt(pos p) {
+  brogueAssert(p.x >= 0 && p.x < DCOLS && p.y >= 0 && p.y < DROWS);
+  return &pmap[p.x][p.y];
+}
+
 extern short **scentMap;
 extern cellDisplayBuffer displayBuffer[COLS][ROWS];
 extern short terrainRandomValues[DCOLS][DROWS][8];

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -378,9 +378,9 @@ item *placeItem(item *theItem, short x, short y) {
 
     removeItemFromChain(theItem, floorItems); // just in case; double-placing an item will result in game-crashing loops in the item list
     addItemToChain(theItem, floorItems);
-    pmap[theItem->loc.x][theItem->loc.y].flags |= HAS_ITEM;
+    pmapAt(theItem->loc)->flags |= HAS_ITEM;
     if ((theItem->flags & ITEM_MAGIC_DETECTED) && itemMagicPolarity(theItem)) {
-        pmap[theItem->loc.x][theItem->loc.y].flags |= ITEM_DETECTED;
+        pmapAt(theItem->loc)->flags |= ITEM_DETECTED;
     }
     if (cellHasTerrainFlag(x, y, T_IS_DF_TRAP)
         && !cellHasTerrainFlag(x, y, T_MOVES_ITEMS)
@@ -1178,10 +1178,10 @@ void updateFloorItems() {
             pos loc;
             getQualifyingLocNear(&loc, x, y, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
             removeItemFrom(x, y);
-            pmap[loc.x][loc.y].flags |= HAS_ITEM;
+            pmapAt(loc)->flags |= HAS_ITEM;
             if (pmap[x][y].flags & ITEM_DETECTED) {
                 pmap[x][y].flags &= ~ITEM_DETECTED;
-                pmap[loc.x][loc.y].flags |= ITEM_DETECTED;
+                pmapAt(loc)->flags |= ITEM_DETECTED;
             }
             theItem->loc = loc;
             refreshDungeonCell(x, y);
@@ -1197,7 +1197,7 @@ void updateFloorItems() {
             continue;
         }
         if (pmap[x][y].machineNumber
-            && pmap[x][y].machineNumber == pmap[player.loc.x][player.loc.y].machineNumber
+            && pmap[x][y].machineNumber == pmapAt(player.loc)->machineNumber
             && (theItem->flags & ITEM_KIND_AUTO_ID)) {
 
             identifyItemKind(theItem);
@@ -1206,7 +1206,7 @@ void updateFloorItems() {
             && pmap[x][y].machineNumber) {
 
             while (nextItem != NULL
-                   && pmap[x][y].machineNumber == pmap[nextItem->loc.x][nextItem->loc.y].machineNumber
+                   && pmap[x][y].machineNumber == pmapAt(nextItem->loc)->machineNumber
                    && cellHasTMFlag(nextItem->loc.x, nextItem->loc.y, TM_SWAP_ENCHANTS_ACTIVATION)) {
 
                 // Skip future items that are also swappable, so that we don't inadvertently
@@ -3997,7 +3997,7 @@ void rechargeItems(unsigned long categories) {
 //    char buf[DCOLS*3], mName[DCOLS];
 //
 //    for (monst = monsters->nextCreature; monst != NULL; monst = monst->nextCreature) {
-//        if (pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW
+//        if (pmapAt(monst->loc)->flags & IN_FIELD_OF_VIEW
 //            && monst->creatureState != MONSTER_FLEEING
 //            && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
 //
@@ -4031,7 +4031,7 @@ void negationBlast(const char *emitterName, const short distance) {
     flashMonster(&player, &pink, 100);
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        if ((pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW)
+        if ((pmapAt(monst->loc)->flags & IN_FIELD_OF_VIEW)
             && (player.loc.x - monst->loc.x) * (player.loc.x - monst->loc.x) + (player.loc.y - monst->loc.y) * (player.loc.y - monst->loc.y) <= distance * distance) {
 
             if (canSeeMonster(monst)) {
@@ -4041,7 +4041,7 @@ void negationBlast(const char *emitterName, const short distance) {
         }
     }
     for (theItem = floorItems; theItem != NULL; theItem = theItem->nextItem) {
-        if ((pmap[theItem->loc.x][theItem->loc.y].flags & IN_FIELD_OF_VIEW)
+        if ((pmapAt(theItem->loc)->flags & IN_FIELD_OF_VIEW)
             && (player.loc.x - theItem->loc.x) * (player.loc.x - theItem->loc.x) + (player.loc.y - theItem->loc.y) * (player.loc.y - theItem->loc.y) <= distance * distance) {
 
             theItem->flags &= ~(ITEM_MAGIC_DETECTED | ITEM_CURSED);
@@ -4051,7 +4051,7 @@ void negationBlast(const char *emitterName, const short distance) {
                     theItem->enchant1 = theItem->enchant2 = theItem->charges = 0;
                     theItem->flags &= ~(ITEM_RUNIC | ITEM_RUNIC_HINTED | ITEM_RUNIC_IDENTIFIED | ITEM_PROTECTED);
                     identify(theItem);
-                    pmap[theItem->loc.x][theItem->loc.y].flags &= ~ITEM_DETECTED;
+                    pmapAt(theItem->loc)->flags &= ~ITEM_DETECTED;
                     refreshDungeonCell(theItem->loc.x, theItem->loc.y);
                     break;
                 case STAFF:
@@ -4084,7 +4084,7 @@ void discordBlast(const char *emitterName, const short distance) {
     colorFlash(&discordColor, 0, IN_FIELD_OF_VIEW, 3 + distance / 5, distance, player.loc.x, player.loc.y);
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        if ((pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW)
+        if ((pmapAt(monst->loc)->flags & IN_FIELD_OF_VIEW)
             && (player.loc.x - monst->loc.x) * (player.loc.x - monst->loc.x) + (player.loc.y - monst->loc.y) * (player.loc.y - monst->loc.y) <= distance * distance) {
 
             if (!(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
@@ -4688,7 +4688,7 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
                 monst->leader = &player;
                 monst->creatureState = MONSTER_ALLY;
                 monst->ticksUntilTurn = monst->info.attackSpeed + 1; // So they don't move before the player's next turn.
-                pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
+                pmapAt(monst->loc)->flags |= HAS_MONSTER;
                 //refreshDungeonCell(monst->loc.x, monst->loc.y);
                 fadeInMonster(monst);
             }
@@ -4730,7 +4730,7 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
                 // increase scent turn number so monsters don't sniff around at the old cell like idiots
                 rogue.scentTurnNumber += 30;
                 // get any items at the destination location
-                if (pmap[player.loc.x][player.loc.y].flags & HAS_ITEM) {
+                if (pmapAt(player.loc)->flags & HAS_ITEM) {
                     pickUpItemAt(player.loc.x, player.loc.y);
                 }
                 updateVision(true);
@@ -4819,14 +4819,14 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
 
     if (theBolt->boltEffect == BE_BLINKING) {
         if (cellHasTerrainFlag(listOfCoordinates[0].x, listOfCoordinates[0].y, (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION))
-            || ((pmap[listOfCoordinates[0].x][listOfCoordinates[0].y].flags & (HAS_PLAYER | HAS_MONSTER))
+            || ((pmapAt(listOfCoordinates[0])->flags & (HAS_PLAYER | HAS_MONSTER))
                 && !(monsterAtLoc(listOfCoordinates[0].x, listOfCoordinates[0].y)->bookkeepingFlags & MB_SUBMERGED))) {
                 // shooting blink point-blank into an obstruction does nothing.
                 return false;
             }
         theBolt->foreColor = &black;
         theBolt->theChar = shootingMonst->info.displayChar;
-        pmap[originLoc.x][originLoc.y].flags &= ~(HAS_PLAYER | HAS_MONSTER);
+        pmapAt(originLoc)->flags &= ~(HAS_PLAYER | HAS_MONSTER);
         refreshDungeonCell(originLoc.x, originLoc.y);
         blinkDistance = theBolt->magnitude * 2 + 1;
         checkForMissingKeys(originLoc.x, originLoc.y);
@@ -5412,9 +5412,9 @@ boolean moveCursor(boolean *targetConfirmed,
         }
 
         if (sidebarHighlighted
-            && (!(pmap[rogue.cursorLoc.x][rogue.cursorLoc.y].flags & (HAS_PLAYER | HAS_MONSTER))
+            && (!(pmapAt(rogue.cursorLoc)->flags & (HAS_PLAYER | HAS_MONSTER))
                 || !canSeeMonster(monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y)))
-            && (!(pmap[rogue.cursorLoc.x][rogue.cursorLoc.y].flags & HAS_ITEM) || !playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y))
+            && (!(pmapAt(rogue.cursorLoc)->flags & HAS_ITEM) || !playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y))
             && (!cellHasTMFlag(rogue.cursorLoc.x, rogue.cursorLoc.y, TM_LIST_IN_SIDEBAR) || !playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y))) {
 
             // The sidebar is highlighted but the cursor is not on a visible item, monster or terrain. Un-highlight the sidebar.
@@ -5550,7 +5550,7 @@ boolean chooseTarget(pos *returnLoc,
         if (monst != NULL && monst != &player && canSeeMonster(monst)) {
             focusedOnSomething = true;
         } else if (playerCanSeeOrSense(targetLoc.x, targetLoc.y)
-                   && (pmap[targetLoc.x][targetLoc.y].flags & HAS_ITEM) || cellHasTMFlag(targetLoc.x, targetLoc.y, TM_LIST_IN_SIDEBAR)) {
+                   && (pmapAt(targetLoc)->flags & HAS_ITEM) || cellHasTMFlag(targetLoc.x, targetLoc.y, TM_LIST_IN_SIDEBAR)) {
             focusedOnSomething = true;
         } else if (focusedOnSomething) {
             refreshSideBar(-1, -1, false);
@@ -5945,7 +5945,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
     thrower->ticksUntilTurn = thrower->attackSpeed;
 
     if (thrower != &player
-        && (pmap[originLoc.x][originLoc.y].flags & IN_FIELD_OF_VIEW)) {
+        && (pmapAt(originLoc)->flags & IN_FIELD_OF_VIEW)) {
 
         monsterName(buf2, thrower, true);
         itemName(theItem, buf3, false, true, NULL);
@@ -6350,7 +6350,7 @@ boolean playerCancelsBlinking(const pos originLoc, const pos targetLoc, const sh
     getImpactLoc(&impactLoc, originLoc, targetLoc, maxDistance > 0 ? maxDistance : DCOLS, true, &boltCatalog[BOLT_BLINKING]);
     getLocationFlags(impactLoc.x, impactLoc.y, &tFlags, &tmFlags, NULL, true);
     if (maxDistance > 0) {
-        if ((pmap[impactLoc.x][impactLoc.y].flags & DISCOVERED)
+        if ((pmapAt(impactLoc)->flags & DISCOVERED)
             && (tFlags & T_LAVA_INSTA_DEATH)
             && !(tFlags & (T_ENTANGLES | T_AUTO_DESCENT))
             && !(tmFlags & TM_EXTINGUISHES_FIRE)) {
@@ -6522,7 +6522,7 @@ void summonGuardian(item *theItem) {
     monst->creatureState = MONSTER_ALLY;
     monst->ticksUntilTurn = monst->info.attackSpeed + 1; // So they don't move before the player's next turn.
     monst->status[STATUS_LIFESPAN_REMAINING] = monst->maxStatus[STATUS_LIFESPAN_REMAINING] = charmGuardianLifespan(netEnchant(theItem));
-    pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
+    pmapAt(monst->loc)->flags |= HAS_MONSTER;
     fadeInMonster(monst);
 }
 
@@ -7241,7 +7241,7 @@ void drinkPotion(item *theItem) {
                 if (tempItem->category & CAN_BE_DETECTED) {
                     detectMagicOnItem(tempItem);
                     if (itemMagicPolarity(tempItem)) {
-                        pmap[tempItem->loc.x][tempItem->loc.y].flags |= ITEM_DETECTED;
+                        pmapAt(tempItem->loc)->flags |= ITEM_DETECTED;
                         hadEffect = true;
                         refreshDungeonCell(tempItem->loc.x, tempItem->loc.y);
                     }

--- a/src/brogue/Light.c
+++ b/src/brogue/Light.c
@@ -273,7 +273,7 @@ void updateLighting() {
         player.info.foreColor = &playerInvisibleColor;
     } else if (playerInDarkness()) {
         player.info.foreColor = &playerInDarknessColor;
-    } else if (pmap[player.loc.x][player.loc.y].flags & IS_IN_SHADOW) {
+    } else if (pmapAt(player.loc)->flags & IS_IN_SHADOW) {
         player.info.foreColor = &playerInShadowColor;
     } else {
         player.info.foreColor = &playerInLightColor;
@@ -281,9 +281,9 @@ void updateLighting() {
 }
 
 boolean playerInDarkness() {
-    return (tmap[player.loc.x][player.loc.y].light[0] + 10 < minersLightColor.red
-            && tmap[player.loc.x][player.loc.y].light[1] + 10 < minersLightColor.green
-            && tmap[player.loc.x][player.loc.y].light[2] + 10 < minersLightColor.blue);
+    return (tmapAt(player.loc)->light[0] + 10 < minersLightColor.red
+            && tmapAt(player.loc)->light[1] + 10 < minersLightColor.green
+            && tmapAt(player.loc)->light[2] + 10 < minersLightColor.blue);
 }
 
 #define flarePrecision 1000

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -198,7 +198,7 @@ boolean monsterIsHidden(const creature *monst, const creature *observer) {
         // Teammates can always see each other.
         return false;
     }
-    if ((monst->status[STATUS_INVISIBLE] && !pmap[monst->loc.x][monst->loc.y].layers[GAS])) {
+    if ((monst->status[STATUS_INVISIBLE] && !pmapAt(monst->loc)->layers[GAS])) {
         // invisible and not in gas
         return true;
     }
@@ -566,7 +566,7 @@ creature *cloneMonster(creature *monst, boolean announce, boolean placeClone) {
         getQualifyingPathLocNear(&(newMonst->loc.x), &(newMonst->loc.y), monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                  avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
-        pmap[newMonst->loc.x][newMonst->loc.y].flags |= HAS_MONSTER;
+        pmapAt(newMonst->loc)->flags |= HAS_MONSTER;
         refreshDungeonCell(newMonst->loc.x, newMonst->loc.y);
         if (announce && canSeeMonster(newMonst)) {
             monsterName(monstName, newMonst, false);
@@ -696,8 +696,8 @@ boolean spawnMinions(short hordeID, creature *leader, boolean summoned, boolean 
             if (monsterCanSubmergeNow(monst)) {
                 monst->bookkeepingFlags |= MB_SUBMERGED;
             }
-            brogueAssert(!(pmap[monst->loc.x][monst->loc.y].flags & HAS_MONSTER));
-            pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
+            brogueAssert(!(pmapAt(monst->loc)->flags & HAS_MONSTER));
+            pmapAt(monst->loc)->flags |= HAS_MONSTER;
             monst->bookkeepingFlags |= (MB_FOLLOWER | MB_JUST_SUMMONED);
             monst->leader = leader;
             monst->creatureState = leader->creatureState;
@@ -956,7 +956,7 @@ boolean summonMinions(creature *summoner) {
     }
 
     if (summoner->info.abilityFlags & MA_ENTER_SUMMONS) {
-        pmap[summoner->loc.x][summoner->loc.y].flags &= ~HAS_MONSTER;
+        pmapAt(summoner->loc)->flags &= ~HAS_MONSTER;
         removeCreature(monsters, summoner);
     }
 
@@ -1020,7 +1020,7 @@ boolean summonMinions(creature *summoner) {
             demoteMonsterFromLeadership(summoner);
             refreshDungeonCell(summoner->loc.x, summoner->loc.y);
         } else {
-            pmap[summoner->loc.x][summoner->loc.y].flags |= HAS_MONSTER;
+            pmapAt(summoner->loc)->flags |= HAS_MONSTER;
             // TODO: why move to the beginning?
             prependCreature(monsters, summoner);
         }
@@ -1601,7 +1601,7 @@ short awarenessDistance(creature *observer, creature *target) {
     // to guide them, but only as long as the player is within FOV. After that, we switch to wandering
     // and wander toward the last location that we saw the player.
     perceivedDistance = (rogue.scentTurnNumber - scentMap[observer->loc.x][observer->loc.y]); // this value is double the apparent distance
-    if ((target == &player && (pmap[observer->loc.x][observer->loc.y].flags & IN_FIELD_OF_VIEW))
+    if ((target == &player && (pmapAt(observer->loc)->flags & IN_FIELD_OF_VIEW))
         || (target != &player && openPathBetween(observer->loc.x, observer->loc.y, target->loc.x, target->loc.y))) {
 
         perceivedDistance = min(perceivedDistance, scentDistance(observer->loc.x, observer->loc.y, target->loc.x, target->loc.y));
@@ -1641,7 +1641,7 @@ boolean awareOfTarget(creature *observer, creature *target) {
             retval = true;
          }
     } else if (target == &player
-        && !(pmap[observer->loc.x][observer->loc.y].flags & IN_FIELD_OF_VIEW)) {
+        && !(pmapAt(observer->loc)->flags & IN_FIELD_OF_VIEW)) {
         // observer not hunting and player-target not in field of view
         retval = false;
     } else if (perceivedDistance <= awareness) {
@@ -1727,7 +1727,7 @@ void updateMonsterState(creature *monst) {
 
     if ((monst->creatureState == MONSTER_WANDERING)
         && awareOfPlayer
-        && (pmap[player.loc.x][player.loc.y].flags & IN_FIELD_OF_VIEW)) {
+        && (pmapAt(player.loc)->flags & IN_FIELD_OF_VIEW)) {
         // If wandering and you notice the player, start tracking the scent.
         alertMonster(monst);
     } else if (monst->creatureState == MONSTER_SLEEPING) {
@@ -2350,7 +2350,7 @@ boolean fleeingMonsterAwareOfPlayer(creature *monst) {
     if (player.status[STATUS_INVISIBLE]) {
         return (distanceBetween(monst->loc.x, monst->loc.y, player.loc.x, player.loc.y) <= 1);
     } else {
-        return (pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW) ? true : false;
+        return (pmapAt(monst->loc)->flags & IN_FIELD_OF_VIEW) ? true : false;
     }
 }
 
@@ -2483,7 +2483,7 @@ boolean targetEligibleForCombatBuff(creature *caster, creature *target) {
                 handledPlayer = true;
                 if (monstersAreEnemies(&player, enemy)
                     && canSeeMonster(enemy)
-                    && (pmap[enemy->loc.x][enemy->loc.y].flags & IN_FIELD_OF_VIEW)) {
+                    && (pmapAt(enemy->loc)->flags & IN_FIELD_OF_VIEW)) {
 
                     return true;
                 }
@@ -2828,7 +2828,7 @@ boolean resurrectAlly(const short x, const short y) {
         getQualifyingPathLocNear(&monToRaise->loc.x, &monToRaise->loc.y, x, y, true,
                                  (T_PATHING_BLOCKER | T_HARMFUL_TERRAIN), 0,
                                  0, (HAS_PLAYER | HAS_MONSTER), false);
-        pmap[monToRaise->loc.x][monToRaise->loc.y].flags |= HAS_MONSTER;
+        pmapAt(monToRaise->loc)->flags |= HAS_MONSTER;
 
         // Restore health etc.
         monToRaise->bookkeepingFlags &= ~(MB_IS_DYING | MB_ADMINISTRATIVE_DEATH | MB_HAS_DIED | MB_IS_FALLING);
@@ -3575,7 +3575,7 @@ boolean knownToPlayerAsPassableOrSecretDoor(short x, short y) {
 
 void setMonsterLocation(creature *monst, short newX, short newY) {
     unsigned long creatureFlag = (monst == &player ? HAS_PLAYER : HAS_MONSTER);
-    pmap[monst->loc.x][monst->loc.y].flags &= ~creatureFlag;
+    pmapAt(monst->loc)->flags &= ~creatureFlag;
     refreshDungeonCell(monst->loc.x, monst->loc.y);
     monst->turnsSpentStationary = 0;
     monst->loc.x = newX;
@@ -3595,7 +3595,7 @@ void setMonsterLocation(creature *monst, short newX, short newY) {
     if (monst == &player) {
         updateVision(true);
         // get any items at the destination location
-        if (pmap[player.loc.x][player.loc.y].flags & HAS_ITEM) {
+        if (pmapAt(player.loc)->flags & HAS_ITEM) {
             pickUpItemAt(player.loc.x, player.loc.y);
         }
     }
@@ -3719,15 +3719,15 @@ boolean moveMonster(creature *monst, short dx, short dy) {
                 if (canPass(monst, defender)) {
 
                     // swap places
-                    pmap[defender->loc.x][defender->loc.y].flags &= ~HAS_MONSTER;
+                    pmapAt(defender->loc)->flags &= ~HAS_MONSTER;
                     refreshDungeonCell(defender->loc.x, defender->loc.y);
 
-                    pmap[monst->loc.x][monst->loc.y].flags &= ~HAS_MONSTER;
+                    pmapAt(monst->loc)->flags &= ~HAS_MONSTER;
                     refreshDungeonCell(monst->loc.x, monst->loc.y);
 
                     monst->loc.x = newX;
                     monst->loc.y = newY;
-                    pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
+                    pmapAt(monst->loc)->flags |= HAS_MONSTER;
 
                     if (monsterAvoids(defender, x, y)) { // don't want a flying monster to swap a non-flying monster into lava!
                         getQualifyingPathLocNear(&(defender->loc.x), &(defender->loc.y), x, y, true,
@@ -3737,7 +3737,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
                         defender->loc.x = x;
                         defender->loc.y = y;
                     }
-                    pmap[defender->loc.x][defender->loc.y].flags |= HAS_MONSTER;
+                    pmapAt(defender->loc)->flags |= HAS_MONSTER;
 
                     refreshDungeonCell(monst->loc.x, monst->loc.y);
                     refreshDungeonCell(defender->loc.x, defender->loc.y);
@@ -4033,10 +4033,10 @@ void toggleMonsterDormancy(creature *monst) {
         // Add it to the normal list.
         prependCreature(monsters, monst);
 
-        pmap[monst->loc.x][monst->loc.y].flags &= ~HAS_DORMANT_MONSTER;
+        pmapAt(monst->loc)->flags &= ~HAS_DORMANT_MONSTER;
 
         // Does it need a new location?
-        if (pmap[monst->loc.x][monst->loc.y].flags & (HAS_MONSTER | HAS_PLAYER)) { // Occupied!
+        if (pmapAt(monst->loc)->flags & (HAS_MONSTER | HAS_PLAYER)) { // Occupied!
             getQualifyingPathLocNear(
                 &(monst->loc.x),
                 &(monst->loc.y),
@@ -4065,7 +4065,7 @@ void toggleMonsterDormancy(creature *monst) {
         // Don't want it to move before the player has a chance to react.
         monst->ticksUntilTurn = 200;
 
-        pmap[monst->loc.x][monst->loc.y].flags |= HAS_MONSTER;
+        pmapAt(monst->loc)->flags |= HAS_MONSTER;
         monst->bookkeepingFlags &= ~MB_IS_DORMANT;
         fadeInMonster(monst);
         return;
@@ -4076,8 +4076,8 @@ void toggleMonsterDormancy(creature *monst) {
         // Add it to the dormant chain.
         prependCreature(dormantMonsters, monst);
         // Miscellaneous transitional tasks.
-        pmap[monst->loc.x][monst->loc.y].flags &= ~HAS_MONSTER;
-        pmap[monst->loc.x][monst->loc.y].flags |= HAS_DORMANT_MONSTER;
+        pmapAt(monst->loc)->flags &= ~HAS_MONSTER;
+        pmapAt(monst->loc)->flags |= HAS_DORMANT_MONSTER;
         monst->bookkeepingFlags |= MB_IS_DORMANT;
         return;
     }
@@ -4204,8 +4204,8 @@ void monsterDetails(char buf[], creature *monst) {
         // If the monster is trapped in impassible terrain, explain as much.
         sprintf(newText, "%s is trapped %s %s.\n     ",
                 capMonstName,
-                (tileCatalog[pmap[monst->loc.x][monst->loc.y].layers[layerWithFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY)]].mechFlags & TM_STAND_IN_TILE) ? "in" : "on",
-                tileCatalog[pmap[monst->loc.x][monst->loc.y].layers[layerWithFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY)]].description);
+                (tileCatalog[pmapAt(monst->loc)->layers[layerWithFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY)]].mechFlags & TM_STAND_IN_TILE) ? "in" : "on",
+                tileCatalog[pmapAt(monst->loc)->layers[layerWithFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY)]].description);
         strcat(buf, newText);
     }
 

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1101,10 +1101,10 @@ boolean playerMoves(short direction) {
             player.loc.x += nbDirs[direction][0];
             player.loc.y += nbDirs[direction][1];
             pmap[x][y].flags &= ~HAS_PLAYER;
-            pmap[player.loc.x][player.loc.y].flags |= HAS_PLAYER;
-            pmap[player.loc.x][player.loc.y].flags &= ~IS_IN_PATH;
+            pmapAt(player.loc)->flags |= HAS_PLAYER;
+            pmapAt(player.loc)->flags &= ~IS_IN_PATH;
             if (defender && defender->creatureState == MONSTER_ALLY) { // Swap places with ally.
-                pmap[defender->loc.x][defender->loc.y].flags &= ~HAS_MONSTER;
+                pmapAt(defender->loc)->flags &= ~HAS_MONSTER;
                 defender->loc.x = x;
                 defender->loc.y = y;
                 if (monsterAvoids(defender, x, y)) {
@@ -1113,10 +1113,10 @@ boolean playerMoves(short direction) {
                 //getQualifyingLocNear(loc, player.loc.x, player.loc.y, true, NULL, forbiddenFlagsForMonster(&(defender->info)) & ~(T_IS_DF_TRAP | T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES), HAS_MONSTER, false, false);
                 //defender->loc.x = loc[0];
                 //defender->loc.y = loc[1];
-                pmap[defender->loc.x][defender->loc.y].flags |= HAS_MONSTER;
+                pmapAt(defender->loc)->flags |= HAS_MONSTER;
             }
 
-            if (pmap[player.loc.x][player.loc.y].flags & HAS_ITEM) {
+            if (pmapAt(player.loc)->flags & HAS_ITEM) {
                 pickUpItemAt(player.loc.x, player.loc.y);
                 rogue.disturbed = true;
             }
@@ -1574,7 +1574,7 @@ void travel(short x, short y, boolean autoConfirm) {
 
     if (D_WORMHOLING) {
         recordMouseClick(mapToWindowX(x), mapToWindowY(y), true, false);
-        pmap[player.loc.x][player.loc.y].flags &= ~HAS_PLAYER;
+        pmapAt(player.loc)->flags &= ~HAS_PLAYER;
         refreshDungeonCell(player.loc.x, player.loc.y);
         player.loc.x = x;
         player.loc.y = y;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -21,6 +21,9 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+#ifndef ROGUE_H
+#define ROGUE_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -3384,4 +3387,6 @@ extern "C" {
 
 #if defined __cplusplus
 }
+#endif
+
 #endif

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -510,7 +510,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
     rogue.lastTarget = NULL;
 
-    connectingStairsDiscovered = (pmap[rogue.downLoc.x][rogue.downLoc.y].flags & (DISCOVERED | MAGIC_MAPPED) ? true : false);
+    connectingStairsDiscovered = (pmapAt(rogue.downLoc)->flags & (DISCOVERED | MAGIC_MAPPED) ? true : false);
     if (stairDirection == 0) { // fallen
         levels[oldLevelNumber-1].playerExitedVia = (pos){ .x = player.loc.x, .y = player.loc.y };
     }
@@ -780,7 +780,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             loc.x = player.loc.x + nbDirs[dir][0];
             loc.y = player.loc.y + nbDirs[dir][1];
             if (!cellHasTerrainFlag(loc.x, loc.y, T_PATHING_BLOCKER)
-                && !(pmap[loc.x][loc.y].flags & (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE))) {
+                && !(pmapAt(loc)->flags & (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE))) {
                 placedPlayer = true;
             }
         }
@@ -795,7 +795,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     }
     player.loc = loc;
 
-    pmap[player.loc.x][player.loc.y].flags |= HAS_PLAYER;
+    pmapAt(player.loc)->flags |= HAS_PLAYER;
 
     if (connectingStairsDiscovered) {
         for (i = rogue.upLoc.x-1; i <= rogue.upLoc.x + 1; i++) {

--- a/src/brogue/SeedCatalog.c
+++ b/src/brogue/SeedCatalog.c
@@ -78,16 +78,16 @@ static void printSeedCatalogItem(item *theItem, creature *theMonster, boolean is
     }
 
     // vaultNumber
-    if (pmap[theItem->loc.x][theItem->loc.y].machineNumber > 0) {
+    if (pmapAt(theItem->loc)->machineNumber > 0) {
         //not all machines are "vaults" so we need to exclude some.
-        if (pmap[theItem->loc.x][theItem->loc.y].layers[0] != ALTAR_SWITCH
-            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != ALTAR_SWITCH_RETRACTING
-            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != ALTAR_CAGE_RETRACTABLE
-            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != ALTAR_INERT
-            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != AMULET_SWITCH
-            && pmap[theItem->loc.x][theItem->loc.y].layers[0] != FLOOR) {
+        if (pmapAt(theItem->loc)->layers[0] != ALTAR_SWITCH
+            && pmapAt(theItem->loc)->layers[0] != ALTAR_SWITCH_RETRACTING
+            && pmapAt(theItem->loc)->layers[0] != ALTAR_CAGE_RETRACTABLE
+            && pmapAt(theItem->loc)->layers[0] != ALTAR_INERT
+            && pmapAt(theItem->loc)->layers[0] != AMULET_SWITCH
+            && pmapAt(theItem->loc)->layers[0] != FLOOR) {
 
-            sprintf(vaultNumber, isCsvFormat ? "%i" : " (vault %i)", pmap[theItem->loc.x][theItem->loc.y].machineNumber);
+            sprintf(vaultNumber, isCsvFormat ? "%i" : " (vault %i)", pmapAt(theItem->loc)->machineNumber);
         }
     }
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -55,7 +55,7 @@ void updateFlavorText() {
         if (rogue.armor
             && (rogue.armor->flags & ITEM_RUNIC)
             && rogue.armor->enchant2 == A_RESPIRATION
-            && tileCatalog[pmap[player.loc.x][player.loc.y].layers[highestPriorityLayer(player.loc.x, player.loc.y, false)]].flags & T_RESPIRATION_IMMUNITIES) {
+            && tileCatalog[pmapAt(player.loc)->layers[highestPriorityLayer(player.loc.x, player.loc.y, false)]].flags & T_RESPIRATION_IMMUNITIES) {
 
             flavorMessage("A pocket of cool, clean air swirls around you.");
         } else if (player.status[STATUS_LEVITATING]) {
@@ -615,7 +615,7 @@ void updateTelepathy() {
         creature *monst = nextCreature(&it);
         if (monsterRevealed(monst)) {
             getFOVMask(grid, monst->loc.x, monst->loc.y, 2 * FP_FACTOR, T_OBSTRUCTS_VISION, 0, false);
-            pmap[monst->loc.x][monst->loc.y].flags |= TELEPATHIC_VISIBLE;
+            pmapAt(monst->loc)->flags |= TELEPATHIC_VISIBLE;
             discoverCell(monst->loc.x, monst->loc.y);
         }
     }
@@ -623,7 +623,7 @@ void updateTelepathy() {
         creature *monst = nextCreature(&it);
         if (monsterRevealed(monst)) {
             getFOVMask(grid, monst->loc.x, monst->loc.y, 2 * FP_FACTOR, T_OBSTRUCTS_VISION, 0, false);
-            pmap[monst->loc.x][monst->loc.y].flags |= TELEPATHIC_VISIBLE;
+            pmapAt(monst->loc)->flags |= TELEPATHIC_VISIBLE;
             discoverCell(monst->loc.x, monst->loc.y);
         }
     }
@@ -683,7 +683,7 @@ short currentStealthRange() {
             // In darkness, halve, rounded down.
             stealthRange = stealthRange / 2;
         }
-        if (pmap[player.loc.x][player.loc.y].flags & IS_IN_SHADOW) {
+        if (pmapAt(player.loc)->flags & IS_IN_SHADOW) {
             // When not standing in a lit area, halve, rounded down (stacks with darkness halving).
             stealthRange = stealthRange / 2;
         }
@@ -760,7 +760,7 @@ void updateVision(boolean refreshDisplay) {
             }
         }
     }
-    pmap[player.loc.x][player.loc.y].flags |= IN_FIELD_OF_VIEW | VISIBLE;
+    pmapAt(player.loc)->flags |= IN_FIELD_OF_VIEW | VISIBLE;
 
     if (rogue.clairvoyance < 0) {
         discoverCell(player.loc.x, player.loc.y);
@@ -787,13 +787,13 @@ void updateVision(boolean refreshDisplay) {
 
     if (player.status[STATUS_HALLUCINATING] > 0) {
         for (theItem = floorItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
-            if ((pmap[theItem->loc.x][theItem->loc.y].flags & DISCOVERED) && refreshDisplay) {
+            if ((pmapAt(theItem->loc)->flags & DISCOVERED) && refreshDisplay) {
                 refreshDungeonCell(theItem->loc.x, theItem->loc.y);
             }
         }
         for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
             creature *monst = nextCreature(&it);
-            if ((pmap[monst->loc.x][monst->loc.y].flags & DISCOVERED) && refreshDisplay) {
+            if ((pmapAt(monst->loc)->flags & DISCOVERED) && refreshDisplay) {
                 refreshDungeonCell(monst->loc.x, monst->loc.y);
             }
         }
@@ -985,7 +985,7 @@ void playerFalls() {
 
     layer = layerWithFlag(player.loc.x, player.loc.y, T_AUTO_DESCENT);
     if (layer >= 0) {
-        message(tileCatalog[pmap[player.loc.x][player.loc.y].layers[layer]].flavorText, REQUIRE_ACKNOWLEDGMENT);
+        message(tileCatalog[pmapAt(player.loc)->layers[layer]].flavorText, REQUIRE_ACKNOWLEDGMENT);
     } else if (layer == -1) {
         message("You plunge downward!", REQUIRE_ACKNOWLEDGMENT);
     }
@@ -1890,7 +1890,7 @@ void monsterEntersLevel(creature *monst, short n) {
                                  avoidedFlagsForMonster(&(monst->info)), HAS_STAIRS, false);
     }
     if (!pit
-        && (pmap[monst->loc.x][monst->loc.y].flags & (HAS_PLAYER | HAS_MONSTER))
+        && (pmapAt(monst->loc)->flags & (HAS_PLAYER | HAS_MONSTER))
         && !(terrainFlags(monst->loc.x, monst->loc.y) & avoidedFlagsForMonster(&(monst->info)))) {
         // Monsters using the stairs will displace any creatures already located there, to thwart stair-dancing.
         creature *prevMonst = monsterAtLoc(monst->loc.x, monst->loc.y);
@@ -1898,8 +1898,8 @@ void monsterEntersLevel(creature *monst, short n) {
         getQualifyingPathLocNear(&(prevMonst->loc.x), &(prevMonst->loc.y), monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(prevMonst->info)), 0,
                                  avoidedFlagsForMonster(&(prevMonst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS), false);
-        pmap[monst->loc.x][monst->loc.y].flags &= ~(HAS_PLAYER | HAS_MONSTER);
-        pmap[prevMonst->loc.x][prevMonst->loc.y].flags |= (prevMonst == &player ? HAS_PLAYER : HAS_MONSTER);
+        pmapAt(monst->loc)->flags &= ~(HAS_PLAYER | HAS_MONSTER);
+        pmapAt(prevMonst->loc)->flags |= (prevMonst == &player ? HAS_PLAYER : HAS_MONSTER);
         refreshDungeonCell(prevMonst->loc.x, prevMonst->loc.y);
         //DEBUG printf("\nBumped a creature (%s) from (%i, %i) to (%i, %i).", prevMonst->info.monsterName, monst->loc.x, monst->loc.y, prevMonst->loc.x, prevMonst->loc.y);
     }
@@ -2281,10 +2281,10 @@ void playerTurnEnded() {
             }
         }
 
-        if (rogue.awarenessBonus > -30 && !(pmap[player.loc.x][player.loc.y].flags & SEARCHED_FROM_HERE)) {
+        if (rogue.awarenessBonus > -30 && !(pmapAt(player.loc)->flags & SEARCHED_FROM_HERE)) {
             // Low-grade auto-search wherever you step, but only once per tile.
             search(rogue.awarenessBonus + 30);
-            pmap[player.loc.x][player.loc.y].flags |= SEARCHED_FROM_HERE;
+            pmapAt(player.loc)->flags |= SEARCHED_FROM_HERE;
         }
         if (!rogue.justSearched && player.status[STATUS_SEARCHING] > 0) {
             // Searching only "charges up" when done on consecutive turns
@@ -2349,7 +2349,7 @@ void playerTurnEnded() {
 
         for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
             creature *monst = nextCreature(&it);
-            if (D_SAFETY_VISION || monst->creatureState == MONSTER_FLEEING && pmap[monst->loc.x][monst->loc.y].flags & IN_FIELD_OF_VIEW) {
+            if (D_SAFETY_VISION || monst->creatureState == MONSTER_FLEEING && pmapAt(monst->loc)->flags & IN_FIELD_OF_VIEW) {
                 updateSafetyMap(); // only if there is a fleeing monster who can see the player
                 break;
             }

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -380,7 +380,7 @@ static void dialogCreateMonster() {
         if (!playerCanSeeOrSense(selectedPosition.x, selectedPosition.y)) {
             locationIsValid = false;
         }
-        if (theMonster->info.displayChar == G_TURRET && (!(pmap[selectedPosition.x][selectedPosition.y].layers[DUNGEON] == WALL))) {
+        if (theMonster->info.displayChar == G_TURRET && (!(pmapAt(selectedPosition)->layers[DUNGEON] == WALL))) {
             locationIsValid = false;
         }
         if (!(theMonster->info.displayChar == G_TURRET) && cellHasTerrainFlag(selectedPosition.x, selectedPosition.y, T_OBSTRUCTS_PASSABILITY)) {
@@ -403,7 +403,7 @@ static void dialogCreateMonster() {
         }
 
         theMonster->loc = selectedPosition;
-        pmap[theMonster->loc.x][theMonster->loc.y].flags |= HAS_MONSTER;
+        pmapAt(theMonster->loc)->flags |= HAS_MONSTER;
         theMonster->creatureState = MONSTER_WANDERING;
         fadeInMonster(theMonster);
         refreshSideBar(-1, -1, false);


### PR DESCRIPTION
In previous PRs, the `pos` type helps organize coordinate info, but the most common operation that's done with coordinates are looking them up in the global `pmap`. And manually writing out

```c
pmap[loc.x][loc.y].flag |= ...
```

is tedious and error-prone if `loc` is anything more than a short variable name, since you need to repeat it twice with `.x` and then `.y`. This PR adds a new global helper function `pmapAt` that returns a pointer, allowing the above to be written as

```c
pmapAt(loc)->flag |=
```

it returns a pointer because it's a "real" function instead of a macro - this adds a little bit of extra friction, but saves all the headache of dealing with a new macro.

This function is declared as `static inline`  in the header - the compiler will therefore not complain about multiple definitions _and_ it won't complain about it being unused. Since it's small (and not really because of the `inline` declaration) the compiler is very likely to inline it and thus this has "zero cost" - it should be as fast as the manual expansion in essentially all cases.

---

To make this work, there's a small technical change: `IncludeGlobals.h` now `#include "Rogue.h"`, which previously wasn't happening. But this causes `Rogue.h` to be included twice in various files. The fix is to add "include guards" around all of `Rogue.h`, which I've done in this PR. It's a small change but it makes it possible to include the header wherever it's needed.

---

All of the code rewrites were performed by a find+replace with some regex patterns, so there shouldn't be any "dumb" mistakes like typos that changed out variable names.

There was one false positive that I manually removed, in `SeedCatalog.c`:

```c
    // opensVaultNumber
    if (theItem->category == KEY && theItem->kind == KEY_DOOR) {
        sprintf(opensVaultNumber, isCsvFormat ? "%i" : " (opens vault %i)",
                pmap[theItem->keyLoc[0].x][theItem->keyLoc[0].y].machineNumber - 1);
    }
```

in this example, `keyLoc[0]` is not a `pos`, it's a different type that has `x` and `y` fields. That should probably be fixed but it's not in this PR.