### PR TITLE
[Issue 508] Potion of life can heal an ally.

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5982,7 +5982,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
                         itemTable potionTable = tableForItemCategory(theItem->category)[theItem->kind];
                         increaseMaxHealthAndHeal(monst, randClump(potionTable.range));
                         return;
-                    }
+                }
 
                 break;
             }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5977,6 +5977,8 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
                 if ((theItem->category & POTION)
                     && monst->creatureState == MONSTER_ALLY
                     && theItem->kind == POTION_LIFE) {
+                        sprintf(buf, "your %s ally catches the potion and guzzles down the whole thing.", monst->info.monsterName);
+                        message(buf, 0);
                         itemTable potionTable = tableForItemCategory(theItem->category)[theItem->kind];
                         increaseMaxHealthAndHeal(monst, randClump(potionTable.range));
                         return;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5973,6 +5973,15 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
                     deleteItem(theItem);
                     return;
                 }
+
+                if ((theItem->category & POTION)
+                    && monst->creatureState == MONSTER_ALLY
+                    && theItem->kind == POTION_LIFE) {
+                        itemTable potionTable = tableForItemCategory(theItem->category)[theItem->kind];
+                        increaseMaxHealthAndHeal(monst, randClump(potionTable.range));
+                        return;
+                    }
+
                 break;
             }
         }
@@ -7162,18 +7171,16 @@ void increaseMaxHealthAndHeal(creature *monst, int maxHealthIncrease) {
 
     if (monst == &player) {
         sprintf(buf, "%syour maximum health increases by %i%%.", isHealed ? "you heal completely and " : "", healthIncrease);
-
     } else if (monst->creatureState == MONSTER_ALLY) {
         if (isHealed) {
             sprintf(buf, "your %s ally heals completely and $HISHER maximum health increases by %i%%.", monst->info.monsterName, healthIncrease);
-            resolvePronounEscapes(buf, &monst);
+            resolvePronounEscapes(buf, monst);
         } else {
             sprintf(buf, "your %s ally's maximum health increases by %i%%.", monst->info.monsterName, healthIncrease);
         }
     }
 
     messageWithColor(buf, &advancementMessageColor, 0);
-
 }
 
 void drinkPotion(item *theItem) {
@@ -7191,7 +7198,7 @@ void drinkPotion(item *theItem) {
 
     switch (theItem->kind) {
         case POTION_LIFE:
-            int magnitude = randClump(potionTable.range);
+            magnitude = randClump(potionTable.range);
             increaseMaxHealthAndHeal(&player, magnitude);
             updatePlayerRegenerationDelay();
             break;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -7151,6 +7151,31 @@ void detectMagicOnItem(item *theItem) {
     }
 }
 
+void increaseMaxHealthAndHeal(creature *monst, int maxHealthIncrease) {
+    char buf[1000] = "";
+
+    int healthIncrease = (monst->info.maxHP + maxHealthIncrease) * 100 / monst->info.maxHP - 100;
+    boolean isHealed = monst->currentHP < monst->info.maxHP;
+
+    monst->info.maxHP += maxHealthIncrease;
+    heal(monst, 100, true);
+
+    if (monst == &player) {
+        sprintf(buf, "%syour maximum health increases by %i%%.", isHealed ? "you heal completely and " : "", healthIncrease);
+
+    } else if (monst->creatureState == MONSTER_ALLY) {
+        if (isHealed) {
+            sprintf(buf, "your %s ally heals completely and $HISHER maximum health increases by %i%%.", monst->info.monsterName, healthIncrease);
+            resolvePronounEscapes(buf, &monst);
+        } else {
+            sprintf(buf, "your %s ally's maximum health increases by %i%%.", monst->info.monsterName, healthIncrease);
+        }
+    }
+
+    messageWithColor(buf, &advancementMessageColor, 0);
+
+}
+
 void drinkPotion(item *theItem) {
     item *tempItem = NULL;
     boolean hadEffect = false;
@@ -7166,15 +7191,9 @@ void drinkPotion(item *theItem) {
 
     switch (theItem->kind) {
         case POTION_LIFE:
-            magnitude = randClump(potionTable.range);
-            sprintf(buf, "%syour maximum health increases by %i%%.",
-                    ((player.currentHP < player.info.maxHP) ? "you heal completely and " : ""),
-                    (player.info.maxHP + magnitude) * 100 / player.info.maxHP - 100);
-
-            player.info.maxHP += magnitude;
-            heal(&player, 100, true);
+            int magnitude = randClump(potionTable.range);
+            increaseMaxHealthAndHeal(&player, magnitude);
             updatePlayerRegenerationDelay();
-            messageWithColor(buf, &advancementMessageColor, 0);
             break;
         case POTION_HALLUCINATION:
             magnitude = randClump(potionTable.range);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -7189,7 +7189,6 @@ void drinkPotion(item *theItem) {
     item *tempItem = NULL;
     boolean hadEffect = false;
     boolean hadEffect2 = false;
-    char buf[1000] = "";
     int magnitude;
 
     brogueAssert(rogue.RNG == RNG_SUBSTANTIVE);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3255,6 +3255,7 @@ extern "C" {
     void updatePlayerRegenerationDelay();
     boolean removeItemFromChain(item *theItem, item *theChain);
     void addItemToChain(item *theItem, item *theChain);
+    void increaseMaxHealthAndHeal(creature *monst, int maxHealthIncrease);
     void drinkPotion(item *theItem);
     item *promptForItemOfType(unsigned short category,
                               unsigned long requiredFlags,


### PR DESCRIPTION
This is my first commit I'm submitting to brogueCE and I also am not familiar with C. So sorry ahead of time if everything isn't perfect. 

This resolves Issue #508 
before throwing a life potion:
<img width="1288" alt="image" src="https://github.com/tmewett/BrogueCE/assets/3633090/99211029-5344-43e8-8d1b-e7f255862cff">
after throwing
<img width="1377" alt="image" src="https://github.com/tmewett/BrogueCE/assets/3633090/47e44f77-d0d5-4fe6-a66b-2704fd292862">
<img width="1265" alt="image" src="https://github.com/tmewett/BrogueCE/assets/3633090/70d2cf9a-824e-4b12-96e3-82a115b79428">
throwing again with the ally at full health.
<img width="1323" alt="image" src="https://github.com/tmewett/BrogueCE/assets/3633090/b28e1a9f-eadc-4c36-a789-ec2bce962b21">
using a potion of life on yourself still works
<img width="845" alt="image" src="https://github.com/tmewett/BrogueCE/assets/3633090/1c931e38-cba1-4849-9839-dfaeef72ca52">



