### PR TITLE
Reduce duration of delays when the game is running slowly

### DIFF
--- a/changes/autoexplore-delay.md
+++ b/changes/autoexplore-delay.md
@@ -1,1 +1,1 @@
-When the game is running slowly, autoexplore and similar actions don't delay as much, to try to compensate.
+Animations such as autoexplore and using a staff now run at the same speed regardless of game performance (up to a limit).

--- a/changes/autoexplore-delay.md
+++ b/changes/autoexplore-delay.md
@@ -1,0 +1,1 @@
+When the game is running slowly, autoexplore and similar actions don't delay as much, to try to compensate.

--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -113,9 +113,24 @@ static uint64_t getTime() {
     return (uint64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
 }
 
+static long lastDelayTime = 0;
+
+// Like SDL_Delay, but reduces the delay if time has passed since the last delay
+static void _delayUpTo(short ms) {
+    long curTime = getTime();
+    long timeDiff = curTime - lastDelayTime;
+    ms -= timeDiff;
+
+    if (ms > 0) {
+        Term.wait(ms);
+    } // else delaying further would go past the time we want to delay until
+
+    lastDelayTime = getTime();
+}
+
 static boolean curses_pauseForMilliseconds(short milliseconds) {
     Term.refresh();
-    Term.wait(milliseconds);
+    _delayUpTo(milliseconds);
 
     // hasKey returns true if we have a mouse event, too.
     return Term.hasKey();
@@ -124,14 +139,11 @@ static boolean curses_pauseForMilliseconds(short milliseconds) {
 static void curses_nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance) {
     int key;
     // TCOD_mouse_t mouse;
-    uint64_t theTime, waitTime;
     // short x, y;
 
     Term.refresh();
 
     for (;;) {
-        theTime = getTime(); //TCOD_sys_elapsed_milli();
-
         /*if (TCOD_console_is_window_closed()) {
             rogue.gameHasEnded = true; // causes the game loop to terminate quickly
             returnEvent->eventType = KEYSTROKE;
@@ -188,11 +200,7 @@ static void curses_nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInpu
             return;
         }
 
-        waitTime = PAUSE_BETWEEN_EVENT_POLLING + theTime - getTime();
-
-        if (waitTime > 0 && waitTime <= PAUSE_BETWEEN_EVENT_POLLING) {
-            curses_pauseForMilliseconds(waitTime);
-        }
+        _delayUpTo(PAUSE_BETWEEN_EVENT_POLLING);
     }
 }
 


### PR DESCRIPTION
This makes autoexplore and similar actions feel much faster when the game is lagging due to e.g. a staff of conjuration, and the game feels a bit faster even when not lagging. It also reduces delays slightly in all cases, so e.g. the main menu animation runs ~5-10% faster, to match the 50ms delay it's apparently supposed to have.

This only affects the SDL version.