### PR TITLE
Refactor monsters.c functions to take `pos` argument

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -1566,8 +1566,7 @@ boolean buildAMachine(enum machineTypes bp,
 
                         if (feature->flags & MF_GENERATE_HORDE) {
                             monst = spawnHorde(0,
-                                               featX,
-                                               featY,
+                                               (pos){ featX, featY },
                                                ((HORDE_IS_SUMMONED | HORDE_LEADER_CAPTIVE) & ~(feature->hordeFlags)),
                                                feature->hordeFlags);
                             if (monst) {
@@ -3308,7 +3307,7 @@ void evacuateCreatures(char blockingMap[DCOLS][DROWS]) {
                 monst = monsterAtLoc((pos) { i, j });
                 pos newLoc;
                 getQualifyingLocNear(&newLoc,
-                                     i, j,
+                                     (pos){ i, j },
                                      true,
                                      blockingMap,
                                      forbiddenFlagsForMonster(&(monst->info)),
@@ -3331,7 +3330,7 @@ boolean spawnDungeonFeature(short x, short y, dungeonFeature *feat, boolean refr
     boolean succeeded;
 
     if ((feat->flags & DFF_RESURRECT_ALLY)
-        && !resurrectAlly(x, y)) {
+        && !resurrectAlly((pos){ x, y })) {
         return false;
     }
 
@@ -3536,7 +3535,7 @@ void restoreItem(item *theItem) {
 
         pos loc;
         // Items can fall into deep water, enclaved lakes, another chasm, even lava!
-        getQualifyingLocNear(&loc, theItem->loc.x, theItem->loc.y, true, 0,
+        getQualifyingLocNear(&loc, theItem->loc, true, 0,
                             (T_OBSTRUCTS_ITEMS),
                             (HAS_MONSTER | HAS_ITEM | HAS_STAIRS), false, false);
 
@@ -3659,10 +3658,10 @@ void initializeLevel() {
     }
 
     pos downLoc;
-    if (getQualifyingGridLocNear(&downLoc, levels[n].downStairsLoc.x, levels[n].downStairsLoc.y, grid, false)) {
+    if (getQualifyingGridLocNear(&downLoc, levels[n].downStairsLoc, grid, false)) {
         prepareForStairs(downLoc.x, downLoc.y, grid);
     } else {
-        getQualifyingLocNear(&downLoc, levels[n].downStairsLoc.x, levels[n].downStairsLoc.y, false, 0,
+        getQualifyingLocNear(&downLoc, levels[n].downStairsLoc, false, 0,
                              (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_ITEMS | T_AUTO_DESCENT | T_IS_DEEP_WATER | T_LAVA_INSTA_DEATH | T_IS_DF_TRAP),
                              (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), true, false);
     }
@@ -3681,10 +3680,10 @@ void initializeLevel() {
     levels[n].downStairsLoc = downLoc;
 
     pos upLoc;
-    if (getQualifyingGridLocNear(&upLoc, levels[n].upStairsLoc.x, levels[n].upStairsLoc.y, grid, false)) {
+    if (getQualifyingGridLocNear(&upLoc, levels[n].upStairsLoc, grid, false)) {
         prepareForStairs(upLoc.x, upLoc.y, grid);
     } else { // Hopefully this never happens.
-        getQualifyingLocNear(&upLoc, levels[n].upStairsLoc.x, levels[n].upStairsLoc.y, false, 0,
+        getQualifyingLocNear(&upLoc, levels[n].upStairsLoc, false, 0,
                              (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_ITEMS | T_AUTO_DESCENT | T_IS_DEEP_WATER | T_LAVA_INSTA_DEATH | T_IS_DF_TRAP),
                              (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), true, false);
     }

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -995,7 +995,7 @@ void processStaggerHit(creature *attacker, creature *defender) {
         && !cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY)
         && !(pmap[newX][newY].flags & (HAS_MONSTER | HAS_PLAYER))) {
 
-        setMonsterLocation(defender, newX, newY);
+        setMonsterLocation(defender, (pos){ newX, newY });
     }
 }
 

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -227,7 +227,7 @@ void calculateDistances(short **distanceMap,
             } else if (canUseSecretDoors
                 && cellHasTMFlag(i, j, TM_IS_SECRET)
                 && cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && !(discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY)) {
+                && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)) {
 
                 cost = 1;
             } else if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -379,7 +379,7 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
     // Fall back to a pathing-agnostic alternative if there are no solutions.
     if (*retValX == -1 && *retValY == -1) {
         pos loc;
-        if (getQualifyingLocNear(&loc, x, y, hallwaysAllowed, NULL,
+        if (getQualifyingLocNear(&loc, (pos){ x, y }, hallwaysAllowed, NULL,
                                  (blockingTerrainFlags | forbiddenTerrainFlags),
                                  (blockingMapFlags | forbiddenMapFlags),
                                  false, deterministic)) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -416,7 +416,7 @@ void fillItemSpawnHeatMap(unsigned short heatMap[DCOLS][DROWS], unsigned short h
         pos neighbor = posNeighborInDirection(loc, dir);
         if (isPosInMap(neighbor)
             && !cellHasTerrainFlag(neighbor.x, neighbor.y, T_IS_DEEP_WATER | T_LAVA_INSTA_DEATH | T_AUTO_DESCENT)
-            && isPassableOrSecretDoor(neighbor.x, neighbor.y)
+            && isPassableOrSecretDoor(neighbor)
             && heatLevel < heatMap[neighbor.x][neighbor.y]) {
 
             fillItemSpawnHeatMap(heatMap, heatLevel, neighbor);
@@ -1182,7 +1182,7 @@ void updateFloorItems() {
         }
         if (cellHasTerrainFlag(x, y, T_MOVES_ITEMS)) {
             pos loc;
-            getQualifyingLocNear(&loc, x, y, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
+            getQualifyingLocNear(&loc, (pos){ x, y }, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
             removeItemAt((pos){ x, y });
             pmapAt(loc)->flags |= HAS_ITEM;
             if (pmap[x][y].flags & ITEM_DETECTED) {
@@ -4408,7 +4408,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                     if (monst->bookkeepingFlags & MB_CAPTIVE) {
                         freeCaptive(monst);
                     }
-                    teleport(monst, -1, -1, false);
+                    teleport(monst, INVALID_POS, false);
                 }
                 break;
             case BE_BECKONING:
@@ -6110,7 +6110,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
         return;
     }
     pos dropLoc;
-    getQualifyingLocNear(&dropLoc, x, y, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
+    getQualifyingLocNear(&dropLoc, (pos){ x, y }, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
     placeItemAt(theItem, dropLoc);
     refreshDungeonCell(dropLoc.x, dropLoc.y);
 }
@@ -6570,7 +6570,7 @@ void useCharm(item *theItem) {
             summonGuardian(theItem);
             break;
         case CHARM_TELEPORTATION:
-            teleport(&player, -1, -1, true);
+            teleport(&player, INVALID_POS, true);
             break;
         case CHARM_RECHARGING:
             rechargeItems(STAFF);
@@ -6872,7 +6872,7 @@ void readScroll(item *theItem) {
             messageWithColor(buf2, &itemMessageColor, 0);
             break;
         case SCROLL_TELEPORT:
-            teleport(&player, -1, -1, true);
+            teleport(&player, INVALID_POS, true);
             break;
         case SCROLL_REMOVE_CURSE:
             for (tempItem = packItems->nextItem; tempItem != NULL; tempItem = tempItem->nextItem) {
@@ -7050,7 +7050,7 @@ void readScroll(item *theItem) {
                     y = player.loc.y + nbDirs[i][1];
                     if (!cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY) && !(pmap[x][y].flags & HAS_MONSTER)
                         && rand_percent(10) && (numberOfMonsters < 3)) {
-                        monst = spawnHorde(0, x, y, (HORDE_LEADER_CAPTIVE | HORDE_NO_PERIODIC_SPAWN | HORDE_IS_SUMMONED | HORDE_MACHINE_ONLY), 0);
+                        monst = spawnHorde(0, (pos){ x, y }, (HORDE_LEADER_CAPTIVE | HORDE_NO_PERIODIC_SPAWN | HORDE_IS_SUMMONED | HORDE_MACHINE_ONLY), 0);
                         if (monst) {
                             // refreshDungeonCell(x, y);
                             // monst->creatureState = MONSTER_TRACKING_SCENT;

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1435,7 +1435,7 @@ short nextStep(short **distanceMap, short x, short y, creature *monst, boolean p
             }
             if ((distanceMap[x][y] - distanceMap[newX][newY]) > bestScore
                 && !diagonalBlocked(x, y, newX, newY, monst == &player)
-                && knownToPlayerAsPassableOrSecretDoor(newX, newY)
+                && knownToPlayerAsPassableOrSecretDoor((pos){ newX, newY })
                 && !blocked) {
 
                 bestDir = dir;
@@ -1651,7 +1651,7 @@ void populateGenericCostMap(short **costMap) {
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
                 costMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag(i, j, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
@@ -1710,7 +1710,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
             getLocationFlags(i, j, &tFlags, NULL, &cFlags, monst == &player);
 
             if ((tFlags & T_OBSTRUCTS_PASSABILITY)
-                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY) || monst == &player)) {
+                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY) || monst == &player)) {
 
                 costMap[i][j] = (tFlags & T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                 continue;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3106,7 +3106,7 @@ extern "C" {
     creature *generateMonster(short monsterID, boolean itemPossible, boolean mutationPossible);
     void mutateMonster(creature *monst, short mutationIndex);
     short chooseMonster(short forLevel);
-    creature *spawnHorde(short hordeID, short x, short y, unsigned long forbiddenFlags, unsigned long requiredFlags);
+    creature *spawnHorde(short hordeID, pos loc, unsigned long forbiddenFlags, unsigned long requiredFlags);
     void fadeInMonster(creature *monst);
 
     creatureList createCreatureList();
@@ -3141,7 +3141,7 @@ extern "C" {
     pos perimeterCoords(short n);
     boolean monsterBlinkToPreferenceMap(creature *monst, short **preferenceMap, boolean blinkUphill);
     boolean monsterSummons(creature *monst, boolean alwaysUse);
-    boolean resurrectAlly(const short x, const short y);
+    boolean resurrectAlly(const pos loc);
     void unAlly(creature *monst);
     boolean monsterFleesFrom(creature *monst, creature *defender);
     void monstersTurn(creature *monst);
@@ -3152,15 +3152,15 @@ extern "C" {
     short runicWeaponChance(item *theItem, boolean customEnchantLevel, fixpt enchantLevel);
     void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed);
     void disentangle(creature *monst);
-    void teleport(creature *monst, short x, short y, boolean respectTerrainAvoidancePreferences);
+    void teleport(creature *monst, pos destination, boolean respectTerrainAvoidancePreferences);
     void chooseNewWanderDestination(creature *monst);
     boolean canPass(creature *mover, creature *blocker);
-    boolean isPassableOrSecretDoor(short x, short y);
-    boolean knownToPlayerAsPassableOrSecretDoor(short x, short y);
-    void setMonsterLocation(creature *monst, short newX, short newY);
+    boolean isPassableOrSecretDoor(pos loc);
+    boolean knownToPlayerAsPassableOrSecretDoor(pos loc);
+    void setMonsterLocation(creature *monst, pos newLoc);
     boolean moveMonster(creature *monst, short dx, short dy);
-    unsigned long burnedTerrainFlagsAtLoc(short x, short y);
-    unsigned long discoveredTerrainFlagsAtLoc(short x, short y);
+    unsigned long burnedTerrainFlagsAtLoc(pos loc);
+    unsigned long discoveredTerrainFlagsAtLoc(pos loc);
     boolean monsterAvoids(creature *monst, pos p);
     short distanceBetween(pos loc1, pos loc2);
     void alertMonster(creature *monst);
@@ -3266,7 +3266,7 @@ extern "C" {
     void drop(item *theItem);
     void findAlternativeHomeFor(creature *monst, short *x, short *y, boolean chooseRandomly);
     boolean getQualifyingLocNear(pos *loc,
-                                 short x, short y,
+                                 pos target,
                                  boolean hallwaysAllowed,
                                  char blockingMap[DCOLS][DROWS],
                                  unsigned long forbiddenTerrainFlags,
@@ -3274,7 +3274,7 @@ extern "C" {
                                  boolean forbidLiquid,
                                  boolean deterministic);
     boolean getQualifyingGridLocNear(pos *loc,
-                                     short x, short y,
+                                     pos target,
                                      boolean grid[DCOLS][DROWS],
                                      boolean deterministic);
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -777,14 +777,14 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     // Position the player.
     pos loc;
     if (stairDirection == 0) { // fell into the level
-        getQualifyingLocNear(&loc, player.loc.x, player.loc.y, true, 0,
+        getQualifyingLocNear(&loc, player.loc, true, 0,
                              (T_PATHING_BLOCKER & ~T_IS_DEEP_WATER),
                              (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
 
         if (cellHasTerrainFlag(loc.x, loc.y, T_IS_DEEP_WATER)) {
             // Fell into deep water... can we swim out of it?
             pos dryLoc;
-            getQualifyingLocNear(&dryLoc, player.loc.x, player.loc.y, true, 0,
+            getQualifyingLocNear(&dryLoc, player.loc, true, 0,
                                 (T_PATHING_BLOCKER),
                                 (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1017,7 +1017,7 @@ void playerFalls() {
         }
     } else {
         message("A strange force seizes you as you fall.", 0);
-        teleport(&player, -1, -1, true);
+        teleport(&player, INVALID_POS, true);
     }
     createFlare(player.loc.x, player.loc.y, GENERIC_FLASH_LIGHT);
     animateFlares(rogue.flares, rogue.flareCount);
@@ -1532,7 +1532,7 @@ void updateAllySafetyMap() {
             playerCostMap[i][j] = monsterCostMap[i][j] = 1;
 
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
                 playerCostMap[i][j] = monsterCostMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag(i, j, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
@@ -1609,7 +1609,7 @@ void updateSafetyMap() {
             playerCostMap[i][j] = monsterCostMap[i][j] = 1; // prophylactic
 
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
                 playerCostMap[i][j] = monsterCostMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag(i, j, T_SACRED)) {
@@ -1659,7 +1659,7 @@ void updateSafetyMap() {
                     }
                     monsterCostMap[i][j] = 5;
                 } else if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                           && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY)
+                           && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
                            && !(pmap[i][j].flags & IN_FIELD_OF_VIEW)) {
                     // Secret door that the player can't currently see
                     playerCostMap[i][j] = 100;
@@ -1685,7 +1685,7 @@ void updateSafetyMap() {
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY)
+                && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
                 && !(pmap[i][j].flags & IN_FIELD_OF_VIEW)) {
 
                 // Secret doors that the player can't see are not particularly safe themselves;
@@ -1738,7 +1738,7 @@ void updateSafeTerrainMap() {
         for (j=0; j<DROWS; j++) {
             monst = monsterAtLoc((pos){ i, j });
             if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc(i, j) & T_OBSTRUCTS_PASSABILITY))) {
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
                 costMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                 rogue.mapToSafeTerrain[i][j] = 30000; // OOS prophylactic


### PR DESCRIPTION
This PR updates functions defined in `Monsters.c` so that they take `pos` arguments instead of `short x`, `short y`. It does some light refactoring inside those functions to make better use of the new `pos` argument when possible.