### PR TITLE
When debugging on Windows don't embed manifest

### DIFF
--- a/make/brogue.mk
+++ b/make/brogue.mk
@@ -2,7 +2,7 @@ bin/brogue$(.exe): $(objects) vars/cflags vars/LDFLAGS vars/libs vars/objects ma
 	$(CC) $(cflags) $(LDFLAGS) -o $@ $(objects) $(libs)
 # on windows, embedding the manifest modifies the executable, preventing debugging
 ifeq ($(SYSTEM),WINDOWS)
-  ifeq ($(DEBUG),NO)
+ifeq ($(DEBUG),NO)
 	mt -manifest windows/brogue.exe.manifest '-outputresource:bin/brogue.exe;1'
-  endif
+endif
 endif

--- a/make/brogue.mk
+++ b/make/brogue.mk
@@ -1,5 +1,8 @@
 bin/brogue$(.exe): $(objects) vars/cflags vars/LDFLAGS vars/libs vars/objects make/brogue.mk
 	$(CC) $(cflags) $(LDFLAGS) -o $@ $(objects) $(libs)
+# on windows, embedding the manifest modifies the executable, preventing debugging
 ifeq ($(SYSTEM),WINDOWS)
+  ifeq ($(DEBUG),NO)
 	mt -manifest windows/brogue.exe.manifest '-outputresource:bin/brogue.exe;1'
+  endif
 endif


### PR DESCRIPTION
Couldn't find a reasonable workaround for this issue.