### PR TITLE
Replace `short[2]` with `pos`

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -2988,7 +2988,7 @@ void refreshWaypoint(short wpIndex) {
         }
     }
     fillGrid(rogue.wpDistance[wpIndex], 30000);
-    rogue.wpDistance[wpIndex][rogue.wpCoordinates[wpIndex][0]][rogue.wpCoordinates[wpIndex][1]] = 0;
+    rogue.wpDistance[wpIndex][rogue.wpCoordinates[wpIndex].x][rogue.wpCoordinates[wpIndex].y] = 0;
     dijkstraScan(rogue.wpDistance[wpIndex], costMap, true);
     freeGrid(costMap);
 }
@@ -3015,8 +3015,7 @@ void setUpWaypoints() {
         if (!grid[x][y]) {
             getFOVMask(grid, x, y, WAYPOINT_SIGHT_RADIUS * FP_FACTOR, T_OBSTRUCTS_SCENT, 0, false);
             grid[x][y] = true;
-            rogue.wpCoordinates[rogue.wpCount][0] = x;
-            rogue.wpCoordinates[rogue.wpCount][1] = y;
+            rogue.wpCoordinates[rogue.wpCount] = (pos) { x, y };
             rogue.wpCount++;
 //            blackOutScreen();
 //            dumpLevelToScreen();

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -28,56 +28,42 @@
 #include "IncludeGlobals.h"
 
 // Populates path[][] with a list of coordinates starting at origin and traversing down the map. Returns the number of steps in the path.
-short getPlayerPathOnMap(short path[1000][2], short **map, short originX, short originY) {
-    short dir, x, y, steps;
+short getPlayerPathOnMap(pos path[1000], short **map, pos origin) {
+    pos at = origin;
 
-    x = originX;
-    y = originY;
-
-    dir = 0;
-
-    for (steps = 0; dir != -1;) {
-        dir = nextStep(map, x, y, &player, false);
-        if (dir != -1) {
-            x += nbDirs[dir][0];
-            y += nbDirs[dir][1];
-            path[steps][0] = x;
-            path[steps][1] = y;
-            steps++;
-            brogueAssert(coordinatesAreInMap(x, y));
+    int steps;
+    for (steps = 0; true; steps++) {
+        const int dir = nextStep(map, at.x, at.y, &player, false);
+        if (dir == -1) {
+            break;
         }
+        at = posNeighborInDirection(at, dir);
+        path[steps] = at;
+        brogueAssert(coordinatesAreInMap(x, y));
     }
     return steps;
 }
 
-void reversePath(short path[1000][2], short steps) {
-    short i, x, y;
-
-    for (i=0; i<steps / 2; i++) {
-        x = path[steps - i - 1][0];
-        y = path[steps - i - 1][1];
-
-        path[steps - i - 1][0] = path[i][0];
-        path[steps - i - 1][1] = path[i][1];
-
-        path[i][0] = x;
-        path[i][1] = y;
+void reversePath(pos path[1000], short steps) {
+    for (int i=0; i<steps / 2; i++) {
+        pos temp = path[steps - i - 1];
+        path[steps - i - 1] = path[i];
+        path[i] = temp;
     }
 }
 
-void hilitePath(short path[1000][2], short steps, boolean unhilite) {
-    short i;
+void hilitePath(pos path[1000], short steps, boolean unhilite) {
     if (unhilite) {
-        for (i=0; i<steps; i++) {
-            brogueAssert(coordinatesAreInMap(path[i][0], path[i][1]));
-            pmap[path[i][0]][path[i][1]].flags &= ~IS_IN_PATH;
-            refreshDungeonCell(path[i][0], path[i][1]);
+        for (int i=0; i<steps; i++) {
+            brogueAssert(isPosInMap(path[i]));
+            pmapAt(path[i])->flags &= ~IS_IN_PATH;
+            refreshDungeonCell(path[i].x, path[i].y);
         }
     } else {
-        for (i=0; i<steps; i++) {
-            brogueAssert(coordinatesAreInMap(path[i][0], path[i][1]));
-            pmap[path[i][0]][path[i][1]].flags |= IS_IN_PATH;
-            refreshDungeonCell(path[i][0], path[i][1]);
+        for (int i=0; i<steps; i++) {
+            brogueAssert(isPosInMap(path[i]));
+            pmapAt(path[i])->flags |= IS_IN_PATH;
+            refreshDungeonCell(path[i].x, path[i].y);
         }
     }
 }
@@ -117,29 +103,29 @@ void showCursor() {
     }
 }
 
-void getClosestValidLocationOnMap(short loc[2], short **map, short x, short y) {
-    short i, j, dist, closestDistance, lowestMapScore;
+pos getClosestValidLocationOnMap(short **map, short x, short y) {
+    pos answer = INVALID_POS;
 
-    closestDistance = 10000;
-    lowestMapScore = 10000;
-    for (i=1; i<DCOLS-1; i++) {
-        for (j=1; j<DROWS-1; j++) {
-            if (map[i][j] >= 0
-                && map[i][j] < 30000) {
+    int closestDistance = 10000;
+    int lowestMapScore = 10000;
+    for (int i=1; i<DCOLS-1; i++) {
+        for (int j=1; j<DROWS-1; j++) {
+            if (map[i][j] >= 0 && map[i][j] < 30000) {
 
-                dist = (i - x)*(i - x) + (j - y)*(j - y);
+                const int dist = (i - x)*(i - x) + (j - y)*(j - y);
                 //hiliteCell(i, j, &purple, min(dist / 2, 100), false);
                 if (dist < closestDistance
                     || dist == closestDistance && map[i][j] < lowestMapScore) {
 
-                    loc[0] = i;
-                    loc[1] = j;
+                    answer = (pos){ i, j };
                     closestDistance = dist;
                     lowestMapScore = map[i][j];
                 }
             }
         }
     }
+
+    return answer;
 }
 
 void processSnapMap(short **map) {
@@ -553,8 +539,9 @@ void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
 
 // This is basically the main loop for the game.
 void mainInputLoop() {
-    short originLoc[2], pathDestination[2], oldTargetLoc[2] = { 0, 0 },
-    path[1000][2], steps, oldRNG, dir, newX, newY;
+    pos oldTargetLoc = { 0, 0 };
+    short steps, oldRNG, dir, newX, newY;
+    pos path[1000];
     creature *monst;
     item *theItem;
     cellDisplayBuffer rbuf[COLS][ROWS];
@@ -595,18 +582,15 @@ void mainInputLoop() {
         steps = 0;
         clearCursorPath();
 
-        originLoc[0] = player.loc.x;
-        originLoc[1] = player.loc.y;
+        const pos originLoc = player.loc;
 
         if (playingBack && rogue.cursorMode) {
             temporaryMessage("Examine what? (<hjklyubn>, mouse, or <tab>)", 0);
         }
 
         if (!playingBack
-            && player.loc.x == rogue.cursorLoc.x
-            && player.loc.y == rogue.cursorLoc.y
-            && oldTargetLoc[0] == rogue.cursorLoc.x
-            && oldTargetLoc[1] == rogue.cursorLoc.y) {
+            && posEq(player.loc, rogue.cursorLoc)
+            && posEq(oldTargetLoc, rogue.cursorLoc)) {
 
             // Path hides when you reach your destination.
             rogue.cursorMode = false;
@@ -614,8 +598,7 @@ void mainInputLoop() {
             rogue.cursorLoc = INVALID_POS;
         }
 
-        oldTargetLoc[0] = rogue.cursorLoc.x;
-        oldTargetLoc[1] = rogue.cursorLoc.y;
+        oldTargetLoc = rogue.cursorLoc;
 
         populateCreatureCostMap(costMap, &player);
 
@@ -628,44 +611,41 @@ void mainInputLoop() {
             textDisplayed = false;
 
             // Draw the cursor and path
-            if (coordinatesAreInMap(oldTargetLoc[0], oldTargetLoc[1])) {
-                refreshDungeonCell(oldTargetLoc[0], oldTargetLoc[1]);               // Remove old cursor.
+            if (isPosInMap(oldTargetLoc)) {
+                refreshDungeonCell(oldTargetLoc.x, oldTargetLoc.y);               // Remove old cursor.
             }
             if (!playingBack) {
-                if (coordinatesAreInMap(oldTargetLoc[0], oldTargetLoc[1])) {
+                if (isPosInMap(oldTargetLoc)) {
                     hilitePath(path, steps, true);                                  // Unhilite old path.
                 }
                 if (isPosInMap(rogue.cursorLoc)) {
+                    pos pathDestination;
                     if (cursorSnapMap[rogue.cursorLoc.x][rogue.cursorLoc.y] >= 0
                         && cursorSnapMap[rogue.cursorLoc.x][rogue.cursorLoc.y] < 30000) {
-
-                        pathDestination[0] = rogue.cursorLoc.x;
-                        pathDestination[1] = rogue.cursorLoc.y;
+                        pathDestination = rogue.cursorLoc;
                     } else {
                         // If the cursor is aimed at an inaccessible area, find the nearest accessible area to path toward.
-                        getClosestValidLocationOnMap(pathDestination, cursorSnapMap, rogue.cursorLoc.x, rogue.cursorLoc.y);
+                        pathDestination = getClosestValidLocationOnMap(cursorSnapMap, rogue.cursorLoc.x, rogue.cursorLoc.y);
                     }
 
                     fillGrid(playerPathingMap, 30000);
-                    playerPathingMap[pathDestination[0]][pathDestination[1]] = 0;
-                    backupCost = costMap[pathDestination[0]][pathDestination[1]];
-                    costMap[pathDestination[0]][pathDestination[1]] = 1;
+                    playerPathingMap[pathDestination.x][pathDestination.y] = 0;
+                    backupCost = costMap[pathDestination.x][pathDestination.y];
+                    costMap[pathDestination.x][pathDestination.y] = 1;
                     dijkstraScan(playerPathingMap, costMap, true);
-                    costMap[pathDestination[0]][pathDestination[1]] = backupCost;
-                    steps = getPlayerPathOnMap(path, playerPathingMap, player.loc.x, player.loc.y);
+                    costMap[pathDestination.x][pathDestination.y] = backupCost;
+                    steps = getPlayerPathOnMap(path, playerPathingMap, player.loc);
 
 //                  steps = getPlayerPathOnMap(path, playerPathingMap, pathDestination[0], pathDestination[1]) - 1; // Get new path.
 //                  reversePath(path, steps);   // Flip it around, back-to-front.
 
                     if (steps >= 0) {
-                        path[steps][0] = pathDestination[0];
-                        path[steps][1] = pathDestination[1];
+                        path[steps] = pathDestination;
                     }
                     steps++;
 //                  if (playerPathingMap[cursor[0]][cursor[1]] != 1
                     if (playerPathingMap[player.loc.x][player.loc.y] != 1
-                        || pathDestination[0] != rogue.cursorLoc.x
-                        || pathDestination[1] != rogue.cursorLoc.y) {
+                        || !posEq(pathDestination, rogue.cursorLoc)) {
 
                         hilitePath(path, steps, false);     // Hilite new path.
                     }
@@ -677,12 +657,11 @@ void mainInputLoop() {
                            rogue.cursorLoc.y,
                            &white,
                            (steps <= 0
-                            || (path[steps-1][0] == rogue.cursorLoc.x && path[steps-1][1] == rogue.cursorLoc.y)
+                            || posEq(path[steps-1], rogue.cursorLoc)
                             || (!playingBack && distanceBetween(player.loc, rogue.cursorLoc) <= 1) ? 100 : 25),
                            true);
 
-                oldTargetLoc[0] = rogue.cursorLoc.x;
-                oldTargetLoc[1] = rogue.cursorLoc.y;
+                oldTargetLoc = rogue.cursorLoc;
 
                 monst = monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y);
                 theItem = itemAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y);
@@ -781,8 +760,8 @@ void mainInputLoop() {
                 }
         } while (!targetConfirmed && !canceled && !doEvent && !rogue.gameHasEnded);
 
-        if (coordinatesAreInMap(oldTargetLoc[0], oldTargetLoc[1])) {
-            refreshDungeonCell(oldTargetLoc[0], oldTargetLoc[1]);                       // Remove old rogue.cursorLoc.
+        if (isPosInMap(oldTargetLoc)) {
+            refreshDungeonCell(oldTargetLoc.x, oldTargetLoc.y);                       // Remove old rogue.cursorLoc.
         }
 
         restoreRNG;
@@ -796,16 +775,14 @@ void mainInputLoop() {
                 && steps > 1) {
                 // Control-clicking moves the player one step along the path.
                 for (dir=0;
-                     dir < DIRECTION_COUNT && (player.loc.x + nbDirs[dir][0] != path[0][0] || player.loc.y + nbDirs[dir][1] != path[0][1]);
+                     dir < DIRECTION_COUNT && !posEq(posNeighborInDirection(player.loc, dir) , path[0]);
                      dir++);
                 playerMoves(dir);
             } else if (D_WORMHOLING) {
                 travel(rogue.cursorLoc.x, rogue.cursorLoc.y, true);
             } else {
                 confirmMessages();
-                if (originLoc[0] == rogue.cursorLoc.x
-                    && originLoc[1] == rogue.cursorLoc.y) {
-
+                if (posEq(originLoc, rogue.cursorLoc)) {
                     confirmMessages();
                 } else if (abs(player.loc.x - rogue.cursorLoc.x) + abs(player.loc.y - rogue.cursorLoc.y) == 1 // horizontal or vertical
                            || (distanceBetween(player.loc, rogue.cursorLoc) == 1 // includes diagonals
@@ -3711,7 +3688,7 @@ enum entityDisplayTypes {
 // If a monster, item or terrain is focused, then display the sidebar with that monster/item highlighted,
 // in the order it would normally appear. If it would normally not fit on the sidebar at all,
 // then list it first.
-// Also update rogue.sidebarLocationList[ROWS][2] list of locations so that each row of
+// Also update `pos rogue.sidebarLocationList[ROWS]` list of locations so that each row of
 // the screen is mapped to the corresponding entity, if any.
 // FocusedEntityMustGoFirst should usually be false when called externally. This is because
 // we won't know if it will fit on the screen in normal order until we try.
@@ -3723,7 +3700,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
     char buf[COLS];
     void *entityList[ROWS] = {0}, *focusEntity = NULL;
     enum entityDisplayTypes entityType[ROWS] = {0}, focusEntityType = EDT_NOTHING;
-    short terrainLocationMap[ROWS][2];
+    pos terrainLocationMap[ROWS];
     boolean gotFocusedEntityOnScreen = (focusX >= 0 ? false : true);
     char addedEntity[DCOLS][DROWS];
     short oldRNG;
@@ -3789,8 +3766,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
     // Initialization.
     displayEntityCount = 0;
     for (i=0; i<ROWS*2; i++) {
-        rogue.sidebarLocationList[i][0] = -1;
-        rogue.sidebarLocationList[i][1] = -1;
+        rogue.sidebarLocationList[i] = INVALID_POS;
     }
 
     // Player always goes first.
@@ -3804,8 +3780,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
         addedEntity[focusX][focusY] = true;
         entityList[displayEntityCount] = focusEntity;
         entityType[displayEntityCount] = focusEntityType;
-        terrainLocationMap[displayEntityCount][0] = focusX;
-        terrainLocationMap[displayEntityCount][1] = focusY;
+        terrainLocationMap[displayEntityCount] = (pos) { focusX, focusY };
         displayEntityCount++;
     }
 
@@ -3870,8 +3845,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
                         addedEntity[i][j] = true;
                         entityList[displayEntityCount] = tileCatalog[pmap[i][j].layers[layerWithTMFlag(i, j, TM_LIST_IN_SIDEBAR)]].description;
                         entityType[displayEntityCount] = EDT_TERRAIN;
-                        terrainLocationMap[displayEntityCount][0] = i;
-                        terrainLocationMap[displayEntityCount][1] = j;
+                        terrainLocationMap[displayEntityCount] = (pos) { i, j };
                         displayEntityCount++;
                     }
                 }
@@ -3900,8 +3874,8 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
                                    (focusEntity && (x != focusX || y != focusY)),
                                    (x == focusX && y == focusY));
         } else if (entityType[i] == EDT_TERRAIN) {
-            x = terrainLocationMap[i][0];
-            y = terrainLocationMap[i][1];
+            x = terrainLocationMap[i].x;
+            y = terrainLocationMap[i].y;
             printY = printTerrainInfo(x, y,
                                       printY,
                                       ((const char *) entityList[i]),
@@ -3912,8 +3886,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
             gotFocusedEntityOnScreen = true;
         }
         for (j=oldPrintY; j<printY; j++) {
-            rogue.sidebarLocationList[j][0] = x;
-            rogue.sidebarLocationList[j][1] = y;
+            rogue.sidebarLocationList[j] = (pos){ x, y };
         }
     }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -364,13 +364,12 @@ short chooseKind(itemTable *theTable, short numKinds) {
 
 // Places an item at (x,y) if provided or else a random location if they're 0. Inserts item into the floor list.
 item *placeItem(item *theItem, short x, short y) {
-    short loc[2];
     enum dungeonLayers layer;
     char theItemName[DCOLS], buf[DCOLS];
     if (x <= 0 || y <= 0) {
-        randomMatchingLocation(&(loc[0]), &(loc[1]), FLOOR, NOTHING, -1);
-        theItem->loc.x = loc[0];
-        theItem->loc.y = loc[1];
+        pos loc;
+        randomMatchingLocation(&loc.x, &loc.y, FLOOR, NOTHING, -1);
+        theItem->loc = loc;
     } else {
         theItem->loc.x = x;
         theItem->loc.y = y;
@@ -3277,8 +3276,7 @@ item *keyOnTileAt(short x, short y) {
 void aggravateMonsters(short distance, short x, short y, const color *flashColor) {
     short i, j, **grid;
 
-    rogue.wpCoordinates[0][0] = x;
-    rogue.wpCoordinates[0][1] = y;
+    rogue.wpCoordinates[0] = (pos) { x, y };
     refreshWaypoint(0);
 
     grid = allocGrid();
@@ -5124,40 +5122,33 @@ boolean nextTargetAfter(short *returnX,
                         boolean targetTerrain,
                         boolean requireOpenPath,
                         boolean reverseDirection) {
-    short i, n, targetCount, newX, newY;
     short selectedIndex = 0;
-    creature *monst;
-    item *theItem;
-    short deduplicatedTargetList[ROWS][2];
+    pos deduplicatedTargetList[ROWS];
 
-    targetCount = 0;
-    for (i=0; i<ROWS; i++) {
-        if (rogue.sidebarLocationList[i][0] != -1) {
-            if (targetCount == 0
-                || deduplicatedTargetList[targetCount-1][0] != rogue.sidebarLocationList[i][0]
-                || deduplicatedTargetList[targetCount-1][1] != rogue.sidebarLocationList[i][1]) {
+    int targetCount = 0;
+    for (int i=0; i<ROWS; i++) {
+        if (isPosInMap(rogue.sidebarLocationList[i])) {
+            if (targetCount == 0 || !posEq(deduplicatedTargetList[targetCount-1], rogue.sidebarLocationList[i])) {
 
-                deduplicatedTargetList[targetCount][0] = rogue.sidebarLocationList[i][0];
-                deduplicatedTargetList[targetCount][1] = rogue.sidebarLocationList[i][1];
-                if (rogue.sidebarLocationList[i][0] == targetX
-                    && rogue.sidebarLocationList[i][1] == targetY) {
+                deduplicatedTargetList[targetCount] = rogue.sidebarLocationList[i];
+                if (posEq(rogue.sidebarLocationList[i], (pos){ targetX, targetY })) {
                     selectedIndex = targetCount;
                 }
                 targetCount++;
             }
         }
     }
-    for (i = reverseDirection ? targetCount - 1 : 0; reverseDirection ? i >= 0 : i < targetCount; reverseDirection ? i-- : i++) {
-        n = (selectedIndex + i) % targetCount;
-        newX = deduplicatedTargetList[n][0];
-        newY = deduplicatedTargetList[n][1];
+    for (int i = reverseDirection ? targetCount - 1 : 0; reverseDirection ? i >= 0 : i < targetCount; reverseDirection ? i-- : i++) {
+        const int n = (selectedIndex + i) % targetCount;
+        const int newX = deduplicatedTargetList[n].x;
+        const int newY = deduplicatedTargetList[n].y;
         if ((newX != player.loc.x || newY != player.loc.y)
             && (newX != targetX || newY != targetY)
             && (!requireOpenPath || openPathBetween(player.loc.x, player.loc.y, newX, newY))) {
 
             brogueAssert(coordinatesAreInMap(newX, newY));
             brogueAssert(n >= 0 && n < targetCount);
-            monst = monsterAtLoc(newX, newY);
+            creature *const monst = monsterAtLoc(newX, newY);
             if (monst) {
                 if (monstersAreEnemies(&player, monst)) {
                     if (targetEnemies) {
@@ -5173,7 +5164,7 @@ boolean nextTargetAfter(short *returnX,
                     }
                 }
             }
-            theItem = itemAtLoc(newX, newY);
+            item *const theItem = itemAtLoc(newX, newY);
             if (!monst && theItem && targetItems) {
                 *returnX = newX;
                 *returnY = newY;
@@ -5293,11 +5284,10 @@ boolean moveCursor(boolean *targetConfirmed,
                 && theEvent.param1 < mapToWindowX(0)
                 && theEvent.param2 >= 0
                 && theEvent.param2 < ROWS - 1
-                && rogue.sidebarLocationList[theEvent.param2][0] > -1) {
+                && isPosInMap(rogue.sidebarLocationList[theEvent.param2])) {
 
                 // If the cursor is on an entity in the sidebar.
-                rogue.cursorLoc.x = rogue.sidebarLocationList[theEvent.param2][0];
-                rogue.cursorLoc.y = rogue.sidebarLocationList[theEvent.param2][1];
+                rogue.cursorLoc = rogue.sidebarLocationList[theEvent.param2];
                 sidebarHighlighted = true;
                 cursorMovementCommand = true;
                 refreshSideBar(rogue.cursorLoc.x, rogue.cursorLoc.y, false);

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -745,7 +745,6 @@ void drawManacles(short x, short y) {
 // If x is negative, location is random.
 // Returns a pointer to the leader.
 creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFlags, unsigned long requiredFlags) {
-    short loc[2];
     short i, failsafe, depth;
     hordeType *theHorde;
     creature *leader, *preexistingMonst;
@@ -789,8 +788,9 @@ creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFla
     if (x < 0 || y < 0) {
         i = 0;
         do {
-            while (!randomMatchingLocation(&(loc[0]), &(loc[1]), FLOOR, NOTHING, (hordeCatalog[hordeID].spawnsIn ? hordeCatalog[hordeID].spawnsIn : -1))
-                   || passableArcCount(loc[0], loc[1]) > 1) {
+            pos loc;
+            while (!randomMatchingLocation(&loc.x, &loc.y, FLOOR, NOTHING, (hordeCatalog[hordeID].spawnsIn ? hordeCatalog[hordeID].spawnsIn : -1))
+                   || passableArcCount(loc.x, loc.y) > 1) {
                 if (!--failsafe) {
                     return NULL;
                 }
@@ -800,8 +800,8 @@ creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFla
                     return NULL;
                 }
             }
-            x = loc[0];
-            y = loc[1];
+            x = loc.x;
+            y = loc.y;
             i++;
 
             // This "while" condition should contain IN_FIELD_OF_VIEW, since that is specifically
@@ -4008,7 +4008,6 @@ void demoteMonsterFromLeadership(creature *monst) {
 
 // Makes a monster dormant, or awakens it from that state
 void toggleMonsterDormancy(creature *monst) {
-    //short loc[2] = {0, 0};
 
     if (removeCreature(dormantMonsters, monst)) {
         // Found it! It's dormant. Wake it up.

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -615,7 +615,7 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
 // (in which case the player/monster should move instead).
 boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *aborted) {
     creature *defender, *hitList[8] = {0};
-    short targetLoc[2], range = 2, i = 0, h = 0;
+    short range = 2, i = 0, h = 0;
     boolean proceed = false, visualEffect = false;
 
     const char boltChar[DIRECTION_COUNT] = "||--\\//\\";
@@ -631,18 +631,20 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
     }
 
     for (i = 0; i < range; i++) {
-        targetLoc[0] = attacker->loc.x + (1 + i) * nbDirs[dir][0];
-        targetLoc[1] = attacker->loc.y + (1 + i) * nbDirs[dir][1];
-        if (!coordinatesAreInMap(targetLoc[0], targetLoc[1])) {
+        const pos targetLoc = (pos) {
+            attacker->loc.x + (1 + i) * nbDirs[dir][0],
+            attacker->loc.y + (1 + i) * nbDirs[dir][1]
+        };
+        if (!isPosInMap(targetLoc)) {
             break;
         }
 
         /* Add creatures that we are willing to attack to the potential
         hitlist. Any of those that are either right by us or visible will
         trigger the attack. */
-        defender = monsterAtLoc(targetLoc[0], targetLoc[1]);
+        defender = monsterAtLoc(targetLoc.x, targetLoc.y);
         if (defender
-            && (!cellHasTerrainFlag(targetLoc[0], targetLoc[1], T_OBSTRUCTS_PASSABILITY)
+            && (!cellHasTerrainFlag(targetLoc.x, targetLoc.y, T_OBSTRUCTS_PASSABILITY)
                 || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))
             && monsterWillAttackTarget(attacker, defender)) {
 
@@ -658,7 +660,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
             }
         }
 
-        if (cellHasTerrainFlag(targetLoc[0], targetLoc[1], (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION))) {
+        if (cellHasTerrainFlag(targetLoc.x, targetLoc.y, (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION))) {
             break;
         }
     }
@@ -674,13 +676,15 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         }
         if (!rogue.playbackFastForward) {
             for (i = 0; i < range; i++) {
-                targetLoc[0] = attacker->loc.x + (1 + i) * nbDirs[dir][0];
-                targetLoc[1] = attacker->loc.y + (1 + i) * nbDirs[dir][1];
-                if (coordinatesAreInMap(targetLoc[0], targetLoc[1])
-                    && playerCanSeeOrSense(targetLoc[0], targetLoc[1])) {
+                const pos targetLoc = (pos) {
+                    attacker->loc.x + (1 + i) * nbDirs[dir][0],
+                    attacker->loc.y + (1 + i) * nbDirs[dir][1]
+                };
+                if (isPosInMap(targetLoc)
+                    && playerCanSeeOrSense(targetLoc.x, targetLoc.y)) {
 
                     visualEffect = true;
-                    plotForegroundChar(boltChar[dir], targetLoc[0], targetLoc[1], &lightBlue, true);
+                    plotForegroundChar(boltChar[dir], targetLoc.x, targetLoc.y, &lightBlue, true);
                 }
             }
         }
@@ -693,10 +697,12 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         if (visualEffect) {
             pauseAnimation(16);
             for (i = 0; i < range; i++) {
-                targetLoc[0] = attacker->loc.x + (1 + i) * nbDirs[dir][0];
-                targetLoc[1] = attacker->loc.y + (1 + i) * nbDirs[dir][1];
-                if (coordinatesAreInMap(targetLoc[0], targetLoc[1])) {
-                    refreshDungeonCell(targetLoc[0], targetLoc[1]);
+                const pos targetLoc = (pos) {
+                    attacker->loc.x + (1 + i) * nbDirs[dir][0],
+                    attacker->loc.y + (1 + i) * nbDirs[dir][1]
+                };
+                if (isPosInMap(targetLoc)) {
+                    refreshDungeonCell(targetLoc.x, targetLoc.y);
                 }
             }
         }
@@ -1469,7 +1475,7 @@ void displayRoute(short **distanceMap, boolean removeRoute) {
     } while (advanced);
 }
 
-void travelRoute(short path[1000][2], short steps) {
+void travelRoute(pos path[1000], short steps) {
     short i, j;
     short dir;
 
@@ -1490,17 +1496,15 @@ void travelRoute(short path[1000][2], short steps) {
     for (i=0; i < steps && !rogue.disturbed; i++) {
         for (j = i + 1; j < steps - 1; j++) {
             // Check to see if the path has become obstructed or avoided since the last time we saw it.
-            if (diagonalBlocked(path[j-1][0], path[j-1][1], path[j][0], path[j][1], true)
-                || monsterAvoids(&player, (pos){path[j][0], path[j][1]})) {
+            if (diagonalBlocked(path[j-1].x, path[j-1].y, path[j].x, path[j].y, true)
+                || monsterAvoids(&player, path[j])) {
 
                 rogue.disturbed = true;
                 break;
             }
         }
         for (dir = 0; dir < DIRECTION_COUNT && !rogue.disturbed; dir++) {
-            if (player.loc.x + nbDirs[dir][0] == path[i][0]
-                && player.loc.y + nbDirs[dir][1] == path[i][1]) {
-
+            if (posEq(posNeighborInDirection(player.loc, dir), path[i])) {
                 if (!playerMoves(dir)) {
                     rogue.disturbed = true;
                 }
@@ -1847,11 +1851,6 @@ void getExploreMap(short **map, boolean headingToStairs) {// calculate explore m
 }
 
 boolean explore(short frameDelay) {
-    short **distanceMap;
-    short path[1000][2], steps;
-    boolean madeProgress, headingToStairs;
-    enum directions dir;
-
     // Explore commands should never be written to a recording.
     // Instead, the elemental movement commands that compose it
     // should be written individually.
@@ -1859,8 +1858,8 @@ boolean explore(short frameDelay) {
 
     clearCursorPath();
 
-    madeProgress    = false;
-    headingToStairs = false;
+    boolean madeProgress    = false;
+    boolean headingToStairs = false;
 
     if (player.status[STATUS_CONFUSED]) {
         message("Not while you're confused.", 0);
@@ -1881,7 +1880,7 @@ boolean explore(short frameDelay) {
     }
 
     // fight any adjacent enemies
-    dir = adjacentFightingDir();
+    enum directions dir = adjacentFightingDir();
     if (dir != NO_DIRECTION
         && startFighting(dir, (player.status[STATUS_HALLUCINATING] ? true : false))) {
 
@@ -1900,7 +1899,7 @@ boolean explore(short frameDelay) {
     rogue.disturbed = false;
     rogue.automationActive = true;
 
-    distanceMap = allocGrid();
+    short** distanceMap = allocGrid();
     do {
         // fight any adjacent enemies
         dir = adjacentFightingDir();
@@ -1918,7 +1917,8 @@ boolean explore(short frameDelay) {
         getExploreMap(distanceMap, headingToStairs);
 
         // hilite path
-        steps = getPlayerPathOnMap(path, distanceMap, player.loc.x, player.loc.y);
+        pos path[1000];
+        const int steps = getPlayerPathOnMap(path, distanceMap, player.loc);
         hilitePath(path, steps, false);
 
         // take a step

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2425,7 +2425,7 @@ typedef struct playerCharacter {
     item *lastItemThrown;
     short rewardRoomsGenerated;         // to meter the number of reward machines
     short machineNumber;                // so each machine on a level gets a unique number
-    short sidebarLocationList[ROWS*2][2];   // to keep track of which location each line of the sidebar references
+    pos sidebarLocationList[ROWS*2];    // to keep track of which location each line of the sidebar references
 
     // maps
     short **mapToShore;                 // how many steps to get back to shore
@@ -2470,7 +2470,7 @@ typedef struct playerCharacter {
     // waypoints:
     short **wpDistance[MAX_WAYPOINT_COUNT];
     short wpCount;
-    short wpCoordinates[MAX_WAYPOINT_COUNT][2];
+    pos wpCoordinates[MAX_WAYPOINT_COUNT];
     short wpRefreshTicker;
 
     // cursor trail:
@@ -2978,7 +2978,7 @@ extern "C" {
                             boolean eightWays);
     short pathingDistance(short x1, short y1, short x2, short y2, unsigned long blockingTerrainFlags);
     short nextStep(short **distanceMap, short x, short y, creature *monst, boolean reverseDirections);
-    void travelRoute(short path[1000][2], short steps);
+    void travelRoute(pos path[1000], short steps);
     void travel(short x, short y, boolean autoConfirm);
     void populateGenericCostMap(short **costMap);
     void getLocationFlags(const short x, const short y,
@@ -2988,9 +2988,9 @@ extern "C" {
     enum directions adjacentFightingDir();
     void getExploreMap(short **map, boolean headingToStairs);
     boolean explore(short frameDelay);
-    short getPlayerPathOnMap(short path[1000][2], short **map, short originX, short originY);
-    void reversePath(short path[1000][2], short steps);
-    void hilitePath(short path[1000][2], short steps, boolean unhilite);
+    short getPlayerPathOnMap(pos path[1000], short **map, pos origin);
+    void reversePath(pos path[1000], short steps);
+    void hilitePath(pos path[1000], short steps, boolean unhilite);
     void clearCursorPath();
     void hideCursor();
     void showCursor();


### PR DESCRIPTION
This PR replaces all of the remaining uses of `short[2]` to describe a position with the `pos` type. This improves clarity and type-safety. Combined with some cleanup in the affected functions, net 39 lines get deleted.

(There are still lots of functions that take `(short, short)` when they ought to take `pos` or `windowpos` instead, but that's for the future)