### PR TITLE
fix declaration of 'armorValueIfUnenchanted' to include args

### DIFF
--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3173,7 +3173,7 @@ extern "C" {
     item *makeItemInto(item *theItem, unsigned long itemCategory, short itemKind);
     void updateEncumbrance();
     short displayedArmorValue();
-    short armorValueIfUnenchanted();
+    short armorValueIfUnenchanted(item *theItem);
     void strengthCheck(item *theItem, boolean noisy);
     void recalculateEquipmentBonuses();
     boolean equipItem(item *theItem, boolean force, item *unequipHint);


### PR DESCRIPTION
A C89 (and through later standards up to C23) function declaration with empty arguments `()` actually means "any arguments" and not "no arguments". So the compiler doesn't complain about this as loudly as it should. The "right" spelling to specify that no arguments are taken is `(void)`.

This is the only function in the codebase which has this problem. It's an easy mistake to make (and to fix).

There aren't any immediate problems, so this isn't fixing any real issues. You just lose some static type-checking ability if the function were called from another file.