### PR TITLE
refactor `buildAMachine`

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,7 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short i, j, k, layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
+    short j, k, layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
         featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
@@ -1019,7 +1019,7 @@ boolean buildAMachine(enum machineTypes bp,
             // First, choose the blueprint. We choose from among blueprints
             // that have the required blueprint flags and that satisfy the depth requirements.
             totalFreq = 0;
-            for (i=1; i<gameConst->numberBlueprints; i++) {
+            for (int i=1; i<gameConst->numberBlueprints; i++) {
                 if (blueprintQualifies(i, requiredMachineFlags)) {
                     totalFreq += blueprintCatalog[i].frequency;
                 }
@@ -1037,7 +1037,7 @@ boolean buildAMachine(enum machineTypes bp,
 
             // Pick from among the suitable blueprints.
             randIndex = rand_range(1, totalFreq);
-            for (i=1; i<gameConst->numberBlueprints; i++) {
+            for (int i=1; i<gameConst->numberBlueprints; i++) {
                 if (blueprintQualifies(i, requiredMachineFlags)) {
                     if (randIndex <= blueprintCatalog[i].frequency) {
                         bp = i;
@@ -1061,7 +1061,7 @@ boolean buildAMachine(enum machineTypes bp,
             if (chooseLocation) {
                 analyzeMap(true); // Make sure the chokeMap is up to date.
                 totalFreq = 0;
-                for(i=0; i<DCOLS; i++) {
+                for(int i=0; i<DCOLS; i++) {
                     for(j=0; j<DROWS && totalFreq < 50; j++) {
                         if ((pmap[i][j].flags & IS_GATE_SITE)
                             && !(pmap[i][j].flags & IS_IN_MACHINE)
@@ -1151,7 +1151,7 @@ boolean buildAMachine(enum machineTypes bp,
                 shuffleList(p->sRows, DROWS);
 
                 for (k=0; k<1000 && qualifyingTileCount < totalFreq; k++) {
-                    for(i=0; i<DCOLS && qualifyingTileCount < totalFreq; i++) {
+                    for(int i=0; i<DCOLS && qualifyingTileCount < totalFreq; i++) {
                         for(j=0; j<DROWS && qualifyingTileCount < totalFreq; j++) {
                             if (distanceMap[p->sCols[i]][p->sRows[j]] == k) {
                                 p->interior[p->sCols[i]][p->sRows[j]] = true;
@@ -1201,7 +1201,7 @@ boolean buildAMachine(enum machineTypes bp,
 
     // If necessary, label the interior as IS_IN_AREA_MACHINE or IS_IN_ROOM_MACHINE and mark down the number.
     machineNumber = ++rogue.machineNumber; // Reserve this machine number, starting with 1.
-    for(i=0; i<DCOLS; i++) {
+    for(int i=0; i<DCOLS; i++) {
         for(j=0; j<DROWS; j++) {
             if (p->interior[i][j]) {
                 pmap[i][j].flags |= ((blueprintCatalog[bp].flags & BP_ROOM) ? IS_IN_ROOM_MACHINE : IS_IN_AREA_MACHINE);
@@ -1231,10 +1231,10 @@ boolean buildAMachine(enum machineTypes bp,
     fillGrid(distanceMap, 0);
     calculateDistances(distanceMap, originX, originY, T_PATHING_BLOCKER, NULL, true, true);
     qualifyingTileCount = 0;
-    for (i=0; i<100; i++) {
+    for (int i=0; i<100; i++) {
         p->distances[i] = 0;
     }
-    for(i=0; i<DCOLS; i++) {
+    for(int i=0; i<DCOLS; i++) {
         for(j=0; j<DROWS; j++) {
             if (p->interior[i][j]
                 && distanceMap[i][j] < 100) {
@@ -1245,7 +1245,7 @@ boolean buildAMachine(enum machineTypes bp,
     }
     distance25 = (int) (qualifyingTileCount / 4);
     distance75 = (int) (3 * qualifyingTileCount / 4);
-    for (i=0; i<100; i++) {
+    for (int i=0; i<100; i++) {
         if (distance25 <= p->distances[i]) {
             distance25 = i;
             break;
@@ -1253,7 +1253,7 @@ boolean buildAMachine(enum machineTypes bp,
             distance25 -= p->distances[i];
         }
     }
-    for (i=0; i<100; i++) {
+    for (int i=0; i<100; i++) {
         if (distance75 <= p->distances[i]) {
             distance75 = i;
             break;
@@ -1266,12 +1266,12 @@ boolean buildAMachine(enum machineTypes bp,
     // Now decide which features will be skipped -- of the features marked MF_ALTERNATIVE, skip all but one, chosen randomly.
     // Then repeat and do the same with respect to MF_ALTERNATIVE_2, to provide up to two independent sets of alternative features per machine.
 
-    for (i=0; i<blueprintCatalog[bp].featureCount; i++) {
+    for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
         skipFeature[i] = false;
     }
     for (j = 0; j <= 1; j++) {
         totalFreq = 0;
-        for (i=0; i<blueprintCatalog[bp].featureCount; i++) {
+        for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
             if (blueprintCatalog[bp].feature[i].flags & alternativeFlags[j]) {
                 skipFeature[i] = true;
                 totalFreq++;
@@ -1279,7 +1279,7 @@ boolean buildAMachine(enum machineTypes bp,
         }
         if (totalFreq > 0) {
             randIndex = rand_range(1, totalFreq);
-            for (i=0; i<blueprintCatalog[bp].featureCount; i++) {
+            for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
                 if (blueprintCatalog[bp].feature[i].flags & alternativeFlags[j]) {
                     if (randIndex == 1) {
                         skipFeature[i] = false; // This is the alternative that gets built. The rest do not.
@@ -1337,7 +1337,7 @@ boolean buildAMachine(enum machineTypes bp,
 
             // Make a master map of candidate locations for this feature.
             qualifyingTileCount = 0;
-            for(i=0; i<DCOLS; i++) {
+            for(int i=0; i<DCOLS; i++) {
                 for(j=0; j<DROWS; j++) {
                     if (cellIsFeatureCandidate(i, j,
                                                originX, originY,
@@ -1385,7 +1385,7 @@ boolean buildAMachine(enum machineTypes bp,
                     featX = -1;
                     featY = -1;
                     randIndex = rand_range(1, qualifyingTileCount);
-                    for(i=0; i<DCOLS && featX < 0; i++) {
+                    for(int i=0; i<DCOLS && featX < 0; i++) {
                         for(j=0; j<DROWS && featX < 0; j++) {
                             if (p->candidates[i][j]) {
                                 if (randIndex == 1) {
@@ -1433,7 +1433,7 @@ boolean buildAMachine(enum machineTypes bp,
                 // Personal space of 0 means nothing gets cleared, 1 means that only the tile itself gets cleared, and 2 means the 3x3 grid centered on it.
 
                 if (DFSucceeded && terrainSucceeded) {
-                    for (i = featX - personalSpace + 1;
+                    for (int i = featX - personalSpace + 1;
                          i <= featX + personalSpace - 1;
                          i++) {
                         for (j = featY - personalSpace + 1;
@@ -1512,6 +1512,7 @@ boolean buildAMachine(enum machineTypes bp,
                         // Also, if we build a sub-machine, and it succeeds, but this (its parent machine) fails,
                         // we pass the monsters and items that it spawned back to the parent,
                         // so that if the parent fails, they can all be freed.
+                        int i;
                         for (i=10; i > 0; i--) {
                             // First make sure our adopted item, if any, is not on the floor or in the pack already.
                             // Otherwise, a previous attempt to place it may have put it on the floor in a different
@@ -1662,7 +1663,7 @@ boolean buildAMachine(enum machineTypes bp,
 
     // Clear out the interior flag for all non-wired cells, if requested.
     if (blueprintCatalog[bp].flags & BP_NO_INTERIOR_FLAG) {
-        for(i=0; i<DCOLS; i++) {
+        for(int i=0; i<DCOLS; i++) {
             for(j=0; j<DROWS; j++) {
                 if (pmap[i][j].machineNumber == machineNumber
                     && !cellHasTMFlag(i, j, (TM_IS_WIRED | TM_IS_CIRCUIT_BREAKER))) {
@@ -1687,12 +1688,12 @@ boolean buildAMachine(enum machineTypes bp,
 
     //Pass created items and monsters to parent where they will be deleted on failure to place parent machine
     if (parentSpawnedItems) {
-        for (i=0; i<itemCount; i++) {
+        for (int i=0; i<itemCount; i++) {
             parentSpawnedItems[i] = p->spawnedItems[i];
         }
     }
     if (parentSpawnedMonsters) {
-        for (i=0; i<monsterCount; i++) {
+        for (int i=0; i<monsterCount; i++) {
             parentSpawnedMonsters[i] = p->spawnedMonsters[i];
         }
     }

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,7 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short k, layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
+    short layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
         featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
@@ -1150,7 +1150,7 @@ boolean buildAMachine(enum machineTypes bp,
                 fillSequentialList(p->sRows, DROWS);
                 shuffleList(p->sRows, DROWS);
 
-                for (k=0; k<1000 && qualifyingTileCount < totalFreq; k++) {
+                for (int k=0; k<1000 && qualifyingTileCount < totalFreq; k++) {
                     for(int i=0; i<DCOLS && qualifyingTileCount < totalFreq; i++) {
                         for(int j=0; j<DROWS && qualifyingTileCount < totalFreq; j++) {
                             if (distanceMap[p->sCols[i]][p->sRows[j]] == k) {

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,7 +969,7 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short j, k, layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
+    short k, layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
         featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
         personalSpace, failsafe, locationFailsafe,
@@ -1062,7 +1062,7 @@ boolean buildAMachine(enum machineTypes bp,
                 analyzeMap(true); // Make sure the chokeMap is up to date.
                 totalFreq = 0;
                 for(int i=0; i<DCOLS; i++) {
-                    for(j=0; j<DROWS && totalFreq < 50; j++) {
+                    for(int j=0; j<DROWS && totalFreq < 50; j++) {
                         if ((pmap[i][j].flags & IS_GATE_SITE)
                             && !(pmap[i][j].flags & IS_IN_MACHINE)
                             && chokeMap[i][j] >= blueprintCatalog[bp].roomSize[0]
@@ -1152,7 +1152,7 @@ boolean buildAMachine(enum machineTypes bp,
 
                 for (k=0; k<1000 && qualifyingTileCount < totalFreq; k++) {
                     for(int i=0; i<DCOLS && qualifyingTileCount < totalFreq; i++) {
-                        for(j=0; j<DROWS && qualifyingTileCount < totalFreq; j++) {
+                        for(int j=0; j<DROWS && qualifyingTileCount < totalFreq; j++) {
                             if (distanceMap[p->sCols[i]][p->sRows[j]] == k) {
                                 p->interior[p->sCols[i]][p->sRows[j]] = true;
                                 qualifyingTileCount++;
@@ -1202,7 +1202,7 @@ boolean buildAMachine(enum machineTypes bp,
     // If necessary, label the interior as IS_IN_AREA_MACHINE or IS_IN_ROOM_MACHINE and mark down the number.
     machineNumber = ++rogue.machineNumber; // Reserve this machine number, starting with 1.
     for(int i=0; i<DCOLS; i++) {
-        for(j=0; j<DROWS; j++) {
+        for(int j=0; j<DROWS; j++) {
             if (p->interior[i][j]) {
                 pmap[i][j].flags |= ((blueprintCatalog[bp].flags & BP_ROOM) ? IS_IN_ROOM_MACHINE : IS_IN_AREA_MACHINE);
                 pmap[i][j].machineNumber = machineNumber;
@@ -1235,7 +1235,7 @@ boolean buildAMachine(enum machineTypes bp,
         p->distances[i] = 0;
     }
     for(int i=0; i<DCOLS; i++) {
-        for(j=0; j<DROWS; j++) {
+        for(int j=0; j<DROWS; j++) {
             if (p->interior[i][j]
                 && distanceMap[i][j] < 100) {
                 p->distances[distanceMap[i][j]]++; // create a histogram of distances -- poor man's sort function
@@ -1269,7 +1269,7 @@ boolean buildAMachine(enum machineTypes bp,
     for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
         skipFeature[i] = false;
     }
-    for (j = 0; j <= 1; j++) {
+    for (int j = 0; j <= 1; j++) {
         totalFreq = 0;
         for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
             if (blueprintCatalog[bp].feature[i].flags & alternativeFlags[j]) {
@@ -1338,7 +1338,7 @@ boolean buildAMachine(enum machineTypes bp,
             // Make a master map of candidate locations for this feature.
             qualifyingTileCount = 0;
             for(int i=0; i<DCOLS; i++) {
-                for(j=0; j<DROWS; j++) {
+                for(int j=0; j<DROWS; j++) {
                     if (cellIsFeatureCandidate(i, j,
                                                originX, originY,
                                                distanceBound,
@@ -1386,7 +1386,7 @@ boolean buildAMachine(enum machineTypes bp,
                     featY = -1;
                     randIndex = rand_range(1, qualifyingTileCount);
                     for(int i=0; i<DCOLS && featX < 0; i++) {
-                        for(j=0; j<DROWS && featX < 0; j++) {
+                        for(int j=0; j<DROWS && featX < 0; j++) {
                             if (p->candidates[i][j]) {
                                 if (randIndex == 1) {
                                     // This is the place!
@@ -1436,7 +1436,7 @@ boolean buildAMachine(enum machineTypes bp,
                     for (int i = featX - personalSpace + 1;
                          i <= featX + personalSpace - 1;
                          i++) {
-                        for (j = featY - personalSpace + 1;
+                        for (int j = featY - personalSpace + 1;
                              j <= featY + personalSpace - 1;
                              j++) {
                             if (coordinatesAreInMap(i, j)) {
@@ -1531,12 +1531,12 @@ boolean buildAMachine(enum machineTypes bp,
                             if (success) {
                                 // Success! Now we have to add that machine's items and monsters to our own list, so they
                                 // all get deleted if this machine or its parent fails.
-                                for (j=0; j<MACHINES_BUFFER_LENGTH && p->spawnedItemsSub[j]; j++) {
+                                for (int j=0; j<MACHINES_BUFFER_LENGTH && p->spawnedItemsSub[j]; j++) {
                                     p->spawnedItems[itemCount] = p->spawnedItemsSub[j];
                                     itemCount++;
                                     p->spawnedItemsSub[j] = NULL;
                                 }
-                                for (j=0; j<MACHINES_BUFFER_LENGTH && p->spawnedMonstersSub[j]; j++) {
+                                for (int j=0; j<MACHINES_BUFFER_LENGTH && p->spawnedMonstersSub[j]; j++) {
                                     p->spawnedMonsters[monsterCount] = p->spawnedMonstersSub[j];
                                     monsterCount++;
                                     p->spawnedMonstersSub[j] = NULL;
@@ -1664,7 +1664,7 @@ boolean buildAMachine(enum machineTypes bp,
     // Clear out the interior flag for all non-wired cells, if requested.
     if (blueprintCatalog[bp].flags & BP_NO_INTERIOR_FLAG) {
         for(int i=0; i<DCOLS; i++) {
-            for(j=0; j<DROWS; j++) {
+            for(int j=0; j<DROWS; j++) {
                 if (pmap[i][j].machineNumber == machineNumber
                     && !cellHasTMFlag(i, j, (TM_IS_WIRED | TM_IS_CIRCUIT_BREAKER))) {
 

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -969,16 +969,16 @@ boolean buildAMachine(enum machineTypes bp,
                       item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
-    short layer, feat, randIndex, totalFreq, instance, instanceCount = 0,
+    short totalFreq, instance, instanceCount = 0,
         featX, featY, itemCount, monsterCount, qualifyingTileCount,
         **distanceMap = NULL, distance25, distance75, distanceBound[2],
-        personalSpace, failsafe, locationFailsafe,
+        personalSpace, locationFailsafe,
         machineNumber;
 
     const unsigned long alternativeFlags[2] = {MF_ALTERNATIVE, MF_ALTERNATIVE_2};
 
-    boolean DFSucceeded, terrainSucceeded, generateEverywhere, chooseBP,
-        chooseLocation, tryAgain, success = false, skipFeature[20];
+    boolean DFSucceeded, terrainSucceeded, generateEverywhere,
+        tryAgain, success = false, skipFeature[20];
 
     creature *monst = NULL, *torchBearer = NULL, *leader = NULL;
 
@@ -990,11 +990,11 @@ boolean buildAMachine(enum machineTypes bp,
 
     memset(p, 0, sizeof(machineData));
 
-    chooseBP = (((signed short) bp) <= 0 ? true : false);
+    const boolean chooseBP = (((signed short) bp) <= 0 ? true : false);
 
-    chooseLocation = (originX <= 0 || originY <= 0 ? true : false);
+    const boolean chooseLocation = (originX <= 0 || originY <= 0 ? true : false);
 
-    failsafe = 10;
+    int failsafe = 10;
     do {
         tryAgain = false;
         if (--failsafe <= 0) {
@@ -1036,7 +1036,7 @@ boolean buildAMachine(enum machineTypes bp,
             }
 
             // Pick from among the suitable blueprints.
-            randIndex = rand_range(1, totalFreq);
+            int randIndex = rand_range(1, totalFreq);
             for (int i=1; i<gameConst->numberBlueprints; i++) {
                 if (blueprintQualifies(i, requiredMachineFlags)) {
                     if (randIndex <= blueprintCatalog[i].frequency) {
@@ -1077,7 +1077,7 @@ boolean buildAMachine(enum machineTypes bp,
 
                 if (totalFreq) {
                     // Choose the gate.
-                    randIndex = rand_range(0, totalFreq - 1);
+                    const int randIndex = rand_range(0, totalFreq - 1);
                     originX = p->gateCandidates[randIndex].x;
                     originY = p->gateCandidates[randIndex].y;
                 } else {
@@ -1211,7 +1211,7 @@ boolean buildAMachine(enum machineTypes bp,
                     pmap[i][j].layers[DUNGEON] = DOOR;
                 }
                 // Clear wired tiles in case we stole them from another machine.
-                for (layer = 0; layer < NUMBER_TERRAIN_LAYERS; layer++) {
+                for (int layer = 0; layer < NUMBER_TERRAIN_LAYERS; layer++) {
                     if (tileCatalog[pmap[i][j].layers[layer]].mechFlags & (TM_IS_WIRED | TM_IS_CIRCUIT_BREAKER)) {
                         pmap[i][j].layers[layer] = (layer == DUNGEON ? FLOOR : NOTHING);
                     }
@@ -1278,7 +1278,7 @@ boolean buildAMachine(enum machineTypes bp,
             }
         }
         if (totalFreq > 0) {
-            randIndex = rand_range(1, totalFreq);
+            int randIndex = rand_range(1, totalFreq);
             for (int i=0; i<blueprintCatalog[bp].featureCount; i++) {
                 if (blueprintCatalog[bp].feature[i].flags & alternativeFlags[j]) {
                     if (randIndex == 1) {
@@ -1299,7 +1299,7 @@ boolean buildAMachine(enum machineTypes bp,
     zeroOutGrid(p->occupied);
 
     // Now tick through the features and build them.
-    for (feat = 0; feat < blueprintCatalog[bp].featureCount; feat++) {
+    for (int feat = 0; feat < blueprintCatalog[bp].featureCount; feat++) {
 
         if (skipFeature[feat]) {
             continue; // Skip the alternative features that were not selected for building.
@@ -1384,7 +1384,7 @@ boolean buildAMachine(enum machineTypes bp,
                     // the candidates map so that subsequent instances of this same feature can't choose it.
                     featX = -1;
                     featY = -1;
-                    randIndex = rand_range(1, qualifyingTileCount);
+                    int randIndex = rand_range(1, qualifyingTileCount);
                     for(int i=0; i<DCOLS && featX < 0; i++) {
                         for(int j=0; j<DROWS && featX < 0; j++) {
                             if (p->candidates[i][j]) {

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -970,8 +970,8 @@ boolean buildAMachine(enum machineTypes bp,
                       creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]) {
 
     short totalFreq, instance, instanceCount = 0,
-        featX, featY, itemCount, monsterCount, qualifyingTileCount,
-        **distanceMap = NULL, distance25, distance75, distanceBound[2],
+        itemCount, monsterCount, qualifyingTileCount,
+        **distanceMap = NULL,
         personalSpace, locationFailsafe,
         machineNumber;
 
@@ -1243,8 +1243,8 @@ boolean buildAMachine(enum machineTypes bp,
             }
         }
     }
-    distance25 = (int) (qualifyingTileCount / 4);
-    distance75 = (int) (3 * qualifyingTileCount / 4);
+    int distance25 = (int) (qualifyingTileCount / 4);
+    int distance75 = (int) (3 * qualifyingTileCount / 4);
     for (int i=0; i<100; i++) {
         if (distance25 <= p->distances[i]) {
             distance25 = i;
@@ -1308,8 +1308,7 @@ boolean buildAMachine(enum machineTypes bp,
         feature = &(blueprintCatalog[bp].feature[feat]);
 
         // Figure out the distance bounds.
-        distanceBound[0] = 0;
-        distanceBound[1] = 10000;
+        short distanceBound[2] = { 0, 10000 };
         if (feature->flags & MF_NEAR_ORIGIN) {
             distanceBound[1] = distance25;
         }
@@ -1375,6 +1374,8 @@ boolean buildAMachine(enum machineTypes bp,
             for (instance = 0; (generateEverywhere || instance < instanceCount) && qualifyingTileCount > 0;) {
 
                 // Find a location for the feature.
+                int featX;
+                int featY;
                 if (feature->flags & MF_BUILD_AT_ORIGIN) {
                     // Does the feature want to be at the origin? If so, put it there. (Just an optimization.)
                     featX = originX;


### PR DESCRIPTION
This is a really small refactor to `buildAMachine`, which is one of the most complicated functions in `Architect.c`, spanning about 850 lines. To make it a little bit easier to understand, I've reduced the scope of most of the "looping" variables, which makes it clearer that there's no long-range dependencies between their values.

