### PR TITLE
Use pos type for creature variables

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1345,7 +1345,7 @@ boolean canAbsorb(creature *ally, boolean ourBolts[NUMBER_BOLT_KINDS], creature 
 
     if (ally->creatureState == MONSTER_ALLY
         && ally->newPowerCount > 0
-        && (ally->targetCorpseLoc[0] <= 0)
+        && (!isPosInMap(ally->targetCorpseLoc))
         && !((ally->info.flags | prey->info.flags) & (MONST_INANIMATE | MONST_IMMOBILE))
         && !monsterAvoids(ally, prey->loc.x, prey->loc.y)
         && grid[ally->loc.x][ally->loc.y] <= 10) {
@@ -1412,8 +1412,7 @@ boolean anyoneWantABite(creature *decedent) {
             }
         }
         if (firstAlly) {
-            firstAlly->targetCorpseLoc[0] = decedent->loc.x;
-            firstAlly->targetCorpseLoc[1] = decedent->loc.y;
+            firstAlly->targetCorpseLoc = decedent->loc;
             strcpy(firstAlly->targetCorpseName, decedent->info.monsterName);
             firstAlly->corpseAbsorptionCounter = 20; // 20 turns to get there and start eating before he loses interest
 

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4737,7 +4737,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                 printProgressBar(0, y++, statusStrings[i], monst->status[i], monst->maxStatus[i], &redBar, dim);
             }
         }
-        if (monst->targetCorpseLoc[0] == monst->loc.x && monst->targetCorpseLoc[1] == monst->loc.y) {
+        if (posEq(monst->targetCorpseLoc, monst->loc)) {
             printProgressBar(0, y++,  monsterText[monst->info.monsterID].absorbStatus, monst->corpseAbsorptionCounter, 20, &redBar, dim);
         }
     }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -155,6 +155,10 @@ typedef struct pos {
 
 #define INVALID_POS ((pos) { .x = -1, .y = -1 })
 
+static inline boolean posEq(pos a, pos b) {
+    return a.x == b.x && a.y == b.y;
+}
+
 // A location within the window.
 // Convert between `windowpos` and `pos` with `mapToWindow` and
 // `windowToMap`
@@ -2262,9 +2266,9 @@ typedef struct creature {
     // Waypoints:
     short targetWaypointIndex;          // the index number of the waypoint we're pathing toward
     boolean waypointAlreadyVisited[MAX_WAYPOINT_COUNT]; // checklist of waypoints
-    short lastSeenPlayerAt[2];          // last location at which the monster hunted the player
+    pos lastSeenPlayerAt;          // last location at which the monster hunted the player
 
-    short targetCorpseLoc[2];           // location of the corpse that the monster is approaching to gain its abilities
+    pos targetCorpseLoc;           // location of the corpse that the monster is approaching to gain its abilities
     char targetCorpseName[30];          // name of the deceased monster that we're approaching to gain its abilities
     unsigned long absorptionFlags;      // ability/behavior flags that the monster will gain when absorption is complete
     boolean absorbBehavior;             // above flag is behavior instead of ability (ignored if absorptionBolt is set)

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1382,7 +1382,7 @@ void monstersFall() {
                 monst->status[STATUS_ENTRANCED] = 0;
                 monst->bookkeepingFlags |= MB_PREPLACED;
                 monst->bookkeepingFlags &= ~(MB_IS_FALLING | MB_SEIZED | MB_SEIZING);
-                monst->targetCorpseLoc[0] = monst->targetCorpseLoc[1] = 0;
+                monst->targetCorpseLoc = INVALID_POS;
 
                 // remove from monster chain
                 removeCreature(monsters, monst);
@@ -1882,7 +1882,7 @@ void monsterEntersLevel(creature *monst, short n) {
         brogueAssert(false);
     }
     monst->depth = rogue.depthLevel;
-    monst->targetCorpseLoc[0] = monst->targetCorpseLoc[1] = 0;
+    monst->targetCorpseLoc = INVALID_POS;
 
     if (!pit) {
         getQualifyingPathLocNear(&(monst->loc.x), &(monst->loc.y), monst->loc.x, monst->loc.y, true,


### PR DESCRIPTION
There were a few leftover creature variables `lastSeenPlayerAt` and `targetCorpseLoc` which were tracked as `short[2]` instead of `pos`. This PR switches them over, and fixes up the functions that use them to use `pos` as well.

---

One pattern that's not addressed in this PR that I think would be fruitful to tackle in the future is this:

```c
    pos targetLoc = {
        monst->loc.x + nbDirs[dir][0],
        monst->loc.y + nbDirs[dir][1]
    };
```

a helper function `pos stepNeighbor(pos, short)` that handles this coordinate logic would be convenient.