### PR TITLE
Use `pos` type for `distanceBetween` & `splitMonster`

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -37,7 +37,7 @@ boolean checkLoopiness(short x, short y) {
     short newX, newY, dir, sdir;
     short numStrings, maxStringLength, currentStringLength;
 
-    if (!(pmapAt((pos){x, y})->flags & IN_LOOP)) {
+    if (!(pmap[x][y].flags & IN_LOOP)) {
         return false;
     }
 

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -34,11 +34,10 @@ boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask) {
 #endif
 
 boolean checkLoopiness(short x, short y) {
-    boolean inString;
     short newX, newY, dir, sdir;
     short numStrings, maxStringLength, currentStringLength;
 
-    if (!(pmap[x][y].flags & IN_LOOP)) {
+    if (!(pmapAt((pos){x, y})->flags & IN_LOOP)) {
         return false;
     }
 
@@ -58,7 +57,7 @@ boolean checkLoopiness(short x, short y) {
     // starting on this unloopy neighbor, work clockwise and count up (a) the number of strings
     // of loopy neighbors, and (b) the length of the longest such string.
     numStrings = maxStringLength = currentStringLength = 0;
-    inString = false;
+    boolean inString = false;
     for (dir = sdir; dir < sdir + 8; dir++) {
         newX = x + cDirs[dir % 8][0];
         newY = y + cDirs[dir % 8][1];
@@ -2214,7 +2213,7 @@ void attachHallwayTo(short **grid, pos doorSites[4]) {
             || !coordinatesAreInMap(newX, newY)
             || grid[newX][newY]) {
 
-            doorSites[dir2] = (pos){ .x = -1, .y = -1 };
+            doorSites[dir2] = INVALID_POS;
         } else {
             doorSites[dir2] = (pos){ .x = newX, .y = newY };
         }

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -344,7 +344,7 @@ void moralAttack(creature *attacker, creature *defender) {
         }
 
         if ((defender->info.abilityFlags & MA_CLONE_SELF_ON_DEFEND) && alliedCloneCount(defender) < 100) {
-            if (distanceBetween(defender->loc.x, defender->loc.y, attacker->loc.x, attacker->loc.y) <= 1) {
+            if (distanceBetween(defender->loc, attacker->loc) <= 1) {
                 splitMonster(defender, attacker->loc);
             } else {
                 splitMonster(defender, INVALID_POS);
@@ -508,8 +508,8 @@ boolean forceWeaponHit(creature *defender, item *theItem) {
     theBolt.magnitude = max(1, netEnchant(theItem) / FP_FACTOR);
     zap(oldLoc, newLoc, &theBolt, false, false);
     if (!(defender->bookkeepingFlags & MB_IS_DYING)
-        && distanceBetween(oldLoc.x, oldLoc.y, defender->loc.x, defender->loc.y) > 0
-        && distanceBetween(oldLoc.x, oldLoc.y, defender->loc.x, defender->loc.y) < weaponForceDistance(netEnchant(theItem))) {
+        && distanceBetween(oldLoc, defender->loc) > 0
+        && distanceBetween(oldLoc, defender->loc) < weaponForceDistance(netEnchant(theItem))) {
 
         if (pmap[defender->loc.x + newLoc.x - oldLoc.x][defender->loc.y + newLoc.y - oldLoc.y].flags & (HAS_MONSTER | HAS_PLAYER)) {
             otherMonster = monsterAtLoc(defender->loc.x + newLoc.x - oldLoc.x, defender->loc.y + newLoc.y - oldLoc.y);
@@ -519,7 +519,7 @@ boolean forceWeaponHit(creature *defender, item *theItem) {
             strcpy(buf2, tileCatalog[pmap[defender->loc.x + newLoc.x - oldLoc.x][defender->loc.y + newLoc.y - oldLoc.y].layers[highestPriorityLayer(defender->loc.x + newLoc.x - oldLoc.x, defender->loc.y + newLoc.y - oldLoc.y, true)]].description);
         }
 
-        forceDamage = distanceBetween(oldLoc.x, oldLoc.y, defender->loc.x, defender->loc.y);
+        forceDamage = distanceBetween(oldLoc, defender->loc);
 
         if (!(defender->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))
             && inflictDamage(NULL, defender, forceDamage, &white, false)) {
@@ -1059,7 +1059,7 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
 
     if ((attacker->info.abilityFlags & MA_SEIZES)
         && (!(attacker->bookkeepingFlags & MB_SEIZING) || !(defender->bookkeepingFlags & MB_SEIZED))
-        && (distanceBetween(attacker->loc.x, attacker->loc.y, defender->loc.x, defender->loc.y) == 1
+        && (distanceBetween(attacker->loc, defender->loc) == 1
             && !diagonalBlocked(attacker->loc.x, attacker->loc.y, defender->loc.x, defender->loc.y, false))) {
 
         attacker->bookkeepingFlags |= MB_SEIZING;

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -107,7 +107,7 @@ void hideCursor() {
 
 void showCursor() {
     // Return or enter turns on cursor mode. When the path is hidden, move the cursor to the player.
-    if (!coordinatesAreInMap(rogue.cursorLoc.x, rogue.cursorLoc.y)) {
+    if (!isPosInMap(rogue.cursorLoc)) {
         rogue.cursorLoc = player.loc;
         rogue.cursorMode = true;
         rogue.cursorPathIntensity = (rogue.cursorMode ? 50 : 20);
@@ -635,7 +635,7 @@ void mainInputLoop() {
                 if (coordinatesAreInMap(oldTargetLoc[0], oldTargetLoc[1])) {
                     hilitePath(path, steps, true);                                  // Unhilite old path.
                 }
-                if (coordinatesAreInMap(rogue.cursorLoc.x, rogue.cursorLoc.y)) {
+                if (isPosInMap(rogue.cursorLoc)) {
                     if (cursorSnapMap[rogue.cursorLoc.x][rogue.cursorLoc.y] >= 0
                         && cursorSnapMap[rogue.cursorLoc.x][rogue.cursorLoc.y] < 30000) {
 
@@ -672,7 +672,7 @@ void mainInputLoop() {
                 }
             }
 
-            if (coordinatesAreInMap(rogue.cursorLoc.x, rogue.cursorLoc.y)) {
+            if (isPosInMap(rogue.cursorLoc)) {
                 hiliteCell(rogue.cursorLoc.x,
                            rogue.cursorLoc.y,
                            &white,
@@ -790,7 +790,7 @@ void mainInputLoop() {
         if (canceled && !playingBack) {
             hideCursor();
             confirmMessages();
-        } else if (targetConfirmed && !playingBack && coordinatesAreInMap(rogue.cursorLoc.x, rogue.cursorLoc.y)) {
+        } else if (targetConfirmed && !playingBack && isPosInMap(rogue.cursorLoc)) {
             if (theEvent.eventType == MOUSE_UP
                 && theEvent.controlKey
                 && steps > 1) {

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -102,7 +102,7 @@ void hideCursor() {
     // Drop out of cursor mode if we're in it, and hide the path either way.
     rogue.cursorMode = false;
     rogue.cursorPathIntensity = (rogue.cursorMode ? 50 : 20);
-    rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+    rogue.cursorLoc = INVALID_POS;
 }
 
 void showCursor() {
@@ -584,7 +584,7 @@ void mainInputLoop() {
     playerPathingMap = allocGrid();
     cursorSnapMap = allocGrid();
 
-    rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+    rogue.cursorLoc = INVALID_POS;
 
     while (!rogue.gameHasEnded && (!playingBack || !canceled)) { // repeats until the game ends
 
@@ -611,7 +611,7 @@ void mainInputLoop() {
             // Path hides when you reach your destination.
             rogue.cursorMode = false;
             rogue.cursorPathIntensity = (rogue.cursorMode ? 50 : 20);
-            rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+            rogue.cursorLoc = INVALID_POS;
         }
 
         oldTargetLoc[0] = rogue.cursorLoc.x;

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -678,7 +678,7 @@ void mainInputLoop() {
                            &white,
                            (steps <= 0
                             || (path[steps-1][0] == rogue.cursorLoc.x && path[steps-1][1] == rogue.cursorLoc.y)
-                            || (!playingBack && distanceBetween(player.loc.x, player.loc.y, rogue.cursorLoc.x, rogue.cursorLoc.y) <= 1) ? 100 : 25),
+                            || (!playingBack && distanceBetween(player.loc, rogue.cursorLoc) <= 1) ? 100 : 25),
                            true);
 
                 oldTargetLoc[0] = rogue.cursorLoc.x;
@@ -808,7 +808,7 @@ void mainInputLoop() {
 
                     confirmMessages();
                 } else if (abs(player.loc.x - rogue.cursorLoc.x) + abs(player.loc.y - rogue.cursorLoc.y) == 1 // horizontal or vertical
-                           || (distanceBetween(player.loc.x, player.loc.y, rogue.cursorLoc.x, rogue.cursorLoc.y) == 1 // includes diagonals
+                           || (distanceBetween(player.loc, rogue.cursorLoc) == 1 // includes diagonals
                                && (!diagonalBlocked(player.loc.x, player.loc.y, rogue.cursorLoc.x, rogue.cursorLoc.y, !rogue.playbackOmniscience)
                                    || ((pmapAt(rogue.cursorLoc)->flags & HAS_MONSTER) && (monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y)->info.flags & MONST_ATTACKABLE_THRU_WALLS)) // there's a turret there
                                    || ((terrainFlags(rogue.cursorLoc.x, rogue.cursorLoc.y) & T_OBSTRUCTS_PASSABILITY) && (terrainMechFlags(rogue.cursorLoc.x, rogue.cursorLoc.y) & TM_PROMOTES_ON_PLAYER_ENTRY))))) { // there's a lever there

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4275,7 +4275,7 @@ void beckonMonster(creature *monst, short x, short y) {
     }
     pos from = monst->loc;
     pos to = (pos){ .x = x, .y = y };
-    theBolt.magnitude = max(1, (distanceBetween(x, y, monst->loc.x, monst->loc.y) - 2) / 2);
+    theBolt.magnitude = max(1, (distanceBetween((pos){x, y}, monst->loc) - 2) / 2);
     zap(from, to, &theBolt, false, true);
     if (monst->ticksUntilTurn < player.attackSpeed+1) {
         monst->ticksUntilTurn = player.attackSpeed+1;
@@ -4414,7 +4414,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
             case BE_BECKONING:
                 if (!(monst->info.flags & MONST_IMMOBILE)
                     && caster
-                    && distanceBetween(caster->loc.x, caster->loc.y, monst->loc.x, monst->loc.y) > 1) {
+                    && distanceBetween(caster->loc, monst->loc) > 1) {
 
                     if (canSeeMonster(monst) && autoID) {
                         *autoID = true;
@@ -5523,7 +5523,7 @@ boolean chooseTarget(pos *returnLoc,
         numCells = min(numCells, maxDistance);
     }
     if (stopAtTarget) {
-        numCells = min(numCells, distanceBetween(player.loc.x, player.loc.y, targetLoc.x, targetLoc.y));
+        numCells = min(numCells, distanceBetween(player.loc, targetLoc));
     }
 
     targetConfirmed = canceled = tabKey = false;
@@ -5570,7 +5570,7 @@ boolean chooseTarget(pos *returnLoc,
             }
 
             if (stopAtTarget) {
-                numCells = min(numCells, distanceBetween(player.loc.x, player.loc.y, targetLoc.x, targetLoc.y));
+                numCells = min(numCells, distanceBetween(player.loc, targetLoc));
             }
             distance = hiliteTrajectory(coordinates, numCells, false, theBolt, &trajColor);
             cursorInTrajectory = false;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3379,7 +3379,7 @@ short getLineCoordinates(pos listOfCoordinates[], const pos originLoc, const pos
                 .x = (point[0] < 0 ? -1 : point[0] / FP_FACTOR),
                 .y = (point[1] < 0 ? -1 : point[1] / FP_FACTOR)
             };
-            if (!coordinatesAreInMap(listOfCoordinates[listLength].x, listOfCoordinates[listLength].y)) break;
+            if (!isPosInMap(listOfCoordinates[listLength])) break;
             listLength++;
         };
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3349,7 +3349,7 @@ short getLineCoordinates(pos listOfCoordinates[], const pos originLoc, const pos
         {50,  1}, {99, 50}, {50, 99}, { 1, 50} };
 
     if (originLoc.x == targetLoc.x && originLoc.y == targetLoc.y) {
-        listOfCoordinates[0] = (pos){ .x = -1, .y = -1 };
+        listOfCoordinates[0] = INVALID_POS;
         return 0;
     }
 
@@ -3476,7 +3476,7 @@ short getLineCoordinates(pos listOfCoordinates[], const pos originLoc, const pos
     }
 
     // demarcate the end of the list
-    listOfCoordinates[listLength] = (pos){ .x = -1, .y = -1 };
+    listOfCoordinates[listLength] = INVALID_POS;
 
     return listLength;
 }
@@ -4250,7 +4250,7 @@ short reflectBolt(short targetX, short targetY, pos listOfCoordinates[], short k
         finalLength = kinkCell + newPathLength + 1;
     }
 
-    listOfCoordinates[finalLength] = (pos){ .x = -1, .y = -1 };
+    listOfCoordinates[finalLength] = INVALID_POS;
     return finalLength;
 }
 
@@ -5489,7 +5489,7 @@ boolean chooseTarget(pos *returnLoc,
     if (rogue.playbackMode) {
         // In playback, pull the next event (a mouseclick) and use that location as the target.
         *returnLoc = pullMouseClickDuringPlayback();
-        rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+        rogue.cursorLoc = INVALID_POS;
         return true;
     }
 
@@ -5535,7 +5535,7 @@ boolean chooseTarget(pos *returnLoc,
             refreshDungeonCell(oldTargetLoc.x, oldTargetLoc.y);
             hiliteTrajectory(coordinates, numCells, true, theBolt, trajectoryColor);
             confirmMessages();
-            rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+            rogue.cursorLoc = INVALID_POS;
             restoreRNG;
             return false;
         }
@@ -5598,7 +5598,7 @@ boolean chooseTarget(pos *returnLoc,
     if (originLoc.x == targetLoc.x && originLoc.y == targetLoc.y) {
         confirmMessages();
         restoreRNG;
-        rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+        rogue.cursorLoc = INVALID_POS;
         return false;
     }
 
@@ -5609,7 +5609,7 @@ boolean chooseTarget(pos *returnLoc,
 
     *returnLoc = targetLoc;
     restoreRNG;
-    rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+    rogue.cursorLoc = INVALID_POS;
     return true;
 }
 

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1645,7 +1645,7 @@ void travel(short x, short y, boolean autoConfirm) {
 //          rogue.cursorLoc.y = y;
 //      }
     } else {
-        rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+        rogue.cursorLoc = INVALID_POS;
         message("No path is available.", 0);
     }
     freeGrid(distanceMap);
@@ -2153,7 +2153,7 @@ boolean useStairs(short stairDirection) {
     if (stairDirection == 1) {
         if (rogue.depthLevel < DEEPEST_LEVEL) {
             //copyDisplayBuffer(fromBuf, displayBuffer);
-            rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+            rogue.cursorLoc = INVALID_POS;
             rogue.depthLevel++;
             message("You descend.", 0);
             startLevel(rogue.depthLevel - 1, stairDirection);
@@ -2172,7 +2172,7 @@ boolean useStairs(short stairDirection) {
         succeeded = true;
     } else {
         if (rogue.depthLevel > 1 || numberOfMatchingPackItems(AMULET, 0, 0, false)) {
-            rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+            rogue.cursorLoc = INVALID_POS;
             rogue.depthLevel--;
             if (rogue.depthLevel == 0) {
                 victory(false);

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -724,8 +724,8 @@ void buildFlailHitList(const short x, const short y, const short newX, const sho
         creature *monst = nextCreature(&it);
         mx = monst->loc.x;
         my = monst->loc.y;
-        if (distanceBetween(x, y, mx, my) == 1
-            && distanceBetween(newX, newY, mx, my) == 1
+        if (distanceBetween((pos){x, y}, (pos){mx, my}) == 1
+            && distanceBetween((pos){newX, newY}, (pos){mx, my}) == 1
             && canSeeMonster(monst)
             && monstersAreEnemies(&player, monst)
             && monst->creatureState != MONSTER_ALLY
@@ -939,7 +939,7 @@ boolean playerMoves(short direction) {
                 creature *tempMonst = nextCreature(&it);
                 if ((tempMonst->bookkeepingFlags & MB_SEIZING)
                     && monstersAreEnemies(&player, tempMonst)
-                    && distanceBetween(player.loc.x, player.loc.y, tempMonst->loc.x, tempMonst->loc.y) == 1
+                    && distanceBetween(player.loc, tempMonst->loc) == 1
                     && !diagonalBlocked(player.loc.x, player.loc.y, tempMonst->loc.x, tempMonst->loc.y, false)
                     && !tempMonst->status[STATUS_ENTRANCED]) {
 
@@ -1725,7 +1725,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
             if ((tFlags & T_LAVA_INSTA_DEATH)
                 && !(monst->info.flags & (MONST_IMMUNE_TO_FIRE | MONST_FLIES | MONST_INVULNERABLE))
                 && (monst->status[STATUS_LEVITATING] || monst->status[STATUS_IMMUNE_TO_FIRE])
-                && max(monst->status[STATUS_LEVITATING], monst->status[STATUS_IMMUNE_TO_FIRE]) < (rogue.mapToShore[i][j] + distanceBetween(i, j, monst->loc.x, monst->loc.y) * monst->movementSpeed / 100)) {
+                && max(monst->status[STATUS_LEVITATING], monst->status[STATUS_IMMUNE_TO_FIRE]) < (rogue.mapToShore[i][j] + distanceBetween((pos){i, j}, monst->loc) * monst->movementSpeed / 100)) {
                 // Only a temporary effect will permit the monster to survive the lava, and the remaining duration either isn't
                 // enough to get it to the spot, or it won't suffice to let it return to shore if it does get there.
                 // Treat these locations as obstacles.
@@ -1736,7 +1736,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
             if (((tFlags & T_AUTO_DESCENT) || (tFlags & T_IS_DEEP_WATER) && !(monst->info.flags & MONST_IMMUNE_TO_WATER))
                 && !(monst->info.flags & MONST_FLIES)
                 && (monst->status[STATUS_LEVITATING])
-                && monst->status[STATUS_LEVITATING] < (rogue.mapToShore[i][j] + distanceBetween(i, j, monst->loc.x, monst->loc.y) * monst->movementSpeed / 100)) {
+                && monst->status[STATUS_LEVITATING] < (rogue.mapToShore[i][j] + distanceBetween((pos){i, j}, monst->loc) * monst->movementSpeed / 100)) {
                 // Only a temporary effect will permit the monster to levitate over the chasm/water, and the remaining duration either isn't
                 // enough to get it to the spot, or it won't suffice to let it return to shore if it does get there.
                 // Treat these locations as obstacles.
@@ -2109,7 +2109,7 @@ boolean search(short searchStrength) {
             if (coordinatesAreInMap(i, j)
                 && playerCanDirectlySee(i, j)) {
 
-                percent = searchStrength - distanceBetween(x, y, i, j) * 10;
+                percent = searchStrength - distanceBetween((pos){x, y}, (pos){i, j}) * 10;
                 if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)) {
                     percent = percent * 2/3;
                 }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1270,6 +1270,10 @@ boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask);
 
 #define coordinatesAreInMap(x, y)           ((x) >= 0 && (x) < DCOLS    && (y) >= 0 && (y) < DROWS)
 
+inline static boolean isPosInMap(pos p) {
+    return p.x >= 0 && p.x < DCOLS && p.y >= 0 && p.y < DROWS;
+}
+
 inline static boolean locIsInWindow(windowpos w) {
     return w.window_x >= 0 && w.window_x < COLS && w.window_y >= 0 && w.window_y < ROWS;
 }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3093,7 +3093,7 @@ extern "C" {
     unsigned long burnedTerrainFlagsAtLoc(short x, short y);
     unsigned long discoveredTerrainFlagsAtLoc(short x, short y);
     boolean monsterAvoids(creature *monst, short x, short y);
-    short distanceBetween(short x1, short y1, short x2, short y2);
+    short distanceBetween(pos loc1, pos loc2);
     void alertMonster(creature *monst);
     void wakeUp(creature *monst);
     boolean monsterRevealed(creature *monst);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -153,6 +153,8 @@ typedef struct pos {
     short y;
 } pos;
 
+#define INVALID_POS ((pos) { .x = -1, .y = -1 })
+
 // A location within the window.
 // Convert between `windowpos` and `pos` with `mapToWindow` and
 // `windowToMap`

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -344,7 +344,7 @@ void initializeRogue(uint64_t seed) {
     rogue.monsterSpawnFuse = rand_range(125, 175);
     rogue.ticksTillUpdateEnvironment = 100;
     rogue.mapToShore = NULL;
-    rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+    rogue.cursorLoc = INVALID_POS;
     rogue.xpxpThisTurn = 0;
 
     rogue.yendorWarden = NULL;
@@ -511,7 +511,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     rogue.updatedAllySafetyMapThisTurn      = false;
     rogue.updatedMapToSafeTerrainThisTurn   = false;
 
-    rogue.cursorLoc = (pos) { .x = -1, .y = -1 };
+    rogue.cursorLoc = INVALID_POS;
     rogue.lastTarget = NULL;
 
     connectingStairsDiscovered = (pmapAt(rogue.downLoc)->flags & (DISCOVERED | MAGIC_MAPPED) ? true : false);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -215,8 +215,7 @@ void initializeRogue(uint64_t seed) {
         do {
             levels[i].downStairsLoc.x = rand_range(1, DCOLS - 2);
             levels[i].downStairsLoc.y = rand_range(1, DROWS - 2);
-        } while (distanceBetween(levels[i].upStairsLoc.x, levels[i].upStairsLoc.y,
-                                 levels[i].downStairsLoc.x, levels[i].downStairsLoc.y) < DCOLS / 3);
+        } while (distanceBetween(levels[i].upStairsLoc, levels[i].downStairsLoc) < DCOLS / 3);
         if (i < DEEPEST_LEVEL) {
             levels[i+1].upStairsLoc.x = levels[i].downStairsLoc.x;
             levels[i+1].upStairsLoc.y = levels[i].downStairsLoc.y;


### PR DESCRIPTION
This PR is a minor refactoring that improves some type-safety by allowing more use of `pos` instead of individual coordinates. It only adds net 3 lines of code but deletes a lot of repeated variable references.

- a new `INVALID_POS` constant is just `(pos){.x = -1, .y = -1}`, which gets used throughout the codebase
- `isPosInMap` is a new predicate, behaving like `coordinatesAreInMap` but for the `pos` type
- `splitMonster` now accepts a `pos` instead of `short x, short y`
- `distanceBetween` now accepts two `pos` args instead of 4 shorts
  - Almost every single call to `distanceBetween` already had at least one `pos` argument, and most of them had 2
