### PR TITLE
refreshDungeonCell refactored to take 'pos' argument

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3214,7 +3214,7 @@ boolean fillSpawnMap(enum dungeonLayers layer,
                 accomplishedSomething = true;
 
                 if (refresh) {
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                     if (player.loc.x == i && player.loc.y == j && !player.status[STATUS_LEVITATING] && refresh) {
                         flavorMessage(tileFlavor(player.loc.x, player.loc.y));
                     }
@@ -3352,7 +3352,7 @@ boolean spawnDungeonFeature(short x, short y, dungeonFeature *feat, boolean refr
             pmap[x][y].volume += feat->startProbability;
             pmap[x][y].layers[GAS] = feat->tile;
             if (refreshCell) {
-                refreshDungeonCell(x, y);
+                refreshDungeonCell((pos){ x, y });
             }
             succeeded = true;
         } else {

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1707,7 +1707,7 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
                 applyInstantTileEffectsToCreature(carriedMonster);
             }
             anyoneWantABite(decedent);
-            refreshDungeonCell(x, y);
+            refreshDungeonCell((pos){ x, y });
         }
     }
     decedent->currentHP = 0;

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -58,13 +58,13 @@ void hilitePath(pos path[1000], short steps, boolean unhilite) {
         for (int i=0; i<steps; i++) {
             brogueAssert(isPosInMap(path[i]));
             pmapAt(path[i])->flags &= ~IS_IN_PATH;
-            refreshDungeonCell(path[i].x, path[i].y);
+            refreshDungeonCell(path[i]);
         }
     } else {
         for (int i=0; i<steps; i++) {
             brogueAssert(isPosInMap(path[i]));
             pmapAt(path[i])->flags |= IS_IN_PATH;
-            refreshDungeonCell(path[i].x, path[i].y);
+            refreshDungeonCell(path[i]);
         }
     }
 }
@@ -78,7 +78,7 @@ void clearCursorPath() {
             for (j=1; j<DROWS; j++) {
                 if (pmap[i][j].flags & IS_IN_PATH) {
                     pmap[i][j].flags &= ~IS_IN_PATH;
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                 }
             }
         }
@@ -613,7 +613,7 @@ void mainInputLoop() {
 
             // Draw the cursor and path
             if (isPosInMap(oldTargetLoc)) {
-                refreshDungeonCell(oldTargetLoc.x, oldTargetLoc.y);               // Remove old cursor.
+                refreshDungeonCell(oldTargetLoc);               // Remove old cursor.
             }
             if (!playingBack) {
                 if (isPosInMap(oldTargetLoc)) {
@@ -762,7 +762,7 @@ void mainInputLoop() {
         } while (!targetConfirmed && !canceled && !doEvent && !rogue.gameHasEnded);
 
         if (isPosInMap(oldTargetLoc)) {
-            refreshDungeonCell(oldTargetLoc.x, oldTargetLoc.y);                       // Remove old rogue.cursorLoc.
+            refreshDungeonCell(oldTargetLoc);                       // Remove old rogue.cursorLoc.
         }
 
         restoreRNG;
@@ -915,7 +915,7 @@ void displayLevel() {
 
     for( i=0; i<DCOLS; i++ ) {
         for (j = DROWS-1; j >= 0; j--) {
-            refreshDungeonCell(i, j);
+            refreshDungeonCell((pos){ i, j });
         }
     }
 }
@@ -987,7 +987,7 @@ void shuffleTerrainColors(short percentOfCells, boolean refreshCells) {
                     }
 
                     if (refreshCells) {
-                        refreshDungeonCell(i, j);
+                        refreshDungeonCell((pos){ i, j });
                     }
                 }
         }
@@ -1518,13 +1518,13 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
     restoreRNG;
 }
 
