### PR TITLE
monsterAtLoc takes a 'pos' instead of two shorts

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -1571,7 +1571,7 @@ boolean buildAMachine(enum machineTypes bp,
                         }
 
                         if (feature->monsterID) {
-                            monst = monsterAtLoc(featX, featY);
+                            monst = monsterAtLoc((pos){ featX, featY });
                             if (monst) {
                                 killCreature(monst, true); // If there's already a monster here, quietly bury the body.
                             }
@@ -3215,7 +3215,7 @@ boolean fillSpawnMap(enum dungeonLayers layer,
                         flavorMessage(tileFlavor(player.loc.x, player.loc.y));
                     }
                     if (pmap[i][j].flags & (HAS_MONSTER)) {
-                        monst = monsterAtLoc(i, j);
+                        monst = monsterAtLoc((pos){ i, j });
                         applyInstantTileEffectsToCreature(monst);
                         if (rogue.gameHasEnded) {
                             return true;
@@ -3300,7 +3300,7 @@ void evacuateCreatures(char blockingMap[DCOLS][DROWS]) {
             if (blockingMap[i][j]
                 && (pmap[i][j].flags & (HAS_MONSTER | HAS_PLAYER))) {
 
-                monst = monsterAtLoc(i, j);
+                monst = monsterAtLoc((pos) { i, j });
                 pos newLoc;
                 getQualifyingLocNear(&newLoc,
                                      i, j,

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -155,7 +155,7 @@ void addMonsterToContiguousMonsterGrid(short x, short y, creature *monst, char g
         newY = y + nbDirs[dir][1];
 
         if (coordinatesAreInMap(newX, newY) && !grid[newX][newY]) {
-            tempMonst = monsterAtLoc(newX, newY);
+            tempMonst = monsterAtLoc((pos){ newX, newY });
             if (tempMonst && monstersAreTeammates(monst, tempMonst)) {
                 addMonsterToContiguousMonsterGrid(newX, newY, monst, grid);
             }
@@ -512,7 +512,7 @@ boolean forceWeaponHit(creature *defender, item *theItem) {
         && distanceBetween(oldLoc, defender->loc) < weaponForceDistance(netEnchant(theItem))) {
 
         if (pmap[defender->loc.x + newLoc.x - oldLoc.x][defender->loc.y + newLoc.y - oldLoc.y].flags & (HAS_MONSTER | HAS_PLAYER)) {
-            otherMonster = monsterAtLoc(defender->loc.x + newLoc.x - oldLoc.x, defender->loc.y + newLoc.y - oldLoc.y);
+            otherMonster = monsterAtLoc((pos){ defender->loc.x + newLoc.x - oldLoc.x, defender->loc.y + newLoc.y - oldLoc.y });
             monsterName(buf2, otherMonster, true);
         } else {
             otherMonster = NULL;
@@ -865,7 +865,7 @@ void applyArmorRunicEffect(char returnString[DCOLS], creature *attacker, short *
                     newX = player.loc.x + nbDirs[dir][0];
                     newY = player.loc.y + nbDirs[dir][1];
                     if (coordinatesAreInMap(newX, newY) && (pmap[newX][newY].flags & HAS_MONSTER)) {
-                        monst = monsterAtLoc(newX, newY);
+                        monst = monsterAtLoc((pos){ newX, newY });
                         if (monst
                             && monst != attacker
                             && monstersAreEnemies(&player, monst)
@@ -1741,7 +1741,7 @@ void buildHitList(creature **hitList, const creature *attacker, creature *defend
             newestX = x + cDirs[newDir][0];
             newestY = y + cDirs[newDir][1];
             if (coordinatesAreInMap(newestX, newestY) && (pmap[newestX][newestY].flags & (HAS_MONSTER | HAS_PLAYER))) {
-                defender = monsterAtLoc(newestX, newestY);
+                defender = monsterAtLoc((pos){ newestX, newestY });
                 if (defender
                     && monsterWillAttackTarget(attacker, defender)
                     && (!cellHasTerrainFlag(defender->loc.x, defender->loc.y, T_OBSTRUCTS_PASSABILITY) || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -216,7 +216,7 @@ void calculateDistances(short **distanceMap,
     for (int i=0; i<DCOLS; i++) {
         for (int j=0; j<DROWS; j++) {
             signed char cost;
-            creature *monst = monsterAtLoc(i, j);
+            creature *monst = monsterAtLoc((pos){ i, j });
             if (monst
                 && (monst->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))
                 && (monst->info.flags & (MONST_IMMOBILE | MONST_GETS_TURN_ON_ACTIVATION))) {

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -663,7 +663,7 @@ void mainInputLoop() {
 
                 oldTargetLoc = rogue.cursorLoc;
 
-                monst = monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y);
+                monst = monsterAtLoc(rogue.cursorLoc);
                 theItem = itemAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y);
                 if (monst != NULL && (canSeeMonster(monst) || rogue.playbackOmniscience)) {
                     rogue.playbackMode = playingBack;
@@ -787,7 +787,7 @@ void mainInputLoop() {
                 } else if (abs(player.loc.x - rogue.cursorLoc.x) + abs(player.loc.y - rogue.cursorLoc.y) == 1 // horizontal or vertical
                            || (distanceBetween(player.loc, rogue.cursorLoc) == 1 // includes diagonals
                                && (!diagonalBlocked(player.loc.x, player.loc.y, rogue.cursorLoc.x, rogue.cursorLoc.y, !rogue.playbackOmniscience)
-                                   || ((pmapAt(rogue.cursorLoc)->flags & HAS_MONSTER) && (monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y)->info.flags & MONST_ATTACKABLE_THRU_WALLS)) // there's a turret there
+                                   || ((pmapAt(rogue.cursorLoc)->flags & HAS_MONSTER) && (monsterAtLoc(rogue.cursorLoc)->info.flags & MONST_ATTACKABLE_THRU_WALLS)) // there's a turret there
                                    || ((terrainFlags(rogue.cursorLoc.x, rogue.cursorLoc.y) & T_OBSTRUCTS_PASSABILITY) && (terrainMechFlags(rogue.cursorLoc.x, rogue.cursorLoc.y) & TM_PROMOTES_ON_PLAYER_ENTRY))))) { // there's a lever there
                                                                                                                                                                                       // Clicking one space away will cause the player to try to move there directly irrespective of path.
                                    for (dir=0;
@@ -1111,9 +1111,9 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
     brogueAssert(coordinatesAreInMap(x, y));
 
     if (pmap[x][y].flags & HAS_MONSTER) {
-        monst = monsterAtLoc(x, y);
+        monst = monsterAtLoc((pos){ x, y });
     } else if (pmap[x][y].flags & HAS_DORMANT_MONSTER) {
-        monst = dormantMonsterAtLoc(x, y);
+        monst = dormantMonsterAtLoc((pos){ x, y });
     }
     if (monst) {
         monsterWithDetectedItem = (monst->carriedItem && (monst->carriedItem->flags & ITEM_MAGIC_DETECTED)
@@ -3717,7 +3717,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
         focusedEntityMustGoFirst = false; // just in case!
     } else {
         if (pmap[focusX][focusY].flags & (HAS_MONSTER | HAS_PLAYER)) {
-            creature *monst = monsterAtLoc(focusX, focusY);
+            creature *monst = monsterAtLoc((pos){ focusX, focusY });
             if (canSeeMonster(monst) || rogue.playbackOmniscience) {
                 focusEntity = monst;
                 focusEntityType = EDT_CREATURE;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3261,7 +3261,7 @@ item *keyOnTileAt(short x, short y) {
         }
     }
     if (pmap[x][y].flags & HAS_MONSTER) {
-        monst = monsterAtLoc(x, y);
+        monst = monsterAtLoc((pos){ x, y });
         if (monst->carriedItem) {
             theItem = monst->carriedItem;
             if (keyMatchesLocation(theItem, x, y)) {
@@ -3402,8 +3402,8 @@ short getLineCoordinates(pos listOfCoordinates[], const pos originLoc, const pos
             boolean burningThrough = (theBolt->flags & BF_FIERY) && cellHasTerrainFlag(x, y, T_IS_FLAMMABLE);
             boolean isCastByPlayer = (originLoc.x == player.loc.x && originLoc.y == player.loc.y);
 
-            creature *caster = monsterAtLoc(originLoc.x, originLoc.y);
-            creature *monst = monsterAtLoc(x, y);
+            creature *caster = monsterAtLoc(originLoc);
+            creature *monst = monsterAtLoc((pos){ x, y });
             boolean isMonster = monst
                 && !(monst->bookkeepingFlags & MB_SUBMERGED)
                 && !monsterIsHidden(monst, caster);
@@ -3493,9 +3493,9 @@ void getImpactLoc(pos *returnLoc, const pos originLoc, const pos targetLoc,
     n = getLineCoordinates(coords, originLoc, targetLoc, theBolt);
     n = min(n, maxDistance);
     for (i=0; i<n; i++) {
-        monst = monsterAtLoc(coords[i].x, coords[i].y);
+        monst = monsterAtLoc(coords[i]);
         if (monst
-            && !monsterIsHidden(monst, monsterAtLoc(originLoc.x, originLoc.y))
+            && !monsterIsHidden(monst, monsterAtLoc(originLoc))
             && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
             // Imaginary bolt hit the player or a monster.
             break;
@@ -3572,7 +3572,7 @@ boolean tunnelize(short x, short y) {
         spawnDungeonFeature(x, y, &dungeonFeatureCatalog[DF_TUNNELIZE], true, false);
         if (pmap[x][y].flags & HAS_MONSTER) {
             // Kill turrets and sentinels if you tunnelize them.
-            monst = monsterAtLoc(x, y);
+            monst = monsterAtLoc((pos){ x, y });
             if (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS) {
                 inflictLethalDamage(NULL, monst);
                 killCreature(monst, false);
@@ -4113,7 +4113,7 @@ void crystalize(short radius) {
                     spawnDungeonFeature(i, j, &dungeonFeatureCatalog[DF_SHATTERING_SPELL], true, false);
 
                     if (pmap[i][j].flags & HAS_MONSTER) {
-                        monst = monsterAtLoc(i, j);
+                        monst = monsterAtLoc((pos){ i, j });
                         if (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS) {
                             inflictLethalDamage(NULL, monst);
                             killCreature(monst, false);
@@ -4320,7 +4320,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
 
     // Handle collisions with monsters.
 
-    monst = monsterAtLoc(x, y);
+    monst = monsterAtLoc((pos){ x, y });
     if (monst && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
         monsterName(monstName, monst, true);
 
@@ -4698,10 +4698,11 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
             }
             break;
         case BE_BLINKING:
-            if (pmap[x][y].flags & HAS_MONSTER) { // We're blinking onto an area already occupied by a submerged monster.
-                                                  // Make sure we don't get the shooting monster by accident.
-                caster->loc.x = caster->loc.y = -1; // Will be set back to the destination in a moment.
-                monst = monsterAtLoc(x, y);
+            if (pmap[x][y].flags & HAS_MONSTER) {
+                // We're blinking onto an area already occupied by a submerged monster.
+                // Make sure we don't get the shooting monster by accident.
+                caster->loc = INVALID_POS; // Will be set back to the destination in a moment.
+                monst = monsterAtLoc((pos){ x, y });
                 findAlternativeHomeFor(monst, &x2, &y2, true);
                 if (x2 >= 0) {
                     // Found an alternative location.
@@ -4804,7 +4805,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
     } else {
         numCells = getLineCoordinates(listOfCoordinates, originLoc, targetLoc, (hideDetails ? &boltCatalog[BOLT_NONE] : theBolt));
     }
-    shootingMonst = monsterAtLoc(originLoc.x, originLoc.y);
+    shootingMonst = monsterAtLoc(originLoc);
 
     if (hideDetails) {
         boltColor = &gray;
@@ -4818,7 +4819,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
     if (theBolt->boltEffect == BE_BLINKING) {
         if (cellHasTerrainFlag(listOfCoordinates[0].x, listOfCoordinates[0].y, (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION))
             || ((pmapAt(listOfCoordinates[0])->flags & (HAS_PLAYER | HAS_MONSTER))
-                && !(monsterAtLoc(listOfCoordinates[0].x, listOfCoordinates[0].y)->bookkeepingFlags & MB_SUBMERGED))) {
+                && !(monsterAtLoc(listOfCoordinates[0])->bookkeepingFlags & MB_SUBMERGED))) {
                 // shooting blink point-blank into an obstruction does nothing.
                 return false;
             }
@@ -4853,7 +4854,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
         x = listOfCoordinates[i].x;
         y = listOfCoordinates[i].y;
 
-        monst = monsterAtLoc(x, y);
+        monst = monsterAtLoc(listOfCoordinates[i]);
 
         // Handle bolt reflection off of creatures (reflection off of terrain is handled further down).
         if (monst
@@ -4978,7 +4979,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
             }
 
             if (!(theBolt->flags & BF_PASSES_THRU_CREATURES)) {
-                monst = monsterAtLoc(listOfCoordinates[i+1].x, listOfCoordinates[i+1].y);
+                monst = monsterAtLoc(listOfCoordinates[i+1]);
                 if (monst && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
                     break;
                 }
@@ -5046,7 +5047,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
     }
 
     if (pmap[x][y].flags & (HAS_MONSTER | HAS_PLAYER)) {
-        monst = monsterAtLoc(x, y);
+        monst = monsterAtLoc((pos){ x, y });
         monsterName(monstName, monst, true);
     } else {
         monst = NULL;
@@ -5148,7 +5149,7 @@ boolean nextTargetAfter(short *returnX,
 
             brogueAssert(coordinatesAreInMap(newX, newY));
             brogueAssert(n >= 0 && n < targetCount);
-            creature *const monst = monsterAtLoc(newX, newY);
+            creature *const monst = monsterAtLoc((pos){ newX, newY });
             if (monst) {
                 if (monstersAreEnemies(&player, monst)) {
                     if (targetEnemies) {
@@ -5206,7 +5207,7 @@ short hiliteTrajectory(const pos coordinateList[DCOLS], short numCells, boolean 
             }
         } else if (!passThroughMonsters && pmap[x][y].flags & (HAS_MONSTER)
                    && (playerCanSee(x, y) || player.status[STATUS_TELEPATHIC])) {
-            monst = monsterAtLoc(x, y);
+            monst = monsterAtLoc((pos){ x, y });
             if (!(monst->bookkeepingFlags & MB_SUBMERGED)
                 && !monsterIsHidden(monst, &player)) {
 
@@ -5403,7 +5404,7 @@ boolean moveCursor(boolean *targetConfirmed,
 
         if (sidebarHighlighted
             && (!(pmapAt(rogue.cursorLoc)->flags & (HAS_PLAYER | HAS_MONSTER))
-                || !canSeeMonster(monsterAtLoc(rogue.cursorLoc.x, rogue.cursorLoc.y)))
+                || !canSeeMonster(monsterAtLoc(rogue.cursorLoc)))
             && (!(pmapAt(rogue.cursorLoc)->flags & HAS_ITEM) || !playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y))
             && (!cellHasTMFlag(rogue.cursorLoc.x, rogue.cursorLoc.y, TM_LIST_IN_SIDEBAR) || !playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y))) {
 
@@ -5499,7 +5500,7 @@ boolean chooseTarget(pos *returnLoc,
             if (nextTargetAfter(&newX, &newY, targetLoc.x, targetLoc.y, !targetAllies, targetAllies, false, false, true, false)) {
                 targetLoc = (pos) { .x = newX, .y = newY };
             }
-            monst = monsterAtLoc(targetLoc.x, targetLoc.y);
+            monst = monsterAtLoc(targetLoc);
         }
         if (monst) {
             targetLoc = monst->loc;
@@ -5536,7 +5537,7 @@ boolean chooseTarget(pos *returnLoc,
             }
         }
 
-        monst = monsterAtLoc(targetLoc.x, targetLoc.y);
+        monst = monsterAtLoc(targetLoc);
         if (monst != NULL && monst != &player && canSeeMonster(monst)) {
             focusedOnSomething = true;
         } else if (playerCanSeeOrSense(targetLoc.x, targetLoc.y)
@@ -5592,7 +5593,7 @@ boolean chooseTarget(pos *returnLoc,
         return false;
     }
 
-    monst = monsterAtLoc(targetLoc.x, targetLoc.y);
+    monst = monsterAtLoc(targetLoc);
     if (monst && monst != &player && canSeeMonster(monst)) {
         rogue.lastTarget = monst;
     }
@@ -5948,7 +5949,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
         y = listOfCoordinates[i].y;
 
         if (pmap[x][y].flags & (HAS_MONSTER | HAS_PLAYER)) {
-            monst = monsterAtLoc(x, y);
+            monst = monsterAtLoc((pos){ x, y });
             if (!(monst->bookkeepingFlags & MB_SUBMERGED)) {
 //          if (projectileReflects(thrower, monst) && i < DCOLS*2) {
 //              if (projectileReflects(thrower, monst)) { // if it scores another reflection roll, reflect at caster
@@ -6073,7 +6074,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
             refreshDungeonCell(x, y);
 
             //if (pmap[x][y].flags & (HAS_MONSTER | HAS_PLAYER)) {
-            //  monst = monsterAtLoc(x, y);
+            //  monst = monsterAtLoc((pos){ x, y });
             //  applyInstantTileEffectsToCreature(monst);
             //}
         } else {
@@ -6101,7 +6102,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
     if ((theItem->category & WEAPON) && theItem->kind == INCENDIARY_DART) {
         spawnDungeonFeature(x, y, &dungeonFeatureCatalog[DF_DART_EXPLOSION], true, false);
         if (pmap[x][y].flags & (HAS_MONSTER | HAS_PLAYER)) {
-            exposeCreatureToFire(monsterAtLoc(x, y));
+            exposeCreatureToFire(monsterAtLoc((pos){ x, y }));
         }
         deleteItem(theItem);
         return;

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -850,7 +850,7 @@ creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFla
         fillGrid(leader->safetyMap, 0);
     }
 
-    preexistingMonst = monsterAtLoc(x, y);
+    preexistingMonst = monsterAtLoc((pos){ x, y });
     if (preexistingMonst) {
         killCreature(preexistingMonst, true); // If there's already a monster here, quietly bury the body.
     }
@@ -1304,7 +1304,7 @@ boolean monsterAvoids(creature *monst, pos p) {
             return false;
         }
         if (distanceBetween(monst->loc, p) <= 1) {
-            defender = monsterAtLoc(p.x, p.y);
+            defender = monsterAtLoc(p);
             if (defender
                 && (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS)) {
                 return false;
@@ -1316,7 +1316,7 @@ boolean monsterAvoids(creature *monst, pos p) {
     // Monsters can always attack unfriendly neighboring monsters,
     // unless it is immune to us for whatever reason.
     if (distanceBetween(monst->loc, p) <= 1) {
-        defender = monsterAtLoc(p.x, p.y);
+        defender = monsterAtLoc(p);
         if (defender
             && !(defender->bookkeepingFlags & MB_IS_DYING)
             && monsterWillAttackTarget(monst, defender)) {
@@ -1330,7 +1330,7 @@ boolean monsterAvoids(creature *monst, pos p) {
     }
 
     // Monsters always avoid enemy monsters that we can't damage.
-    defender = monsterAtLoc(p.x, p.y);
+    defender = monsterAtLoc(p);
     if (defender
         && !(defender->bookkeepingFlags & MB_IS_DYING)
         && monstersAreEnemies(monst, defender)
@@ -2004,17 +2004,17 @@ boolean openPathBetween(short x1, short y1, short x2, short y2) {
     return false;
 }
 
-// will return the player if the player is at (x, y).
-creature *monsterAtLoc(short x, short y) {
-    if (!(pmap[x][y].flags & (HAS_MONSTER | HAS_PLAYER))) {
+// will return the player if the player is at (p.x, p.y).
+creature *monsterAtLoc(pos p) {
+    if (!(pmapAt(p)->flags & (HAS_MONSTER | HAS_PLAYER))) {
         return NULL;
     }
-    if (player.loc.x == x && player.loc.y == y) {
+    if (posEq(player.loc, p)) {
         return &player;
     }
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        if (monst->loc.x == x && monst->loc.y == y) {
+        if (posEq(monst->loc, p)) {
             return monst;
         }
     }
@@ -2024,14 +2024,14 @@ creature *monsterAtLoc(short x, short y) {
     return NULL;
 }
 
-creature *dormantMonsterAtLoc(short x, short y) {
-    if (!(pmap[x][y].flags & HAS_DORMANT_MONSTER)) {
+creature *dormantMonsterAtLoc(pos p) {
+    if (!(pmapAt(p)->flags & HAS_DORMANT_MONSTER)) {
         return NULL;
     }
 
     for (creatureIterator it = iterateCreatures(dormantMonsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        if (monst->loc.x == x && monst->loc.y == y) {
+        if (posEq(monst->loc, p)) {
             return monst;
         }
     }
@@ -2741,7 +2741,7 @@ enum directions scentDirection(creature *monst) {
         for (dir=0; dir< DIRECTION_COUNT; dir++) {
             newX = x + nbDirs[dir][0];
             newY = y + nbDirs[dir][1];
-            otherMonst = monsterAtLoc(newX, newY);
+            otherMonst = monsterAtLoc((pos){ newX, newY });
             if (coordinatesAreInMap(newX, newY)
                 && (scentMap[newX][newY] > bestNearbyScent)
                 && (!(pmap[newX][newY].flags & HAS_MONSTER) || (otherMonst && canPass(monst, otherMonst)))
@@ -3656,7 +3656,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
     }
 
     if (pmap[newX][newY].flags & (HAS_MONSTER | HAS_PLAYER)) {
-        defender = monsterAtLoc(newX, newY);
+        defender = monsterAtLoc((pos){ newX, newY });
     } else {
         if (monst->bookkeepingFlags & MB_SEIZED) {
             for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -159,9 +159,9 @@ void describeLocation(char *buf, short x, short y) {
     theItem = itemAtLoc(x, y);
     monsterDormant = false;
     if (pmap[x][y].flags & HAS_MONSTER) {
-        monst = monsterAtLoc(x, y);
+        monst = monsterAtLoc((pos){ x, y });
     } else if (pmap[x][y].flags & HAS_DORMANT_MONSTER) {
-        monst = dormantMonsterAtLoc(x, y);
+        monst = dormantMonsterAtLoc((pos){ x, y });
         monsterDormant = true;
     }
 
@@ -423,7 +423,7 @@ void useKeyAt(item *theItem, short x, short y) {
             deleteItem(theItem);
             pmap[x][y].flags &= ~HAS_ITEM;
         } else if (pmap[x][y].flags & HAS_MONSTER) {
-            monst = monsterAtLoc(x, y);
+            monst = monsterAtLoc((pos){ x, y });
             if (monst->carriedItem && monst->carriedItem == theItem) {
                 monst->carriedItem = NULL;
                 deleteItem(theItem);
@@ -514,7 +514,7 @@ boolean freeCaptivesEmbeddedAt(short x, short y) {
 
     if (pmap[x][y].flags & HAS_MONSTER) {
         // Free any captives trapped in the tunnelized terrain.
-        monst = monsterAtLoc(x, y);
+        monst = monsterAtLoc((pos){ x, y });
         if ((monst->bookkeepingFlags & MB_CAPTIVE)
             && !(monst->info.flags & MONST_ATTACKABLE_THRU_WALLS)
             && (cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY))) {
@@ -584,7 +584,7 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
     pos strikeLoc;
     getImpactLoc(&strikeLoc, originLoc, targetLoc, 5, false, &boltCatalog[BOLT_WHIP]);
 
-    defender = monsterAtLoc(strikeLoc.x, strikeLoc.y);
+    defender = monsterAtLoc(strikeLoc);
     if (defender
         && (attacker != &player || canSeeMonster(defender))
         && !monsterIsHidden(defender, attacker)
@@ -642,7 +642,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         /* Add creatures that we are willing to attack to the potential
         hitlist. Any of those that are either right by us or visible will
         trigger the attack. */
-        defender = monsterAtLoc(targetLoc.x, targetLoc.y);
+        defender = monsterAtLoc(targetLoc);
         if (defender
             && (!cellHasTerrainFlag(targetLoc.x, targetLoc.y, T_OBSTRUCTS_PASSABILITY)
                 || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))
@@ -790,8 +790,8 @@ boolean playerMoves(short direction) {
                     && cellHasTerrainFlag(newestX, newestY, T_LAVA_INSTA_DEATH)
                     && !cellHasTerrainFlag(newestX, newestY, T_OBSTRUCTS_PASSABILITY | T_ENTANGLES)
                     && !((pmap[newestX][newestY].flags & HAS_MONSTER)
-                         && canSeeMonster(monsterAtLoc(newestX, newestY))
-                         && monsterAtLoc(newestX, newestY)->creatureState != MONSTER_ALLY)) {
+                         && canSeeMonster(monsterAtLoc((pos){ newestX, newestY }))
+                         && monsterAtLoc((pos){ newestX, newestY })->creatureState != MONSTER_ALLY)) {
 
                     if (!confirm("Risk stumbling into lava?", false)) {
                         cancelKeystroke();
@@ -819,7 +819,7 @@ boolean playerMoves(short direction) {
     }
 
     if (pmap[newX][newY].flags & HAS_MONSTER) {
-        defender = monsterAtLoc(newX, newY);
+        defender = monsterAtLoc((pos){ newX, newY });
     }
 
     // If there's no enemy at the movement location that the player is aware of, consider terrain promotions.
@@ -1025,7 +1025,7 @@ boolean playerMoves(short direction) {
             newestX = player.loc.x + 2*nbDirs[direction][0];
             newestY = player.loc.y + 2*nbDirs[direction][1];
             if (coordinatesAreInMap(newestX, newestY) && (pmap[newestX][newestY].flags & HAS_MONSTER)) {
-                tempMonst = monsterAtLoc(newestX, newestY);
+                tempMonst = monsterAtLoc((pos){ newestX, newestY });
                 if (tempMonst
                     && canSeeMonster(tempMonst)
                     && monstersAreEnemies(&player, tempMonst)
@@ -1420,7 +1420,7 @@ short nextStep(short **distanceMap, short x, short y, creature *monst, boolean p
         brogueAssert(coordinatesAreInMap(newX, newY));
         if (coordinatesAreInMap(newX, newY)) {
             blocked = false;
-            blocker = monsterAtLoc(newX, newY);
+            blocker = monsterAtLoc((pos){ newX, newY });
             if (monst
                 && monsterAvoids(monst, (pos){newX, newY})) {
 
@@ -1743,7 +1743,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
             }
 
             if (cFlags & HAS_MONSTER) {
-                currentTenant = monsterAtLoc(i, j);
+                currentTenant = monsterAtLoc((pos){ i, j });
                 if (currentTenant
                     && (currentTenant->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))
                     && !canPass(monst, currentTenant)) {
@@ -1789,7 +1789,7 @@ enum directions adjacentFightingDir() {
     }
     for (enum directions dir = 0; dir < DIRECTION_COUNT; dir++) {
         const pos newLoc = posNeighborInDirection(player.loc, dir);
-        creature *const monst = monsterAtLoc(newLoc.x, newLoc.y);
+        creature *const monst = monsterAtLoc(newLoc);
         if (monst
             && canSeeMonster(monst)
             && (!diagonalBlocked(player.loc.x, player.loc.y, newLoc.x, newLoc.y, false) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))
@@ -2012,7 +2012,7 @@ short directionOfKeypress(unsigned short ch) {
 
 boolean startFighting(enum directions dir, boolean tillDeath) {
     const pos neighborLoc = posNeighborInDirection(player.loc, dir);
-    creature * const monst = monsterAtLoc(neighborLoc.x, neighborLoc.y);
+    creature * const monst = monsterAtLoc(neighborLoc);
     if (monst->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE)) {
         return false;
     }
@@ -2030,18 +2030,18 @@ boolean startFighting(enum directions dir, boolean tillDeath) {
             break;
         }
     } while (!rogue.disturbed && !rogue.gameHasEnded && (tillDeath || player.currentHP > expectedDamage)
-             && (pmapAt(neighborLoc)->flags & HAS_MONSTER) && monsterAtLoc(neighborLoc.x, neighborLoc.y) == monst);
+             && (pmapAt(neighborLoc)->flags & HAS_MONSTER) && monsterAtLoc(neighborLoc) == monst);
 
     rogue.blockCombatText = false;
     return rogue.disturbed;
 }
 
 boolean isDisturbed(short x, short y) {
-    short i;
-    creature *monst;
-    for (i=0; i< DIRECTION_COUNT; i++) {
-        monst = monsterAtLoc(x + nbDirs[i][0], y + nbDirs[i][1]);
-        if (pmap[x + nbDirs[i][0]][y + nbDirs[i][1]].flags & (HAS_ITEM)) {
+    pos p = (pos){ x, y };
+    for (int i=0; i< DIRECTION_COUNT; i++) {
+        const pos neighborPos = posNeighborInDirection(p, i);
+        creature *const monst = monsterAtLoc(neighborPos);
+        if (pmapAt(neighborPos)->flags & (HAS_ITEM)) {
             // Do not trigger for submerged or invisible or unseen monsters.
             return true;
         }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3090,8 +3090,8 @@ extern "C" {
                                  unsigned long blockingTerrain, unsigned long blockingFlags);
     boolean traversiblePathBetween(creature *monst, short x2, short y2);
     boolean openPathBetween(short x1, short y1, short x2, short y2);
-    creature *monsterAtLoc(short x, short y);
-    creature *dormantMonsterAtLoc(short x, short y);
+    creature *monsterAtLoc(pos p);
+    creature *dormantMonsterAtLoc(pos p);
     pos perimeterCoords(short n);
     boolean monsterBlinkToPreferenceMap(creature *monst, short **preferenceMap, boolean blinkUphill);
     boolean monsterSummons(creature *monst, boolean alwaysUse);

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1539,7 +1539,7 @@ void updateAllySafetyMap() {
             } else if (cellHasTerrainFlag(i, j, T_SACRED)) {
                 playerCostMap[i][j] = 1;
                 monsterCostMap[i][j] = PDS_FORBIDDEN;
-            } else if ((pmap[i][j].flags & HAS_MONSTER) && monstersAreEnemies(&player, monsterAtLoc(i, j))) {
+            } else if ((pmap[i][j].flags & HAS_MONSTER) && monstersAreEnemies(&player, monsterAtLoc((pos){ i, j }))) {
                 playerCostMap[i][j] = 1;
                 monsterCostMap[i][j] = PDS_FORBIDDEN;
                 allySafetyMap[i][j] = 0;
@@ -1623,7 +1623,7 @@ void updateSafetyMap() {
                 }
             } else {
                 if (pmap[i][j].flags & HAS_MONSTER) {
-                    monst = monsterAtLoc(i, j);
+                    monst = monsterAtLoc((pos){ i, j });
                     if ((monst->creatureState == MONSTER_SLEEPING
                          || monst->turnsSpentStationary > 2
                          || (monst->info.flags & MONST_GETS_TURN_ON_ACTIVATION)
@@ -1735,7 +1735,7 @@ void updateSafeTerrainMap() {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            monst = monsterAtLoc(i, j);
+            monst = monsterAtLoc((pos){ i, j });
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
 
@@ -1893,7 +1893,7 @@ void monsterEntersLevel(creature *monst, short n) {
         && (pmapAt(monst->loc)->flags & (HAS_PLAYER | HAS_MONSTER))
         && !(terrainFlags(monst->loc.x, monst->loc.y) & avoidedFlagsForMonster(&(monst->info)))) {
         // Monsters using the stairs will displace any creatures already located there, to thwart stair-dancing.
-        creature *prevMonst = monsterAtLoc(monst->loc.x, monst->loc.y);
+        creature *prevMonst = monsterAtLoc(monst->loc);
         brogueAssert(prevMonst);
         getQualifyingPathLocNear(&(prevMonst->loc.x), &(prevMonst->loc.y), monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(prevMonst->info)), 0,

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -396,7 +396,7 @@ static void dialogCreateMonster() {
         }
 
         // If there's already a monster here, quietly bury the body.
-        oldMonster = monsterAtLoc(selectedPosition.x, selectedPosition.y);
+        oldMonster = monsterAtLoc(selectedPosition);
         if (oldMonster) {
             killCreature(oldMonster, true);
             removeDeadMonsters();


### PR DESCRIPTION
The `monsterAtLoc` and `dormantMonsterAtLoc` functions are commonly-used, but they still didn't take a `pos` argument. This change should have no observable difference in behavior.