### PR TITLE
refactor `buildAMachine`

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,7 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
+    short totalFreq, instance, instanceCount = 0,
         featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
@@ -1036,7 +1036,7 @@ boolean buildAMachine(enum machineTypes bp,
             }
 
             // Pick from among the suitable blueprints.
-            randIndex = rand_range(1, totalFreq);
+            int randIndex = rand_range(1, totalFreq);
             for (int i=1; i<gameConst->numberBlueprints; i++) {
                 if (blueprintQualifies(i, requiredMachineFlags)) {
                     if (randIndex <= blueprintCatalog[i].frequency) {
@@ -1077,7 +1077,7 @@ boolean buildAMachine(enum machineTypes bp,
 
                 if (totalFreq) {
                     // Choose the gate.
-                    randIndex = rand_range(0, totalFreq - 1);
+                    const int randIndex = rand_range(0, totalFreq - 1);
                     originX = p->gateCandidates[randIndex].x;
                     originY = p->gateCandidates[randIndex].y;
                 } else {
@@ -1211,7 +1211,7 @@ boolean buildAMachine(enum machineTypes bp,
                     pmap[i][j].layers[DUNGEON] = DOOR;
                 }
                 // Clear wired tiles in case we stole them from another machine.
-                for (layer = 0; layer < NUMBER_TERRAIN_LAYERS; layer++) {
+                for (short layer = 0; layer < NUMBER_TERRAIN_LAYERS; layer++) {
                     if (tileCatalog[pmap[i][j].layers[layer]].mechFlags & (TM_IS_WIRED | TM_IS_CIRCUIT_BREAKER)) {
                         pmap[i][j].layers[layer] = (layer == DUNGEON ? FLOOR : NOTHING);
                     }
@@ -1278,7 +1278,7 @@ boolean buildAMachine(enum machineTypes bp,
             }
         }
         if (totalFreq > 0) {
-            randIndex = rand_range(1, totalFreq);
+            int randIndex = rand_range(1, totalFreq);
             for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
                 if (blueprintCatalog[bp].feature[i].flags & alternativeFlags[j]) {
                     if (randIndex == 1) {
@@ -1299,7 +1299,7 @@ boolean buildAMachine(enum machineTypes bp,
     zeroOutGrid(p->occupied);
 
     // Now tick through the features and build them.
-    for (feat = 0; feat < blueprintCatalog[bp].featureCount; feat++) {
+    for (int feat = 0; feat < blueprintCatalog[bp].featureCount; feat++) {
 
         if (skipFeature[feat]) {
             continue; // Skip the alternative features that were not selected for building.
@@ -1384,7 +1384,7 @@ boolean buildAMachine(enum machineTypes bp,
                     // the candidates map so that subsequent instances of this same feature can't choose it.
                     featX = -1;
                     featY = -1;
-                    randIndex = rand_range(1, qualifyingTileCount);
+                    int randIndex = rand_range(1, qualifyingTileCount);
                     for(int i=0; i<DCOLS && featX < 0; i++) {
                         for(int j=0; j<DROWS && featX < 0; j++) {
                             if (p->candidates[i][j]) {

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,7 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short i, j, k, layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
+    short layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
         featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
@@ -1019,7 +1019,7 @@ boolean buildAMachine(enum machineTypes bp,
             // First, choose the blueprint. We choose from among blueprints
             // that have the required blueprint flags and that satisfy the depth requirements.
             totalFreq = 0;
-            for (i=1; i<gameConst->numberBlueprints; i++) {
+            for (int i=1; i<gameConst->numberBlueprints; i++) {
                 if (blueprintQualifies(i, requiredMachineFlags)) {
                     totalFreq += blueprintCatalog[i].frequency;
                 }
@@ -1037,7 +1037,7 @@ boolean buildAMachine(enum machineTypes bp,
 
             // Pick from among the suitable blueprints.
             randIndex = rand_range(1, totalFreq);
-            for (i=1; i<gameConst->numberBlueprints; i++) {
+            for (int i=1; i<gameConst->numberBlueprints; i++) {
                 if (blueprintQualifies(i, requiredMachineFlags)) {
                     if (randIndex <= blueprintCatalog[i].frequency) {
                         bp = i;
@@ -1061,8 +1061,8 @@ boolean buildAMachine(enum machineTypes bp,
             if (chooseLocation) {
                 analyzeMap(true); // Make sure the chokeMap is up to date.
                 totalFreq = 0;
-                for(i=0; i<DCOLS; i++) {
-                    for(j=0; j<DROWS && totalFreq < 50; j++) {
+                for(int i=0; i<DCOLS; i++) {
+                    for(int j=0; j<DROWS && totalFreq < 50; j++) {
                         if ((pmap[i][j].flags & IS_GATE_SITE)
                             && !(pmap[i][j].flags & IS_IN_MACHINE)
                             && chokeMap[i][j] >= blueprintCatalog[bp].roomSize[0]
@@ -1150,9 +1150,9 @@ boolean buildAMachine(enum machineTypes bp,
                 fillSequentialList(p->sRows, DROWS);
                 shuffleList(p->sRows, DROWS);
 
-                for (k=0; k<1000 && qualifyingTileCount < totalFreq; k++) {
-                    for(i=0; i<DCOLS && qualifyingTileCount < totalFreq; i++) {
-                        for(j=0; j<DROWS && qualifyingTileCount < totalFreq; j++) {
+                for (int k=0; k<1000 && qualifyingTileCount < totalFreq; k++) {
+                    for(int i=0; i<DCOLS && qualifyingTileCount < totalFreq; i++) {
+                        for(int j=0; j<DROWS && qualifyingTileCount < totalFreq; j++) {
                             if (distanceMap[p->sCols[i]][p->sRows[j]] == k) {
                                 p->interior[p->sCols[i]][p->sRows[j]] = true;
                                 qualifyingTileCount++;
@@ -1201,8 +1201,8 @@ boolean buildAMachine(enum machineTypes bp,
 
     // If necessary, label the interior as IS_IN_AREA_MACHINE or IS_IN_ROOM_MACHINE and mark down the number.
     machineNumber = ++rogue.machineNumber; // Reserve this machine number, starting with 1.
-    for(i=0; i<DCOLS; i++) {
-        for(j=0; j<DROWS; j++) {
+    for(int i=0; i<DCOLS; i++) {
+        for(int j=0; j<DROWS; j++) {
             if (p->interior[i][j]) {
                 pmap[i][j].flags |= ((blueprintCatalog[bp].flags & BP_ROOM) ? IS_IN_ROOM_MACHINE : IS_IN_AREA_MACHINE);
                 pmap[i][j].machineNumber = machineNumber;
@@ -1231,11 +1231,11 @@ boolean buildAMachine(enum machineTypes bp,
     fillGrid(distanceMap, 0);
     calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, true);
     qualifyingTileCount = 0;
-    for (i=0; i<100; i++) {
+    for (int i=0; i<100; i++) {
         p->distances[i] = 0;
     }
-    for(i=0; i<DCOLS; i++) {
-        for(j=0; j<DROWS; j++) {
+    for(int i=0; i<DCOLS; i++) {
+        for(int j=0; j<DROWS; j++) {
             if (p->interior[i][j]
                 && distanceMap[i][j] < 100) {
                 p->distances[distanceMap[i][j]]++; // create a histogram of distances -- poor man's sort function
@@ -1245,7 +1245,7 @@ boolean buildAMachine(enum machineTypes bp,
     }
     distance25 = (int) (qualifyingTileCount / 4);
     distance75 = (int) (3 * qualifyingTileCount / 4);
-    for (i=0; i<100; i++) {
+    for (int i=0; i<100; i++) {
         if (distance25 <= p->distances[i]) {
             distance25 = i;
             break;
@@ -1253,7 +1253,7 @@ boolean buildAMachine(enum machineTypes bp,
             distance25 -= p->distances[i];
         }
     }
-    for (i=0; i<100; i++) {
+    for (int i=0; i<100; i++) {
         if (distance75 <= p->distances[i]) {
             distance75 = i;
             break;
@@ -1266,12 +1266,12 @@ boolean buildAMachine(enum machineTypes bp,
     // Now decide which features will be skipped -- of the features marked MF_ALTERNATIVE, skip all but one, chosen randomly.
     // Then repeat and do the same with respect to MF_ALTERNATIVE_2, to provide up to two independent sets of alternative features per machine.
 
-    for (i=0; i<blueprintCatalog[bp].featureCount; i++) {
+    for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
         skipFeature[i] = false;
     }
-    for (j = 0; j <= 1; j++) {
+    for (int j = 0; j <= 1; j++) {
         totalFreq = 0;
-        for (i=0; i<blueprintCatalog[bp].featureCount; i++) {
+        for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
             if (blueprintCatalog[bp].feature[i].flags & alternativeFlags[j]) {
                 skipFeature[i] = true;
                 totalFreq++;
@@ -1279,7 +1279,7 @@ boolean buildAMachine(enum machineTypes bp,
         }
         if (totalFreq > 0) {
             randIndex = rand_range(1, totalFreq);
-            for (i=0; i<blueprintCatalog[bp].featureCount; i++) {
+            for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
                 if (blueprintCatalog[bp].feature[i].flags & alternativeFlags[j]) {
                     if (randIndex == 1) {
                         skipFeature[i] = false; // This is the alternative that gets built. The rest do not.
@@ -1337,8 +1337,8 @@ boolean buildAMachine(enum machineTypes bp,
 
             // Make a master map of candidate locations for this feature.
             qualifyingTileCount = 0;
-            for(i=0; i<DCOLS; i++) {
-                for(j=0; j<DROWS; j++) {
+            for(int i=0; i<DCOLS; i++) {
+                for(int j=0; j<DROWS; j++) {
                     if (cellIsFeatureCandidate(i, j,
                                                originX, originY,
                                                distanceBound,
@@ -1385,8 +1385,8 @@ boolean buildAMachine(enum machineTypes bp,
                     featX = -1;
                     featY = -1;
                     randIndex = rand_range(1, qualifyingTileCount);
-                    for(i=0; i<DCOLS && featX < 0; i++) {
-                        for(j=0; j<DROWS && featX < 0; j++) {
+                    for(int i=0; i<DCOLS && featX < 0; i++) {
+                        for(int j=0; j<DROWS && featX < 0; j++) {
                             if (p->candidates[i][j]) {
                                 if (randIndex == 1) {
                                     // This is the place!
@@ -1433,10 +1433,10 @@ boolean buildAMachine(enum machineTypes bp,
                 // Personal space of 0 means nothing gets cleared, 1 means that only the tile itself gets cleared, and 2 means the 3x3 grid centered on it.
 
                 if (DFSucceeded && terrainSucceeded) {
-                    for (i = featX - personalSpace + 1;
+                    for (int i = featX - personalSpace + 1;
                          i <= featX + personalSpace - 1;
                          i++) {
-                        for (j = featY - personalSpace + 1;
+                        for (int j = featY - personalSpace + 1;
                              j <= featY + personalSpace - 1;
                              j++) {
                             if (coordinatesAreInMap(i, j)) {
@@ -1512,6 +1512,7 @@ boolean buildAMachine(enum machineTypes bp,
                         // Also, if we build a sub-machine, and it succeeds, but this (its parent machine) fails,
                         // we pass the monsters and items that it spawned back to the parent,
                         // so that if the parent fails, they can all be freed.
+                        int i;
                         for (i=10; i > 0; i--) {
                             // First make sure our adopted item, if any, is not on the floor or in the pack already.
                             // Otherwise, a previous attempt to place it may have put it on the floor in a different
@@ -1530,12 +1531,12 @@ boolean buildAMachine(enum machineTypes bp,
                             if (success) {
                                 // Success! Now we have to add that machine's items and monsters to our own list, so they
                                 // all get deleted if this machine or its parent fails.
-                                for (j=0; j<MACHINES_BUFFER_LENGTH && p->spawnedItemsSub[j]; j++) {
+                                for (int j=0; j<MACHINES_BUFFER_LENGTH && p->spawnedItemsSub[j]; j++) {
                                     p->spawnedItems[itemCount] = p->spawnedItemsSub[j];
                                     itemCount++;
                                     p->spawnedItemsSub[j] = NULL;
                                 }
-                                for (j=0; j<MACHINES_BUFFER_LENGTH && p->spawnedMonstersSub[j]; j++) {
+                                for (int j=0; j<MACHINES_BUFFER_LENGTH && p->spawnedMonstersSub[j]; j++) {
                                     p->spawnedMonsters[monsterCount] = p->spawnedMonstersSub[j];
                                     monsterCount++;
                                     p->spawnedMonstersSub[j] = NULL;
@@ -1544,7 +1545,7 @@ boolean buildAMachine(enum machineTypes bp,
                             }
                         }
 
-                        if (!i) {
+                        if (i != 0) {
                             if (D_MESSAGE_MACHINE_GENERATION) printf("\nDepth %i: Failed to place blueprint %i because it requires an adoptive machine and we couldn't place one.", rogue.depthLevel, bp);
                             // failure! abort!
                             copyMap(p->levelBackup, pmap);
@@ -1662,8 +1663,8 @@ boolean buildAMachine(enum machineTypes bp,
 
     // Clear out the interior flag for all non-wired cells, if requested.
     if (blueprintCatalog[bp].flags & BP_NO_INTERIOR_FLAG) {
-        for(i=0; i<DCOLS; i++) {
-            for(j=0; j<DROWS; j++) {
+        for(int i=0; i<DCOLS; i++) {
+            for(int j=0; j<DROWS; j++) {
                 if (pmap[i][j].machineNumber == machineNumber
                     && !cellHasTMFlag(i, j, (TM_IS_WIRED | TM_IS_CIRCUIT_BREAKER))) {
 
@@ -1687,12 +1688,12 @@ boolean buildAMachine(enum machineTypes bp,
 
     //Pass created items and monsters to parent where they will be deleted on failure to place parent machine
     if (parentSpawnedItems) {
-        for (i=0; i<itemCount; i++) {
+        for (int i=0; i<itemCount; i++) {
             parentSpawnedItems[i] = p->spawnedItems[i];
         }
     }
     if (parentSpawnedMonsters) {
-        for (i=0; i<monsterCount; i++) {
+        for (int i=0; i<monsterCount; i++) {
             parentSpawnedMonsters[i] = p->spawnedMonsters[i];
         }
     }

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,7 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short itemCount, monsterCount, qualifyingTileCount,
+    short qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
         machineNumber;
@@ -1292,7 +1292,8 @@ boolean buildAMachine(enum machineTypes bp,
     }
 
     // Keep track of all monsters and items that we spawn -- if we abort, we have to go back and delete them all.
-    itemCount = monsterCount = 0;
+    int monsterCount = 0;
+    int itemCount = 0;
 
     // Zero out occupied[][], and use it to keep track of the personal space around each feature that gets placed.
     zeroOutGrid(p->occupied);

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,7 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short totalFreq, instance, instanceCount = 0,
+    short instance, instanceCount = 0,
         featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
@@ -1018,7 +1018,7 @@ boolean buildAMachine(enum machineTypes bp,
 
             // First, choose the blueprint. We choose from among blueprints
             // that have the required blueprint flags and that satisfy the depth requirements.
-            totalFreq = 0;
+            int totalFreq = 0;
             for (int i=1; i<gameConst->numberBlueprints; i++) {
                 if (blueprintQualifies(i, requiredMachineFlags)) {
                     totalFreq += blueprintCatalog[i].frequency;
@@ -1060,7 +1060,7 @@ boolean buildAMachine(enum machineTypes bp,
 
             if (chooseLocation) {
                 analyzeMap(true); // Make sure the chokeMap is up to date.
-                totalFreq = 0;
+                int totalFreq = 0;
                 for(int i=0; i<DCOLS; i++) {
                     for(int j=0; j<DROWS && totalFreq < 50; j++) {
                         if ((pmap[i][j].flags & IS_GATE_SITE)
@@ -1143,7 +1143,7 @@ boolean buildAMachine(enum machineTypes bp,
                 fillGrid(distanceMap, 0);
                 calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, false);
                 qualifyingTileCount = 0; // Keeps track of how many interior cells we've added.
-                totalFreq = rand_range(blueprintCatalog[bp].roomSize[0], blueprintCatalog[bp].roomSize[1]); // Keeps track of the goal size.
+                const int totalFreq = rand_range(blueprintCatalog[bp].roomSize[0], blueprintCatalog[bp].roomSize[1]); // Keeps track of the goal size.
 
                 fillSequentialList(p->sCols, DCOLS);
                 shuffleList(p->sCols, DCOLS);
@@ -1270,7 +1270,7 @@ boolean buildAMachine(enum machineTypes bp,
         skipFeature[i] = false;
     }
     for (int j = 0; j <= 1; j++) {
-        totalFreq = 0;
+        int totalFreq = 0;
         for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
             if (blueprintCatalog[bp].feature[i].flags & alternativeFlags[j]) {
                 skipFeature[i] = true;

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,7 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short instance, instanceCount = 0,
+    short instanceCount = 0,
         featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
@@ -1333,6 +1333,7 @@ boolean buildAMachine(enum machineTypes bp,
             }
         }
 
+        int instance;
         do { // If the MF_REPEAT_UNTIL_NO_PROGRESS flag is set, repeat until we fail to build the required number of instances.
 
             // Make a master map of candidate locations for this feature.
@@ -1372,7 +1373,8 @@ boolean buildAMachine(enum machineTypes bp,
             // Cache the personal space constant.
             personalSpace = feature->personalSpace;
 
-            for (instance = 0; (generateEverywhere || instance < instanceCount) && qualifyingTileCount > 0;) {
+            instance = 0;
+            while ((generateEverywhere || instance < instanceCount) && qualifyingTileCount > 0) {
 
                 // Find a location for the feature.
                 if (feature->flags & MF_BUILD_AT_ORIGIN) {

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,8 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short qualifyingTileCount,
-        **distanceMap = NULL, distance25, distance75, distanceBound[2],
+    short **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
         machineNumber;
 
@@ -1141,7 +1140,7 @@ boolean buildAMachine(enum machineTypes bp,
                 }
                 fillGrid(distanceMap, 0);
                 calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, false);
-                qualifyingTileCount = 0; // Keeps track of how many interior cells we've added.
+                int qualifyingTileCount = 0; // Keeps track of how many interior cells we've added.
                 const int totalFreq = rand_range(blueprintCatalog[bp].roomSize[0], blueprintCatalog[bp].roomSize[1]); // Keeps track of the goal size.
 
                 fillSequentialList(p->sCols, DCOLS);
@@ -1229,7 +1228,7 @@ boolean buildAMachine(enum machineTypes bp,
     }
     fillGrid(distanceMap, 0);
     calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, true);
-    qualifyingTileCount = 0;
+    int qualifyingTileCount = 0;
     for (int i=0; i<100; i++) {
         p->distances[i] = 0;
     }

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,8 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short instanceCount = 0,
-        featX, featY, itemCount, monsterCount, qualifyingTileCount,
+    short featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
         machineNumber;
@@ -1361,6 +1360,7 @@ boolean buildAMachine(enum machineTypes bp,
                 temporaryMessage("Indicating: Occupied (red); Candidates (green); Interior (blue).", REQUIRE_ACKNOWLEDGMENT);
             }
 
+            int instanceCount = 0;
             if (feature->flags & MF_EVERYWHERE & ~MF_BUILD_AT_ORIGIN) {
                 // Generate everywhere that qualifies -- instead of randomly picking tiles, keep spawning until we run out of eligible tiles.
                 generateEverywhere = true;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2857,8 +2857,8 @@ extern "C" {
                           short originX, short originY,
                           unsigned long requiredMachineFlags,
                           item *adoptiveItem,
-                          item *parentSpawnedItems[50],
-                          creature *parentSpawnedMonsters[50]);
+                          item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
+                          creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]);
     void attachRooms(short **grid, const dungeonProfile *theDP, short attempts, short maxRoomCount);
     void digDungeon();
     void updateMapToShore();

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -143,6 +143,7 @@ typedef struct pos {
 } pos;
 
 #define INVALID_POS ((pos) { .x = -1, .y = -1 })
+#define TOP_LEFT ((pos) {.x = 0, .y = 0 })
 
 static inline boolean posEq(pos a, pos b) {
     return a.x == b.x && a.y == b.y;
@@ -156,6 +157,8 @@ typedef struct windowpos {
     short window_y;
 } windowpos;
 
+#define STAT_BAR_WIDTH          20          // number of characters in the stats bar to the left of the map
+
 // Size of the portion of the terminal window devoted to displaying the dungeon:
 #define DCOLS                   (COLS - STAT_BAR_WIDTH - 1) // n columns on the left for the sidebar;
                                                             // one column to separate the sidebar from the map.
@@ -163,7 +166,23 @@ typedef struct windowpos {
                                                             // one line at the bottom for flavor text;
                                                             // another line at the bottom for the menu bar.
 
-#define STAT_BAR_WIDTH          20          // number of characters in the stats bar to the left of the map
+inline static boolean isPosInMap(pos p) {
+    return p.x >= 0 && p.x < DCOLS && p.y >= 0 && p.y < DROWS;
+}
+
+// Returns the "next" position in the map, or returns `INVALID_POS` if it was the last one.
+static inline pos posNext(pos at) {
+    brogueAssert(isPosInMap(at));
+    at.y += 1;
+    if (at.y == DROWS) {
+        at.y = 0;
+        at.x++;
+    }
+    if (!isPosInMap(at)) {
+        return INVALID_POS;
+    }
+    return at;
+}
 
 #define LOS_SLOPE_GRANULARITY   32768       // how finely we divide up the squares when calculating slope;
                                             // higher numbers mean fewer artifacts but more memory and processing
@@ -1234,10 +1253,6 @@ boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask);
                                                 && cellHasTerrainFlag((x), (y), T_OBSTRUCTS_PASSABILITY)))
 
 #define coordinatesAreInMap(x, y)           ((x) >= 0 && (x) < DCOLS    && (y) >= 0 && (y) < DROWS)
-
-inline static boolean isPosInMap(pos p) {
-    return p.x >= 0 && p.x < DCOLS && p.y >= 0 && p.y < DROWS;
-}
 
 inline static boolean locIsInWindow(windowpos w) {
     return w.window_x >= 0 && w.window_x < COLS && w.window_y >= 0 && w.window_y < ROWS;


### PR DESCRIPTION
The `buildAMachine` function was 850 lines long, and fairly complicated. It still is, but I've cleaned it up a little.

There are three main parts to this PR:

- `buildAMachine` originally defined about 30 variables at the top of the function; those that can be have been moved to lower scopes and marked `const` if possible
- `buildAMachine` now takes a `pos origin` as an argument instead of separate `short originX`, `short originY`
- when iterating over the whole dungeon, a new `for (pos at = TOP_LEFT; isPosInMap(at); at = posNext(at))` pattern is used
  - this simplifies control-flow in a few places because we can just `break` out of the loop without needing extra flags (since it's only one level deep now instead of 2)

This should be replay-compatible.

---

This PR has a lot of individual commits - I'd recommend squash+merge since they're almost all really small.

The indentation has changed in a few places, so I recommend comparing with the "hide whitespace" option, to clearly show what's changed and what's the same.