-void refreshDungeonCell(short x, short y) {
+void refreshDungeonCell(pos loc) {
     enum displayGlyph cellChar;
     color foreColor, backColor;
-    brogueAssert(coordinatesAreInMap(x, y));
+    brogueAssert(isPosInMap(loc));
 
-    getCellAppearance(x, y, &cellChar, &foreColor, &backColor);
-    plotCharWithColor(cellChar, mapToWindow((pos){ x, y }), &foreColor, &backColor);
+    getCellAppearance(loc.x, loc.y, &cellChar, &foreColor, &backColor);
+    plotCharWithColor(cellChar, mapToWindow(loc), &foreColor, &backColor);
 }
 
 void applyColorMultiplier(color *baseColor, const color *multiplierColor) {
@@ -1873,7 +1873,7 @@ void dumpLevelToScreen() {
                 tmap[i][j].light[0] = 100;
                 tmap[i][j].light[1] = 100;
                 tmap[i][j].light[2] = 100;
-                refreshDungeonCell(i, j);
+                refreshDungeonCell((pos){ i, j });
                 pmap[i][j] = backup;
             } else {
                 plotCharWithColor(' ', mapToWindow((pos){ i, j }), &white, &black);
@@ -2068,7 +2068,7 @@ void flashCell(const color *theColor, short frames, short x, short y) {
         interrupted = pauseAnimation(50);
     }
 
-    refreshDungeonCell(x, y);
+    refreshDungeonCell((pos){ x, y });
 }
 
 // special effect expanding flash of light at dungeon coordinates (x, y) restricted to tiles with matching flags
@@ -3539,7 +3539,7 @@ void displayMoreSign() {
         printString("--MORE--", COLS - 8, MESSAGE_LINES, &black, &white, 0);
         waitForAcknowledgment();
         for (i=1; i<=8; i++) {
-            refreshDungeonCell(DCOLS - i, 0);
+            refreshDungeonCell((pos){ DCOLS - i, 0 });
         }
     }
 }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -387,7 +387,7 @@ item *placeItemAt(item *theItem, pos dest) {
         if (playerCanSee(dest.x, dest.y)) {
             if (cellHasTMFlag(dest.x, dest.y, TM_IS_SECRET)) {
                 discover(dest.x, dest.y);
-                refreshDungeonCell(dest.x, dest.y);
+                refreshDungeonCell(dest);
             }
             itemName(theItem, theItemName, false, false, NULL);
             sprintf(buf, "a pressure plate clicks underneath the %s!", theItemName);
@@ -1042,7 +1042,7 @@ void swapItemToEnchantLevel(item *theItem, short newEnchant, boolean enchantment
         removeItemFromChain(theItem, floorItems);
         pmap[x][y].flags &= ~(HAS_ITEM | ITEM_DETECTED);
         if (pmap[x][y].flags & (ANY_KIND_OF_VISIBLE | DISCOVERED | ITEM_DETECTED)) {
-            refreshDungeonCell(x, y);
+            refreshDungeonCell((pos){ x, y });
         }
         if (playerCanSee(x, y)) {
             messageWithColor(buf2, &itemMessageColor, 0);
@@ -1171,7 +1171,7 @@ void updateFloorItems() {
                 theItem->nextItem = levels[rogue.depthLevel-1 + 1].items;
                 levels[rogue.depthLevel-1 + 1].items = theItem;
             }
-            refreshDungeonCell(x, y);
+            refreshDungeonCell((pos){ x, y });
             continue;
         }
         if ((cellHasTerrainFlag(x, y, T_IS_FIRE) && (theItem->flags & ITEM_FLAMMABLE))
@@ -1190,8 +1190,8 @@ void updateFloorItems() {
                 pmapAt(loc)->flags |= ITEM_DETECTED;
             }
             theItem->loc = loc;
-            refreshDungeonCell(x, y);
-            refreshDungeonCell(loc.x, loc.y);
+            refreshDungeonCell((pos){ x, y });
+            refreshDungeonCell(loc);
             continue;
         }
         if (cellHasTMFlag(x, y, TM_PROMOTES_ON_ITEM)) {
@@ -3730,7 +3730,7 @@ boolean negate(creature *monst) {
             monst->info.flags &= ~NEGATABLE_TRAITS;
             negated = true;
             monst->wasNegated = true;
-            refreshDungeonCell(monst->loc.x, monst->loc.y);
+            refreshDungeonCell(monst->loc);
             refreshSideBar(-1, -1, false);
         }
         for (i = 0; i < 20; i++) {
@@ -3845,7 +3845,7 @@ boolean polymorph(creature *monst) {
 
     monst->ticksUntilTurn = max(monst->ticksUntilTurn, 101);
 
-    refreshDungeonCell(monst->loc.x, monst->loc.y);
+    refreshDungeonCell(monst->loc);
     if (boltCatalog[BOLT_POLYMORPH].backColor) {
         flashMonster(monst, boltCatalog[BOLT_POLYMORPH].backColor, 100);
     }
@@ -3927,7 +3927,7 @@ void makePlayerTelepathic(short duration) {
     player.status[STATUS_TELEPATHIC] = player.maxStatus[STATUS_TELEPATHIC] = duration;
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        refreshDungeonCell(monst->loc.x, monst->loc.y);
+        refreshDungeonCell(monst->loc);
     }
     if (!hasNextCreature(iterateCreatures(monsters))) {
         message("you can somehow tell that you are alone on this depth at the moment.", 0);
@@ -4052,7 +4052,7 @@ void negationBlast(const char *emitterName, const short distance) {
                     theItem->flags &= ~(ITEM_RUNIC | ITEM_RUNIC_HINTED | ITEM_RUNIC_IDENTIFIED | ITEM_PROTECTED);
                     identify(theItem);
                     pmapAt(theItem->loc)->flags &= ~ITEM_DETECTED;
-                    refreshDungeonCell(theItem->loc.x, theItem->loc.y);
+                    refreshDungeonCell(theItem->loc);
                     break;
                 case STAFF:
                     theItem->charges = 0;
@@ -4143,7 +4143,7 @@ boolean imbueInvisibility(creature *monst, short duration) {
             autoID = true;
         }
         monst->status[STATUS_INVISIBLE] = monst->maxStatus[STATUS_INVISIBLE] = duration;
-        refreshDungeonCell(monst->loc.x, monst->loc.y);
+        refreshDungeonCell(monst->loc);
         refreshSideBar(-1, -1, false);
         if (boltCatalog[BOLT_POLYMORPH].backColor) {
             flashMonster(monst, boltCatalog[BOLT_INVISIBILITY].backColor, 100);
@@ -4464,7 +4464,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                         monst->status[STATUS_DISCORDANT] = 0;
                         becomeAllyWith(monst);
                         //refreshSideBar(-1, -1, false);
-                        refreshDungeonCell(monst->loc.x, monst->loc.y);
+                        refreshDungeonCell(monst->loc);
                         if (canSeeMonster(monst)) {
                             if (autoID) {
                                 *autoID = true;
@@ -4689,7 +4689,7 @@ void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *au
                 monst->creatureState = MONSTER_ALLY;
                 monst->ticksUntilTurn = monst->info.attackSpeed + 1; // So they don't move before the player's next turn.
                 pmapAt(monst->loc)->flags |= HAS_MONSTER;
-                //refreshDungeonCell(monst->loc.x, monst->loc.y);
+                //refreshDungeonCell(monst->loc);
                 fadeInMonster(monst);
             }
             updateVision(true);
@@ -4828,7 +4828,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
         theBolt->foreColor = &black;
         theBolt->theChar = shootingMonst->info.displayChar;
         pmapAt(originLoc)->flags &= ~(HAS_PLAYER | HAS_MONSTER);
-        refreshDungeonCell(originLoc.x, originLoc.y);
+        refreshDungeonCell(originLoc);
         blinkDistance = theBolt->magnitude * 2 + 1;
         checkForMissingKeys(originLoc.x, originLoc.y);
     }
@@ -4945,7 +4945,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
                                && theBolt->foreColor
                                && theBolt->theChar) {
 
-                        refreshDungeonCell(x2, y2); // Clean up the contrail so it doesn't leave a trail of characters.
+                        refreshDungeonCell((pos){ x2, y2 }); // Clean up the contrail so it doesn't leave a trail of characters.
                     }
                 }
                 if (playerCanSee(x2, y2)) {
@@ -4962,7 +4962,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
             theBolt->magnitude = (blinkDistance - i) / 2 + 1;
             boltLength = theBolt->magnitude * 5;
             for (j=0; j<i; j++) {
-                refreshDungeonCell(listOfCoordinates[j].x, listOfCoordinates[j].y);
+                refreshDungeonCell(listOfCoordinates[j]);
             }
             if (i >= blinkDistance) {
                 break;
@@ -4999,11 +4999,11 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
             theBolt->magnitude--;
             boltLength = theBolt->magnitude * 5;
             for (j=0; j<i; j++) {
-                refreshDungeonCell(listOfCoordinates[j].x, listOfCoordinates[j].y);
+                refreshDungeonCell(listOfCoordinates[j]);
             }
             if (theBolt->magnitude <= 0) {
-                refreshDungeonCell(listOfCoordinates[i-1].x, listOfCoordinates[i-1].y);
-                refreshDungeonCell(x, y);
+                refreshDungeonCell(listOfCoordinates[i-1]);
+                refreshDungeonCell((pos){ x, y });
                 break;
             }
         }
@@ -5042,9 +5042,9 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
     }
 
     if (!fastForward) {
-        refreshDungeonCell(x, y);
+        refreshDungeonCell((pos){ x, y });
         if (i > 0) {
-            refreshDungeonCell(listOfCoordinates[i-1].x, listOfCoordinates[i-1].y);
+            refreshDungeonCell(listOfCoordinates[i-1]);
         }
     }
 
@@ -5106,7 +5106,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
                 x2 = listOfCoordinates[j].x;
                 y2 = listOfCoordinates[j].y;
                 if (playerCanSeeOrSense(x2, y2)) {
-                    refreshDungeonCell(x2, y2);
+                    refreshDungeonCell((pos){ x2, y2 });
                 }
             }
         }
@@ -5196,7 +5196,7 @@ short hiliteTrajectory(const pos coordinateList[DCOLS], short numCells, boolean 
         x = coordinateList[i].x;
         y = coordinateList[i].y;
         if (eraseHiliting) {
-            refreshDungeonCell(x, y);
+            refreshDungeonCell((pos){ x, y });
         } else {
             hiliteCell(x, y, hiliteColor, 20, true);
         }
@@ -5525,7 +5525,7 @@ boolean chooseTarget(pos *returnLoc,
         printLocationDescription(targetLoc.x, targetLoc.y);
 
         if (canceled) {
-            refreshDungeonCell(oldTargetLoc.x, oldTargetLoc.y);
+            refreshDungeonCell(oldTargetLoc);
             hiliteTrajectory(coordinates, numCells, true, theBolt, trajectoryColor);
             confirmMessages();
             rogue.cursorLoc = INVALID_POS;
@@ -5553,7 +5553,7 @@ boolean chooseTarget(pos *returnLoc,
             refreshSideBar(targetLoc.x, targetLoc.y, false);
         }
 
-        refreshDungeonCell(oldTargetLoc.x, oldTargetLoc.y);
+        refreshDungeonCell(oldTargetLoc);
         hiliteTrajectory(coordinates, numCells, true, theBolt, &trajColor);
 
         if (!targetConfirmed) {
@@ -5586,7 +5586,7 @@ boolean chooseTarget(pos *returnLoc,
         numCells = min(numCells, maxDistance);
     }
     hiliteTrajectory(coordinates, numCells, true, theBolt, trajectoryColor);
-    refreshDungeonCell(oldTargetLoc.x, oldTargetLoc.y);
+    refreshDungeonCell(oldTargetLoc);
 
     if (originLoc.x == targetLoc.x && originLoc.y == targetLoc.y) {
         confirmMessages();
@@ -6020,7 +6020,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
                 fastForward = rogue.playbackFastForward || pauseAnimation(25);
             }
 
-            refreshDungeonCell(x, y);
+            refreshDungeonCell((pos){ x, y });
         }
 
         if (x == targetLoc.x && y == targetLoc.y) { // reached its target
@@ -6073,7 +6073,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
 
             autoIdentify(theItem);
 
-            refreshDungeonCell(x, y);
+            refreshDungeonCell((pos){ x, y });
 
             //if (pmap[x][y].flags & (HAS_MONSTER | HAS_PLAYER)) {
             //  monst = monsterAtLoc((pos){ x, y });
@@ -6112,7 +6112,7 @@ void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistanc
     pos dropLoc;
     getQualifyingLocNear(&dropLoc, (pos){ x, y }, true, 0, (T_OBSTRUCTS_ITEMS | T_OBSTRUCTS_PASSABILITY), (HAS_ITEM), false, false);
     placeItemAt(theItem, dropLoc);
-    refreshDungeonCell(dropLoc.x, dropLoc.y);
+    refreshDungeonCell(dropLoc);
 }
 
 /*
@@ -7052,7 +7052,7 @@ void readScroll(item *theItem) {
                         && rand_percent(10) && (numberOfMonsters < 3)) {
                         monst = spawnHorde(0, (pos){ x, y }, (HORDE_LEADER_CAPTIVE | HORDE_NO_PERIODIC_SPAWN | HORDE_IS_SUMMONED | HORDE_MACHINE_ONLY), 0);
                         if (monst) {
-                            // refreshDungeonCell(x, y);
+                            // refreshDungeonCell((pos){ x, y });
                             // monst->creatureState = MONSTER_TRACKING_SCENT;
                             // monst->ticksUntilTurn = player.movementSpeed;
                             wakeUp(monst);
@@ -7194,7 +7194,7 @@ void drinkPotion(item *theItem) {
                     if (itemMagicPolarity(tempItem)) {
                         pmapAt(tempItem->loc)->flags |= ITEM_DETECTED;
                         hadEffect = true;
-                        refreshDungeonCell(tempItem->loc.x, tempItem->loc.y);
+                        refreshDungeonCell(tempItem->loc);
                     }
                 }
             }
@@ -7204,7 +7204,7 @@ void drinkPotion(item *theItem) {
                     detectMagicOnItem(monst->carriedItem);
                     if (itemMagicPolarity(monst->carriedItem)) {
                         hadEffect = true;
-                        refreshDungeonCell(monst->loc.x, monst->loc.y);
+                        refreshDungeonCell(monst->loc);
                     }
                 }
             }
@@ -7490,7 +7490,7 @@ item *itemAtLoc(pos loc) {
         hiliteCell(loc.x, loc.y, &white, 75, true);
         rogue.automationActive = false;
         message("ERROR: An item was supposed to be here, but I couldn't find it.", REQUIRE_ACKNOWLEDGMENT);
-        refreshDungeonCell(loc.x, loc.y);
+        refreshDungeonCell(loc);
     }
     return theItem;
 }

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -577,7 +577,7 @@ creature *cloneMonster(creature *monst, boolean announce, boolean placeClone) {
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                  avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
         pmapAt(newMonst->loc)->flags |= HAS_MONSTER;
-        refreshDungeonCell(newMonst->loc.x, newMonst->loc.y);
+        refreshDungeonCell(newMonst->loc);
         if (announce && canSeeMonster(newMonst)) {
             monsterName(monstName, newMonst, false);
             sprintf(buf, "another %s appears!", monstName);
@@ -864,7 +864,7 @@ creature *spawnHorde(short hordeID, pos loc, unsigned long forbiddenFlags, unsig
 
     pmapAt(loc)->flags |= HAS_MONSTER;
     if (playerCanSeeOrSense(loc.x, loc.y)) {
-        refreshDungeonCell(loc.x, loc.y);
+        refreshDungeonCell(loc);
     }
     if (monsterCanSubmergeNow(leader)) {
         leader->bookkeepingFlags |= MB_SUBMERGED;
@@ -998,7 +998,7 @@ boolean summonMinions(creature *summoner) {
             monst->bookkeepingFlags &= ~MB_JUST_SUMMONED;
             if (canSeeMonster(monst)) {
                 seenMinionCount++;
-                refreshDungeonCell(monst->loc.x, monst->loc.y);
+                refreshDungeonCell(monst->loc);
             }
             monst->ticksUntilTurn = 101;
             monst->leader = summoner;
@@ -1023,7 +1023,7 @@ boolean summonMinions(creature *summoner) {
         if (atLeastOneMinion && host) {
             host->carriedMonster = summoner;
             demoteMonsterFromLeadership(summoner);
-            refreshDungeonCell(summoner->loc.x, summoner->loc.y);
+            refreshDungeonCell(summoner->loc);
         } else {
             pmapAt(summoner->loc)->flags |= HAS_MONSTER;
             // TODO: why move to the beginning?
@@ -1929,7 +1929,7 @@ void decrementMonsterStatus(creature *monst) {
                     && !--monst->status[i]
                     && playerCanSee(monst->loc.x, monst->loc.y)) {
 
-                    refreshDungeonCell(monst->loc.x, monst->loc.y);
+                    refreshDungeonCell(monst->loc);
                 }
                 break;
             default:
@@ -1949,7 +1949,7 @@ void decrementMonsterStatus(creature *monst) {
 
                 monst->creatureState = MONSTER_TRACKING_SCENT;
             }
-            refreshDungeonCell(monst->loc.x, monst->loc.y);
+            refreshDungeonCell(monst->loc);
         } else if (monst->info.flags & (MONST_RESTRICTED_TO_LIQUID)
                    && monst->creatureState != MONSTER_ALLY) {
             monst->creatureState = MONSTER_FLEEING;
@@ -3562,7 +3562,7 @@ boolean knownToPlayerAsPassableOrSecretDoor(pos loc) {
 void setMonsterLocation(creature *monst, pos newLoc) {
     unsigned long creatureFlag = (monst == &player ? HAS_PLAYER : HAS_MONSTER);
     pmapAt(monst->loc)->flags &= ~creatureFlag;
-    refreshDungeonCell(monst->loc.x, monst->loc.y);
+    refreshDungeonCell(monst->loc);
     monst->turnsSpentStationary = 0;
     monst->loc = newLoc;
     pmapAt(newLoc)->flags |= creatureFlag;
@@ -3575,7 +3575,7 @@ void setMonsterLocation(creature *monst, pos newLoc) {
 
         discover(newLoc.x, newLoc.y); // if you see a monster use a secret door, you discover it
     }
-    refreshDungeonCell(newLoc.x, newLoc.y);
+    refreshDungeonCell(newLoc);
     applyInstantTileEffectsToCreature(monst);
     if (monst == &player) {
         updateVision(true);
@@ -3705,10 +3705,10 @@ boolean moveMonster(creature *monst, short dx, short dy) {
 
                     // swap places
                     pmapAt(defender->loc)->flags &= ~HAS_MONSTER;
-                    refreshDungeonCell(defender->loc.x, defender->loc.y);
+                    refreshDungeonCell(defender->loc);
 
                     pmapAt(monst->loc)->flags &= ~HAS_MONSTER;
-                    refreshDungeonCell(monst->loc.x, monst->loc.y);
+                    refreshDungeonCell(monst->loc);
 
                     monst->loc.x = newX;
                     monst->loc.y = newY;
@@ -3724,8 +3724,8 @@ boolean moveMonster(creature *monst, short dx, short dy) {
                     }
                     pmapAt(defender->loc)->flags |= HAS_MONSTER;
 
-                    refreshDungeonCell(monst->loc.x, monst->loc.y);
-                    refreshDungeonCell(defender->loc.x, defender->loc.y);
+                    refreshDungeonCell(monst->loc);
+                    refreshDungeonCell(defender->loc);
 
                     monst->ticksUntilTurn = monst->movementSpeed;
                     return true;
@@ -3745,7 +3745,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
                         // Bog monsters and krakens won't surface on the turn that they seize their target.
                         monst->bookkeepingFlags &= ~MB_SUBMERGED;
                     }
-                    refreshDungeonCell(x, y);
+                    refreshDungeonCell((pos){ x, y });
 
                     buildHitList(hitList, monst, defender,
                                  (monst->info.abilityFlags & MA_ATTACKS_ALL_ADJACENT) ? true : false);
@@ -3934,7 +3934,7 @@ void makeMonsterDropItem(creature *monst) {
                              T_OBSTRUCTS_ITEMS, (HAS_PLAYER | HAS_STAIRS | HAS_ITEM), false);
     placeItemAt(monst->carriedItem, (pos){ x, y });
     monst->carriedItem = NULL;
-    refreshDungeonCell(x, y);
+    refreshDungeonCell((pos){ x, y });
 }
 
 void checkForContinuedLeadership(creature *monst) {

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -498,7 +498,7 @@ void becomeAllyWith(creature *monst) {
     monst->bookkeepingFlags |= MB_FOLLOWER;
     monst->leader = &player;
     monst->bookkeepingFlags &= ~(MB_CAPTIVE | MB_SEIZED);
-    refreshDungeonCell(monst->loc.x, monst->loc.y);
+    refreshDungeonCell(monst->loc);
 }
 
 void freeCaptive(creature *monst) {
@@ -703,7 +703,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
                     attacker->loc.y + (1 + i) * nbDirs[dir][1]
                 };
                 if (isPosInMap(targetLoc)) {
-                    refreshDungeonCell(targetLoc.x, targetLoc.y);
+                    refreshDungeonCell(targetLoc);
                 }
             }
         }
@@ -1116,8 +1116,8 @@ boolean playerMoves(short direction) {
                 pickUpItemAt(player.loc);
                 rogue.disturbed = true;
             }
-            refreshDungeonCell(x, y);
-            refreshDungeonCell(player.loc.x, player.loc.y);
+            refreshDungeonCell((pos){ x, y });
+            refreshDungeonCell(player.loc);
             playerMoved = true;
 
             checkForMissingKeys(x, y);
@@ -1148,7 +1148,7 @@ boolean playerMoves(short direction) {
             if (!(pmap[newX][newY].flags & DISCOVERED)) {
                 committed = true;
                 discoverCell(newX, newY);
-                refreshDungeonCell(newX, newY);
+                refreshDungeonCell((pos){ newX, newY });
             }
 
             messageWithColor(tileCatalog[i].flavorText, &backgroundMessageColor, 0);
@@ -1455,7 +1455,7 @@ void displayRoute(short **distanceMap, boolean removeRoute) {
     }
     do {
         if (removeRoute) {
-            refreshDungeonCell(currentX, currentY);
+            refreshDungeonCell((pos){ currentX, currentY });
         } else {
             hiliteCell(currentX, currentY, &hiliteColor, 50, true);
         }
@@ -1569,12 +1569,12 @@ void travel(short x, short y, boolean autoConfirm) {
     if (D_WORMHOLING) {
         recordMouseClick(mapToWindowX(x), mapToWindowY(y), true, false);
         pmapAt(player.loc)->flags &= ~HAS_PLAYER;
-        refreshDungeonCell(player.loc.x, player.loc.y);
+        refreshDungeonCell(player.loc);
         player.loc.x = x;
         player.loc.y = y;
         pmap[x][y].flags |= HAS_PLAYER;
         updatePlayerUnderwaterness();
-        refreshDungeonCell(x, y);
+        refreshDungeonCell((pos){ x, y });
         updateVision(true);
         return;
     }
@@ -2068,7 +2068,7 @@ void discover(short x, short y) {
                 spawnDungeonFeature(x, y, feat, true, false);
             }
         }
-        refreshDungeonCell(x, y);
+        refreshDungeonCell((pos){ x, y });
 
         if (playerCanSee(x, y)) {
             rogue.disturbed = true;
@@ -2224,27 +2224,27 @@ void updateFieldOfViewDisplay(boolean updateDancingTerrain, boolean refreshDispl
                 }
                 discoverCell(i, j);
                 if (refreshDisplay) {
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                 }
             } else if (!(pmap[i][j].flags & VISIBLE) && (pmap[i][j].flags & WAS_VISIBLE)) { // if the cell ceased being visible this move
                 storeMemories(i, j);
                 if (refreshDisplay) {
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                 }
             } else if (!(pmap[i][j].flags & CLAIRVOYANT_VISIBLE) && (pmap[i][j].flags & WAS_CLAIRVOYANT_VISIBLE)) { // ceased being clairvoyantly visible
                 storeMemories(i, j);
                 if (refreshDisplay) {
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                 }
             } else if (!(pmap[i][j].flags & WAS_CLAIRVOYANT_VISIBLE) && (pmap[i][j].flags & CLAIRVOYANT_VISIBLE)) { // became clairvoyantly visible
                 pmap[i][j].flags &= ~STABLE_MEMORY;
                 if (refreshDisplay) {
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                 }
             } else if (!(pmap[i][j].flags & TELEPATHIC_VISIBLE) && (pmap[i][j].flags & WAS_TELEPATHIC_VISIBLE)) { // ceased being telepathically visible
                 storeMemories(i, j);
                 if (refreshDisplay) {
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                 }
             } else if (!(pmap[i][j].flags & WAS_TELEPATHIC_VISIBLE) && (pmap[i][j].flags & TELEPATHIC_VISIBLE)) { // became telepathically visible
                 if (!(pmap[i][j].flags & DISCOVERED)
@@ -2254,7 +2254,7 @@ void updateFieldOfViewDisplay(boolean updateDancingTerrain, boolean refreshDispl
 
                 pmap[i][j].flags &= ~STABLE_MEMORY;
                 if (refreshDisplay) {
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                 }
             } else if (playerCanSeeOrSense(i, j)
                        && (tmap[i][j].light[0] != tmap[i][j].oldLight[0] ||
@@ -2262,7 +2262,7 @@ void updateFieldOfViewDisplay(boolean updateDancingTerrain, boolean refreshDispl
                            tmap[i][j].light[2] != tmap[i][j].oldLight[2])) { // if the cell's light color changed this move
 
                            if (refreshDisplay) {
-                               refreshDungeonCell(i, j);
+                               refreshDungeonCell((pos){ i, j });
                            }
                        } else if (updateDancingTerrain
                                   && playerCanSee(i, j)
@@ -2279,7 +2279,7 @@ void updateFieldOfViewDisplay(boolean updateDancingTerrain, boolean refreshDispl
 
                                       pmap[i][j].flags &= ~STABLE_MEMORY;
                                       if (refreshDisplay) {
-                                          refreshDungeonCell(i, j);
+                                          refreshDungeonCell((pos){ i, j });
                                       }
                                   }
         }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2943,7 +2943,7 @@ extern "C" {
     void waitForAcknowledgment();
     void waitForKeystrokeOrMouseClick();
     boolean confirm(char *prompt, boolean alsoDuringPlayback);
-    void refreshDungeonCell(short x, short y);
+    void refreshDungeonCell(pos loc);
     void applyColorMultiplier(color *baseColor, const color *multiplierColor);
     void applyColorAverage(color *baseColor, const color *newColor, short averageWeight);
     void applyColorAugment(color *baseColor, const color *augmentingColor, short augmentWeight);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1323,7 +1323,7 @@ void enableEasyMode() {
         message("An ancient and terrible evil burrows into your willing flesh!", REQUIRE_ACKNOWLEDGMENT);
         rogue.easyMode = true;
         setPlayerDisplayChar();
-        refreshDungeonCell(player.loc.x, player.loc.y);
+        refreshDungeonCell(player.loc);
         refreshSideBar(-1, -1, false);
         message("Wracked by spasms, your body contorts into an ALL-POWERFUL AMPERSAND!!!", 0);
         message("You have a feeling that you will take 20% as much damage from now on.", 0);

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -38,7 +38,7 @@ void exposeCreatureToFire(creature *monst) {
         if (monst == &player) {
             rogue.minersLight.lightColor = &fireForeColor;
             player.info.foreColor = &torchLightColor;
-            refreshDungeonCell(player.loc.x, player.loc.y);
+            refreshDungeonCell(player.loc);
             //updateVision(); // this screws up the firebolt visual effect by erasing it while a message is displayed
             combatMessage("you catch fire", &badMessageColor);
         } else if (canDirectlySeeMonster(monst)) {
@@ -191,7 +191,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
             }
             killCreature(monst, false);
             spawnDungeonFeature(*x, *y, &(dungeonFeatureCatalog[DF_CREATURE_FIRE]), true, false);
-            refreshDungeonCell(*x, *y);
+            refreshDungeonCell((pos){ *x, *y });
             return;
         }
     }
@@ -222,7 +222,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
         pmap[*x][*y].flags |= PRESSURE_PLATE_DEPRESSED;
         if (playerCanSee(*x, *y) && cellHasTMFlag(*x, *y, TM_IS_SECRET)) {
             discover(*x, *y);
-            refreshDungeonCell(*x, *y);
+            refreshDungeonCell((pos){ *x, *y });
         }
         if (canSeeMonster(monst)) {
             monsterName(buf, monst, true);
@@ -334,7 +334,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
                         buf3);
                 messageWithColor(buf2, messageColorFromVictim(monst), 0);
                 killCreature(monst, false);
-                refreshDungeonCell(*x, *y);
+                refreshDungeonCell((pos){ *x, *y });
                 return;
             } else {
                 // if survived
@@ -528,7 +528,7 @@ void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
                     messageWithColor(buf2, messageColorFromVictim(monst), 0);
                 }
                 killCreature(monst, false);
-                refreshDungeonCell(x, y);
+                refreshDungeonCell((pos){ x, y });
                 return;
             }
         }
@@ -789,13 +789,13 @@ void updateVision(boolean refreshDisplay) {
     if (player.status[STATUS_HALLUCINATING] > 0) {
         for (theItem = floorItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
             if ((pmapAt(theItem->loc)->flags & DISCOVERED) && refreshDisplay) {
-                refreshDungeonCell(theItem->loc.x, theItem->loc.y);
+                refreshDungeonCell(theItem->loc);
             }
         }
         for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
             creature *monst = nextCreature(&it);
             if ((pmapAt(monst->loc)->flags & DISCOVERED) && refreshDisplay) {
-                refreshDungeonCell(monst->loc.x, monst->loc.y);
+                refreshDungeonCell(monst->loc);
             }
         }
     }
@@ -854,7 +854,7 @@ void burnItem(item *theItem) {
     deleteItem(theItem);
     pmap[x][y].flags &= ~(HAS_ITEM | ITEM_DETECTED);
     if (pmap[x][y].flags & (ANY_KIND_OF_VISIBLE | DISCOVERED | ITEM_DETECTED)) {
-        refreshDungeonCell(x, y);
+        refreshDungeonCell((pos){ x, y });
     }
     if (playerCanSee(x, y)) {
         messageWithColor(buf2, &itemMessageColor, 0);
@@ -1112,7 +1112,7 @@ void promoteTile(short x, short y, enum dungeonLayers layer, boolean useFireDF) 
         if (layer == GAS) {
             pmap[x][y].volume = 0;
         }
-        refreshDungeonCell(x, y);
+        refreshDungeonCell((pos){ x, y });
     }
     if (DFType) {
         spawnDungeonFeature(x, y, &dungeonFeatureCatalog[DFType], true, false);
@@ -1212,7 +1212,7 @@ boolean exposeTileToFire(short x, short y, boolean alwaysIgnite) {
                 promoteTile(x, y, layer, !explosivePromotion);
             }
         }
-        refreshDungeonCell(x, y);
+        refreshDungeonCell((pos){ x, y });
     }
     return fireIgnited;
 }
@@ -1267,7 +1267,7 @@ void updateVolumetricMedia() {
                     pmap[i][j].layers[GAS] = gasType;
                 } else if (pmap[i][j].layers[GAS] && newGasVolume[i][j] < 1) {
                     pmap[i][j].layers[GAS] = NOTHING;
-                    refreshDungeonCell(i, j);
+                    refreshDungeonCell((pos){ i, j });
                 }
                 if (pmap[i][j].volume > 0) {
                     if (tileCatalog[pmap[i][j].layers[GAS]].mechFlags & TM_GAS_DISSIPATES_QUICKLY) {
@@ -1312,7 +1312,7 @@ void updateVolumetricMedia() {
         for (j=0; j<DROWS; j++) {
             if (pmap[i][j].volume != newGasVolume[i][j]) {
                 pmap[i][j].volume = newGasVolume[i][j];
-                refreshDungeonCell(i, j);
+                refreshDungeonCell((pos){ i, j });
             }
         }
     }
@@ -1401,7 +1401,7 @@ void monstersFall() {
             }
 
             pmap[x][y].flags &= ~HAS_MONSTER;
-            refreshDungeonCell(x, y);
+            refreshDungeonCell((pos){ x, y });
         }
     }
 }
@@ -1858,7 +1858,7 @@ void extinguishFireOnCreature(creature *monst) {
     if (monst == &player) {
         player.info.foreColor = &white;
         rogue.minersLight.lightColor = &minersLightColor;
-        refreshDungeonCell(player.loc.x, player.loc.y);
+        refreshDungeonCell(player.loc);
         updateVision(true);
         message("you are no longer on fire.", 0);
     }
@@ -1901,7 +1901,7 @@ void monsterEntersLevel(creature *monst, short n) {
                                  avoidedFlagsForMonster(&(prevMonst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS), false);
         pmapAt(monst->loc)->flags &= ~(HAS_PLAYER | HAS_MONSTER);
         pmapAt(prevMonst->loc)->flags |= (prevMonst == &player ? HAS_PLAYER : HAS_MONSTER);
-        refreshDungeonCell(prevMonst->loc.x, prevMonst->loc.y);
+        refreshDungeonCell(prevMonst->loc);
         //DEBUG printf("\nBumped a creature (%s) from (%i, %i) to (%i, %i).", prevMonst->info.monsterName, monst->loc.x, monst->loc.y, prevMonst->loc.x, prevMonst->loc.y);
     }
 
@@ -1916,7 +1916,7 @@ void monsterEntersLevel(creature *monst, short n) {
     restoreMonster(monst, NULL, NULL);
     //DEBUG printf("\nPlaced a creature (%s) at (%i, %i).", monst->info.monsterName, monst->loc.x, monst->loc.y);
     monst->ticksUntilTurn = monst->movementSpeed;
-    refreshDungeonCell(monst->loc.x, monst->loc.y);
+    refreshDungeonCell(monst->loc);
 
     if (pit) {
         monsterName(monstName, monst, true);

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -408,7 +408,7 @@ static void dialogCreateMonster() {
         theMonster->creatureState = MONSTER_WANDERING;
         fadeInMonster(theMonster);
         refreshSideBar(-1, -1, false);
-        refreshDungeonCell(theMonster->loc.x, theMonster->loc.y);
+        refreshDungeonCell(theMonster->loc);
 
         if (!(theMonster->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))
             || theMonster->info.monsterID == MK_PHOENIX_EGG


### PR DESCRIPTION
About half of calls to `refreshDungeonCell` were already `pos` values being split apart, so this generally cleans things up a lot.

