### PR TITLE
add `posNeighborInDirection` utility function + update monsterAvoids to accept `pos`

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3704,11 +3704,9 @@ void initializeLevel() {
 
         // Run a field of view check from up stairs so that monsters do not spawn within sight of it.
         for (dir=0; dir<4; dir++) {
-            if (coordinatesAreInMap(upLoc.x + nbDirs[dir][0], upLoc.y + nbDirs[dir][1])
-                && !cellHasTerrainFlag(upLoc.x + nbDirs[dir][0], upLoc.y + nbDirs[dir][1], T_OBSTRUCTS_PASSABILITY)) {
-
-                upLoc.x += nbDirs[dir][0];
-                upLoc.y += nbDirs[dir][1];
+            pos nextLoc = posNeighborInDirection(upLoc, dir);
+            if (isPosInMap(nextLoc) && !cellHasTerrainFlag(nextLoc.x, nextLoc.y, T_OBSTRUCTS_PASSABILITY)) {
+                upLoc = nextLoc;
                 break;
             }
         }

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -197,7 +197,7 @@ void splitMonster(creature *monst, pos loc) {
                         && !eligibleGrid[newX][newY]
                         && !monsterGrid[newX][newY]
                         && !(pmap[newX][newY].flags & (HAS_PLAYER | HAS_MONSTER))
-                        && !monsterAvoids(monst, newX, newY)) {
+                        && !monsterAvoids(monst, (pos){ newX, newY })) {
 
                         eligibleGrid[newX][newY] = true;
                         eligibleLocationCount++;
@@ -1347,7 +1347,7 @@ boolean canAbsorb(creature *ally, boolean ourBolts[NUMBER_BOLT_KINDS], creature 
         && ally->newPowerCount > 0
         && (!isPosInMap(ally->targetCorpseLoc))
         && !((ally->info.flags | prey->info.flags) & (MONST_INANIMATE | MONST_IMMOBILE))
-        && !monsterAvoids(ally, prey->loc.x, prey->loc.y)
+        && !monsterAvoids(ally, prey->loc)
         && grid[ally->loc.x][ally->loc.y] <= 10) {
 
         if (~(ally->info.abilityFlags) & prey->info.abilityFlags & LEARNABLE_ABILITIES) {

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -233,7 +233,7 @@ void calculateDistances(short **distanceMap,
                        || (traveler && traveler == &player && !(pmap[i][j].flags & (DISCOVERED | MAGIC_MAPPED)))) {
 
                 cost = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
-            } else if ((traveler && monsterAvoids(traveler, i, j)) || cellHasTerrainFlag(i, j, blockingTerrainFlags)) {
+            } else if ((traveler && monsterAvoids(traveler, (pos){i, j})) || cellHasTerrainFlag(i, j, blockingTerrainFlags)) {
                 cost = PDS_FORBIDDEN;
             } else {
                 cost = 1;

--- a/src/brogue/IncludeGlobals.h
+++ b/src/brogue/IncludeGlobals.h
@@ -45,6 +45,14 @@ extern short **allySafetyMap;
 extern short **chokeMap;
 
 extern const short nbDirs[8][2];
+
+// Returns the `pos` which is one cell away in the provided direction.
+// The direction must not be `NO_DIRECTION`.
+static inline pos posNeighborInDirection(pos p, enum directions direction_to_step) {
+  brogueAssert(direction_to_step >= 0 && direction_to_step < 8);
+  return (pos) { .x = p.x + nbDirs[direction_to_step][0], .y = p.y + nbDirs[direction_to_step][1] };
+}
+
 extern const short cDirs[8][2];
 extern levelData *levels;
 extern creature player;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -145,6 +145,17 @@ typedef long long fixpt;
 #define COLS                    100
 #define ROWS                    (31 + MESSAGE_LINES)
 
+// Returns the sign of the input:
+// - if (x == 0)  ===> returns 0
+// - if (x >= 1)  ===> returns +1
+// - if (x <= -1) ===> returns -1
+static inline int signum(int x) {
+    if (x == 0) {
+        return 0;
+    }
+    return x > 0 ? 1 : -1;
+}
+
 // A location within the dungeon.
 // Typically, 0 <= x < DCOLS and 0 <= y < DROWS,
 // but occasionally coordinates are used which point outside of this region.
@@ -3096,7 +3107,7 @@ extern "C" {
     boolean moveMonster(creature *monst, short dx, short dy);
     unsigned long burnedTerrainFlagsAtLoc(short x, short y);
     unsigned long discoveredTerrainFlagsAtLoc(short x, short y);
-    boolean monsterAvoids(creature *monst, short x, short y);
+    boolean monsterAvoids(creature *monst, pos p);
     short distanceBetween(pos loc1, pos loc2);
     void alertMonster(creature *monst);
     void wakeUp(creature *monst);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -780,8 +780,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
         placedPlayer = false;
         for (dir=0; dir<4 && !placedPlayer; dir++) {
-            loc.x = player.loc.x + nbDirs[dir][0];
-            loc.y = player.loc.y + nbDirs[dir][1];
+            loc = posNeighborInDirection(player.loc, dir);
             if (!cellHasTerrainFlag(loc.x, loc.y, T_PATHING_BLOCKER)
                 && !(pmapAt(loc)->flags & (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE))) {
                 placedPlayer = true;

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -2071,12 +2071,9 @@ void decrementPlayerStatus() {
 }
 
 boolean dangerChanged(boolean danger[4]) {
-    enum directions dir;
-    short newX, newY;
-    for (dir = 0; dir < 4; dir++) {
-        newX = player.loc.x + nbDirs[dir][0];
-        newY = player.loc.y + nbDirs[dir][1];
-        if (danger[dir] != monsterAvoids(&player, newX, newY)) {
+    for (enum directions dir = 0; dir < 4; dir++) {
+        const pos newLoc = posNeighborInDirection(player.loc, dir);
+        if (danger[dir] != monsterAvoids(&player, newLoc)) {
             return true;
         }
     }
@@ -2084,21 +2081,16 @@ boolean dangerChanged(boolean danger[4]) {
 }
 
 void autoRest() {
-    short i = 0;
-    boolean initiallyEmbedded; // Stop as soon as we're free from crystal.
     boolean danger[4];
-    short newX, newY;
-    enum directions dir;
-
-    for (dir = 0; dir < 4; dir++) {
-        newX = player.loc.x + nbDirs[dir][0];
-        newY = player.loc.y + nbDirs[dir][1];
-        danger[dir] = monsterAvoids(&player, newX, newY);
+    for (enum directions dir = 0; dir < 4; dir++) {
+        const pos newLoc = posNeighborInDirection(player.loc, dir);
+        danger[dir] = monsterAvoids(&player, newLoc);
     }
 
     rogue.disturbed = false;
     rogue.automationActive = true;
-    initiallyEmbedded = cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY);
+    // Stop as soon as we're free from crystal.
+    const boolean initiallyEmbedded = cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY);
 
     if ((player.currentHP < player.info.maxHP
          || player.status[STATUS_HALLUCINATING]
@@ -2108,6 +2100,8 @@ void autoRest() {
          || player.status[STATUS_DARKNESS]
          || initiallyEmbedded)
         && !rogue.disturbed) {
+
+        int i = 0;
         while (i++ < TURNS_FOR_FULL_REGEN
                && (player.currentHP < player.info.maxHP
                    || player.status[STATUS_HALLUCINATING]
@@ -2127,7 +2121,7 @@ void autoRest() {
             }
         }
     } else {
-        for (i=0; i<100 && !rogue.disturbed; i++) {
+        for (int i=0; i<100 && !rogue.disturbed; i++) {
             recordKeystroke(REST_KEY, false, false);
             rogue.justRested = true;
             playerTurnEnded();


### PR DESCRIPTION
One of the most common operations on `pos` is moving one step in the provided direction; this PR adds the `pos posNeighborInDirection(pos, enum direction);` function which does this for you.

Because many of the (new) uses of this function also call `monsterAvoids`, and it was already being passed a (deconstructed) `pos` in quite a few places, I also converted `monsterAvoids` from `boolean monsterAvoids(creature*, short, short)` into `boolean monsterAvoids(creature*, pos);`.