### PR TITLE
convert randomMatchingLocation to take a 'pos' argument

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -365,12 +365,13 @@ short chooseKind(const itemTable *theTable, short numKinds) {
 item *placeItemAt(item *theItem, pos dest) {
     enum dungeonLayers layer;
     char theItemName[DCOLS], buf[DCOLS];
+
+    // If no valid position is supplied by the caller, choose a random one instead.
     if (!isPosInMap(dest)) {
-        randomMatchingLocation(&dest.x, &dest.y, FLOOR, NOTHING, -1);
-        theItem->loc = dest;
-    } else {
-        theItem->loc = dest;
+        randomMatchingLocation(&dest, FLOOR, NOTHING, -1);
     }
+
+    theItem->loc = dest;
 
     removeItemFromChain(theItem, floorItems); // just in case; double-placing an item will result in game-crashing loops in the item list
     addItemToChain(theItem, floorItems);
@@ -671,7 +672,7 @@ void populateItems(pos upstairs) {
         pos itemPlacementLoc = INVALID_POS;
         if ((theItem->category & FOOD) || ((theItem->category & POTION) && theItem->kind == POTION_STRENGTH)) {
             do {
-                randomMatchingLocation(&itemPlacementLoc.x, &itemPlacementLoc.y, FLOOR, NOTHING, -1); // Food and gain strength don't follow the heat map.
+                randomMatchingLocation(&itemPlacementLoc, FLOOR, NOTHING, -1); // Food and gain strength don't follow the heat map.
             } while (passableArcCount(itemPlacementLoc.x, itemPlacementLoc.y) > 1); // Not in a hallway.
         } else {
             getItemSpawnLoc(itemSpawnHeatMap, &itemPlacementLoc.x, &itemPlacementLoc.y, &totalHeat);

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -799,7 +799,7 @@ creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFla
         i = 0;
         do {
             pos loc;
-            while (!randomMatchingLocation(&loc.x, &loc.y, FLOOR, NOTHING, (hordeCatalog[hordeID].spawnsIn ? hordeCatalog[hordeID].spawnsIn : -1))
+            while (!randomMatchingLocation(&loc, FLOOR, NOTHING, (hordeCatalog[hordeID].spawnsIn ? hordeCatalog[hordeID].spawnsIn : -1))
                    || passableArcCount(loc.x, loc.y) > 1) {
                 if (!--failsafe) {
                     return NULL;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3000,7 +3000,7 @@ extern "C" {
     void freeCreatureList(creatureList *list);
     void removeDeadMonsters();
     void freeEverything();
-    boolean randomMatchingLocation(short *x, short *y, short dungeonType, short liquidType, short terrainType);
+    boolean randomMatchingLocation(pos *loc, short dungeonType, short liquidType, short terrainType);
     enum dungeonLayers highestPriorityLayer(short x, short y, boolean skipGas);
     enum dungeonLayers layerWithTMFlag(short x, short y, unsigned long flag);
     enum dungeonLayers layerWithFlag(short x, short y, unsigned long flag);


### PR DESCRIPTION
This is a small refactor to the `randomMatchingLocation` so that it writes to a `*pos` argument, instead of two `short*` arguments.