### PR TITLE
Add static to all functions that should have it, and remove several unused static functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include config.mk
 
 cflags := -Isrc/brogue -Isrc/platform -Isrc/variants -std=c99 \
 	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-unused-result \
-	-Wformat -Werror=format-security -Wformat-overflow=0
+	-Wformat -Werror=format-security -Wformat-overflow=0 -Wmissing-prototypes
 libs := -lm
 cppflags := -DDATADIR=$(DATADIR)
 

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -34,7 +34,7 @@ boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask) {
 }
 #endif
 
-boolean checkLoopiness(short x, short y) {
+static boolean checkLoopiness(short x, short y) {
     short newX, newY, dir, sdir;
     short numStrings, maxStringLength, currentStringLength;
 
@@ -98,7 +98,7 @@ boolean checkLoopiness(short x, short y) {
     }
 }
 
-void auditLoop(short x, short y, char grid[DCOLS][DROWS]) {
+static void auditLoop(short x, short y, char grid[DCOLS][DROWS]) {
     short dir, newX, newY;
     if (coordinatesAreInMap(x, y)
         && !grid[x][y]
@@ -117,7 +117,7 @@ void auditLoop(short x, short y, char grid[DCOLS][DROWS]) {
 
 // Assumes it is called with respect to a passable (startX, startY), and that the same is not already included in results.
 // Returns 10000 if the area included an area machine.
-short floodFillCount(char results[DCOLS][DROWS], char passMap[DCOLS][DROWS], short startX, short startY) {
+static short floodFillCount(char results[DCOLS][DROWS], char passMap[DCOLS][DROWS], short startX, short startY) {
     short dir, newX, newY, count;
 
     count = (passMap[startX][startY] == 2 ? 5000 : 1);
@@ -317,7 +317,7 @@ void analyzeMap(boolean calculateChokeMap) {
 }
 
 // Add some loops to the otherwise simply connected network of rooms.
-void addLoops(short **grid, short minimumPathingDistance) {
+static void addLoops(short **grid, short minimumPathingDistance) {
     short newX, newY, oppX, oppY;
     short **pathMap, **costMap;
     short i, d, x, y, sCoord[DCOLS*DROWS];
@@ -377,7 +377,7 @@ void addLoops(short **grid, short minimumPathingDistance) {
 // Assumes (startX, startY) is in the machine.
 // Returns true if everything went well, and false if we ran into a machine component
 // that was already there, as we don't want to build a machine around it.
-boolean addTileToMachineInteriorAndIterate(char interior[DCOLS][DROWS], short startX, short startY) {
+static boolean addTileToMachineInteriorAndIterate(char interior[DCOLS][DROWS], short startX, short startY) {
     short dir, newX, newY;
     boolean goodSoFar = true;
 
@@ -408,7 +408,7 @@ boolean addTileToMachineInteriorAndIterate(char interior[DCOLS][DROWS], short st
     return goodSoFar;
 }
 
-void copyMap(pcell from[DCOLS][DROWS], pcell to[DCOLS][DROWS]) {
+static void copyMap(pcell from[DCOLS][DROWS], pcell to[DCOLS][DROWS]) {
     short i, j;
 
     for(i=0; i<DCOLS; i++) {
@@ -418,7 +418,7 @@ void copyMap(pcell from[DCOLS][DROWS], pcell to[DCOLS][DROWS]) {
     }
 }
 
-boolean itemIsADuplicate(item *theItem, item **spawnedItems, short itemCount) {
+static boolean itemIsADuplicate(item *theItem, item **spawnedItems, short itemCount) {
     short i;
     if (theItem->category & (STAFF | WAND | POTION | SCROLL | RING | WEAPON | ARMOR | CHARM)) {
         for (i = 0; i < itemCount; i++) {
@@ -432,7 +432,7 @@ boolean itemIsADuplicate(item *theItem, item **spawnedItems, short itemCount) {
     return false;
 }
 
-boolean blueprintQualifies(short i, unsigned long requiredMachineFlags) {
+static boolean blueprintQualifies(short i, unsigned long requiredMachineFlags) {
     if (blueprintCatalog[i].depthRange[0] > rogue.depthLevel
         || blueprintCatalog[i].depthRange[1] < rogue.depthLevel
                 // Must have the required flags:
@@ -447,7 +447,7 @@ boolean blueprintQualifies(short i, unsigned long requiredMachineFlags) {
     return true;
 }
 
-void abortItemsAndMonsters(item *spawnedItems[MACHINES_BUFFER_LENGTH], creature *spawnedMonsters[MACHINES_BUFFER_LENGTH]) {
+static void abortItemsAndMonsters(item *spawnedItems[MACHINES_BUFFER_LENGTH], creature *spawnedMonsters[MACHINES_BUFFER_LENGTH]) {
     short i, j;
 
     for (i=0; i<MACHINES_BUFFER_LENGTH && spawnedItems[i]; i++) {
@@ -469,7 +469,7 @@ void abortItemsAndMonsters(item *spawnedItems[MACHINES_BUFFER_LENGTH], creature 
     }
 }
 
-boolean cellIsFeatureCandidate(short x, short y,
+static boolean cellIsFeatureCandidate(short x, short y,
                                short originX, short originY,
                                short distanceBound[2],
                                char interior[DCOLS][DROWS],
@@ -568,7 +568,7 @@ boolean cellIsFeatureCandidate(short x, short y,
 }
 
 
-void addLocationToKey(item *theItem, short x, short y, boolean disposableHere) {
+static void addLocationToKey(item *theItem, short x, short y, boolean disposableHere) {
     short i;
 
     for (i=0; i < KEY_ID_MAXIMUM && (theItem->keyLoc[i].loc.x || theItem->keyLoc[i].machine); i++);
@@ -576,7 +576,7 @@ void addLocationToKey(item *theItem, short x, short y, boolean disposableHere) {
     theItem->keyLoc[i].disposableHere = disposableHere;
 }
 
-void addMachineNumberToKey(item *theItem, short machineNumber, boolean disposableHere) {
+static void addMachineNumberToKey(item *theItem, short machineNumber, boolean disposableHere) {
     short i;
 
     for (i=0; i < KEY_ID_MAXIMUM && (theItem->keyLoc[i].loc.x || theItem->keyLoc[i].machine); i++);
@@ -584,7 +584,7 @@ void addMachineNumberToKey(item *theItem, short machineNumber, boolean disposabl
     theItem->keyLoc[i].disposableHere = disposableHere;
 }
 
-void expandMachineInterior(char interior[DCOLS][DROWS], short minimumInteriorNeighbors) {
+static void expandMachineInterior(char interior[DCOLS][DROWS], short minimumInteriorNeighbors) {
     boolean madeChange;
     short nbcount, newX, newY, i, j, layer;
     enum directions dir;
@@ -651,7 +651,7 @@ void expandMachineInterior(char interior[DCOLS][DROWS], short minimumInteriorNei
     }
 }
 
-boolean fillInteriorForVestibuleMachine(char interior[DCOLS][DROWS], short bp, short originX, short originY) {
+static boolean fillInteriorForVestibuleMachine(char interior[DCOLS][DROWS], short bp, short originX, short originY) {
     short **distanceMap, **costMap, qualifyingTileCount, totalFreq, sRows[DROWS], sCols[DCOLS], i, j, k;
     boolean success = true;
 
@@ -711,7 +711,7 @@ boolean fillInteriorForVestibuleMachine(char interior[DCOLS][DROWS], short bp, s
     return success;
 }
 
-void redesignInterior(char interior[DCOLS][DROWS], short originX, short originY, short theProfileIndex) {
+static void redesignInterior(char interior[DCOLS][DROWS], short originX, short originY, short theProfileIndex) {
     short i, j, n, newX, newY;
     enum directions dir;
     pos orphanList[20];
@@ -833,7 +833,7 @@ void redesignInterior(char interior[DCOLS][DROWS], short originX, short originY,
     freeGrid(grid);
 }
 
-void prepareInteriorWithMachineFlags(char interior[DCOLS][DROWS], short originX, short originY, unsigned long flags, short dungeonProfileIndex) {
+static void prepareInteriorWithMachineFlags(char interior[DCOLS][DROWS], short originX, short originY, unsigned long flags, short dungeonProfileIndex) {
     short i, j, newX, newY;
     enum dungeonLayers layer;
     enum directions dir;
@@ -1705,7 +1705,7 @@ boolean buildAMachine(enum machineTypes bp,
 }
 
 // add machines to the dungeon.
-void addMachines() {
+static void addMachines() {
     short machineCount, failsafe;
     short randomMachineFactor;
 
@@ -1744,7 +1744,7 @@ void addMachines() {
 // Add terrain, DFs and flavor machines. Includes traps, torches, funguses, flavor machines, etc.
 // If buildAreaMachines is true, build ONLY the autogenerators that include machines.
 // If false, build all EXCEPT the autogenerators that include machines.
-void runAutogenerators(boolean buildAreaMachines) {
+static void runAutogenerators(boolean buildAreaMachines) {
     short AG, count, i;
     const autoGenerator *gen;
     char grid[DCOLS][DROWS];
@@ -1820,7 +1820,7 @@ void runAutogenerators(boolean buildAreaMachines) {
 }
 
 // Knock down the boundaries between similar lakes where possible.
-void cleanUpLakeBoundaries() {
+static void cleanUpLakeBoundaries() {
     short i, j, x, y, failsafe, layer;
     boolean reverse, madeChange;
     unsigned long subjectFlags;
@@ -1877,7 +1877,7 @@ void cleanUpLakeBoundaries() {
     } while (madeChange && failsafe > 0);
 }
 
-void removeDiagonalOpenings() {
+static void removeDiagonalOpenings() {
     short i, j, k, x1, y1, x2, layer;
     boolean diagonalCornerRemoved;
 
@@ -1915,7 +1915,7 @@ void removeDiagonalOpenings() {
     } while (diagonalCornerRemoved == true);
 }
 
-void insertRoomAt(short **dungeonMap, short **roomMap, const short roomToDungeonX, const short roomToDungeonY, const short xRoom, const short yRoom) {
+static void insertRoomAt(short **dungeonMap, short **roomMap, const short roomToDungeonX, const short roomToDungeonY, const short xRoom, const short yRoom) {
     short newX, newY;
     enum directions dir;
 
@@ -1935,7 +1935,7 @@ void insertRoomAt(short **dungeonMap, short **roomMap, const short roomToDungeon
     }
 }
 
-void designCavern(short **grid, short minWidth, short maxWidth, short minHeight, short maxHeight) {
+static void designCavern(short **grid, short minWidth, short maxWidth, short minHeight, short maxHeight) {
     short destX, destY;
     short caveX, caveY, caveWidth, caveHeight;
     short fillX = 0, fillY = 0;
@@ -1969,7 +1969,7 @@ void designCavern(short **grid, short minWidth, short maxWidth, short minHeight,
 }
 
 // This is a special room that appears at the entrance to the dungeon on depth 1.
-void designEntranceRoom(short **grid) {
+static void designEntranceRoom(short **grid) {
     short roomWidth, roomHeight, roomWidth2, roomHeight2, roomX, roomY, roomX2, roomY2;
 
     fillGrid(grid, 0);
@@ -1987,7 +1987,7 @@ void designEntranceRoom(short **grid) {
     drawRectangleOnGrid(grid, roomX2, roomY2, roomWidth2, roomHeight2, 1);
 }
 
-void designCrossRoom(short **grid) {
+static void designCrossRoom(short **grid) {
     short roomWidth, roomHeight, roomWidth2, roomHeight2, roomX, roomY, roomX2, roomY2;
 
     fillGrid(grid, 0);
@@ -2007,7 +2007,7 @@ void designCrossRoom(short **grid) {
     drawRectangleOnGrid(grid, roomX2 - 5, roomY2 + 5, roomWidth2, roomHeight2, 1);
 }
 
-void designSymmetricalCrossRoom(short **grid) {
+static void designSymmetricalCrossRoom(short **grid) {
     short majorWidth, majorHeight, minorWidth, minorHeight;
 
     fillGrid(grid, 0);
@@ -2028,7 +2028,7 @@ void designSymmetricalCrossRoom(short **grid) {
     drawRectangleOnGrid(grid, (DCOLS - minorWidth)/2, (DROWS - majorHeight)/2, minorWidth, majorHeight, 1);
 }
 
-void designSmallRoom(short **grid) {
+static void designSmallRoom(short **grid) {
     short width, height;
 
     fillGrid(grid, 0);
@@ -2037,7 +2037,7 @@ void designSmallRoom(short **grid) {
     drawRectangleOnGrid(grid, (DCOLS - width) / 2, (DROWS - height) / 2, width, height, 1);
 }
 
-void designCircularRoom(short **grid) {
+static void designCircularRoom(short **grid) {
     short radius;
 
     if (rand_percent(5)) {
@@ -2055,7 +2055,7 @@ void designCircularRoom(short **grid) {
     }
 }
 
-void designChunkyRoom(short **grid) {
+static void designChunkyRoom(short **grid) {
     short i, x, y;
     short minX, maxX, minY, maxY;
     short chunkCount = rand_range(2, 8);
@@ -2090,7 +2090,7 @@ void designChunkyRoom(short **grid) {
 // If the indicated tile is a wall on the room stored in grid, and it could be the site of
 // a door out of that room, then return the outbound direction that the door faces.
 // Otherwise, return NO_DIRECTION.
-enum directions directionOfDoorSite(short **grid, short x, short y) {
+static enum directions directionOfDoorSite(short **grid, short x, short y) {
     enum directions dir, solutionDir;
     short newX, newY, oppX, oppY;
 
@@ -2119,7 +2119,7 @@ enum directions directionOfDoorSite(short **grid, short x, short y) {
     return solutionDir;
 }
 
-void chooseRandomDoorSites(short **roomMap, pos doorSites[4]) {
+static void chooseRandomDoorSites(short **roomMap, pos doorSites[4]) {
     short i, j, k, newX, newY;
     enum directions dir;
     short **grid;
@@ -2169,7 +2169,7 @@ void chooseRandomDoorSites(short **roomMap, pos doorSites[4]) {
     freeGrid(grid);
 }
 
-void attachHallwayTo(short **grid, pos doorSites[4]) {
+static void attachHallwayTo(short **grid, pos doorSites[4]) {
     short i, x, y, newX, newY, dirs[4];
     short length;
     enum directions dir, dir2;
@@ -2238,7 +2238,7 @@ void attachHallwayTo(short **grid, pos doorSites[4]) {
 //      6. Cavern (the kind that fills a level)
 //      7. Entrance room (the big upside-down T room at the start of depth 1)
 
-void designRandomRoom(short **grid, boolean attachHallway, pos doorSites[4],
+static void designRandomRoom(short **grid, boolean attachHallway, pos doorSites[4],
                       const short roomTypeFrequencies[ROOM_TYPE_COUNT]) {
     short randIndex, i, sum;
     enum directions dir;
@@ -2308,7 +2308,7 @@ void designRandomRoom(short **grid, boolean attachHallway, pos doorSites[4],
     }
 }
 
-boolean roomFitsAt(short **dungeonMap, short **roomMap, short roomToDungeonX, short roomToDungeonY) {
+static boolean roomFitsAt(short **dungeonMap, short **roomMap, short roomToDungeonX, short roomToDungeonY) {
     short xRoom, yRoom, xDungeon, yDungeon, i, j;
 
     for (xRoom = 0; xRoom < DCOLS; xRoom++) {
@@ -2389,7 +2389,7 @@ void attachRooms(short **grid, const dungeonProfile *theDP, short attempts, shor
     freeGrid(roomMap);
 }
 
-void adjustDungeonProfileForDepth(dungeonProfile *theProfile) {
+static void adjustDungeonProfileForDepth(dungeonProfile *theProfile) {
     const short descentPercent = clamp(100 * (rogue.depthLevel - 1) / (gameConst->amuletLevel - 1), 0, 100);
 
     theProfile->roomFrequencies[0] += 20 * (100 - descentPercent) / 100;
@@ -2400,7 +2400,7 @@ void adjustDungeonProfileForDepth(dungeonProfile *theProfile) {
     theProfile->corridorChance += 80 * (100 - descentPercent) / 100;
 }
 
-void adjustDungeonFirstRoomProfileForDepth(dungeonProfile *theProfile) {
+static void adjustDungeonFirstRoomProfileForDepth(dungeonProfile *theProfile) {
     short i;
     const short descentPercent = clamp(100 * (rogue.depthLevel - 1) / (gameConst->amuletLevel - 1), 0, 100);
 
@@ -2420,7 +2420,7 @@ void adjustDungeonFirstRoomProfileForDepth(dungeonProfile *theProfile) {
 // On the grid, a 0 denotes granite, a 1 denotes floor, and a 2 denotes a possible door site.
 // -1 denotes off-limits areas -- rooms can't be placed there and also can't sprout off of there.
 // Parent function will translate this grid into pmap[][] to make floors, walls, doors, etc.
-void carveDungeon(short **grid) {
+static void carveDungeon(short **grid) {
     dungeonProfile theDP, theFirstRoomDP;
 
     theDP = dungeonProfileCatalog[DP_BASIC];
@@ -2444,7 +2444,7 @@ void carveDungeon(short **grid) {
 //    temporaryMessage("How does this finished level look?", REQUIRE_ACKNOWLEDGMENT);
 }
 
-void finishWalls(boolean includingDiagonals) {
+static void finishWalls(boolean includingDiagonals) {
     short i, j, x1, y1;
     boolean foundExposure;
     enum directions dir;
@@ -2482,7 +2482,7 @@ void finishWalls(boolean includingDiagonals) {
     }
 }
 
-void liquidType(short *deep, short *shallow, short *shallowWidth) {
+static void liquidType(short *deep, short *shallow, short *shallowWidth) {
     short randMin, randMax, rand;
 
     randMin = (rogue.depthLevel < gameConst->minimumLavaLevel ? 1 : 0);
@@ -2518,7 +2518,7 @@ void liquidType(short *deep, short *shallow, short *shallowWidth) {
 
 // Fills a lake marked in unfilledLakeMap with the specified liquid type, scanning outward to reach other lakes within scanWidth.
 // Any wreath of shallow liquid must be done elsewhere.
-void fillLake(short x, short y, short liquid, short scanWidth, char wreathMap[DCOLS][DROWS], short **unfilledLakeMap) {
+static void fillLake(short x, short y, short liquid, short scanWidth, char wreathMap[DCOLS][DROWS], short **unfilledLakeMap) {
     short i, j;
 
     for (i = x - scanWidth; i <= x + scanWidth; i++) {
@@ -2533,7 +2533,7 @@ void fillLake(short x, short y, short liquid, short scanWidth, char wreathMap[DC
     }
 }
 
-void lakeFloodFill(short x, short y, short **floodMap, short **grid, short **lakeMap, short dungeonToGridX, short dungeonToGridY) {
+static void lakeFloodFill(short x, short y, short **floodMap, short **grid, short **lakeMap, short dungeonToGridX, short dungeonToGridY) {
     short newX, newY;
     enum directions dir;
 
@@ -2552,7 +2552,7 @@ void lakeFloodFill(short x, short y, short **floodMap, short **grid, short **lak
     }
 }
 
-boolean lakeDisruptsPassability(short **grid, short **lakeMap, short dungeonToGridX, short dungeonToGridY) {
+static boolean lakeDisruptsPassability(short **grid, short **lakeMap, short dungeonToGridX, short dungeonToGridY) {
     boolean result;
     short i, j, x, y;
     short **floodMap;
@@ -2602,7 +2602,7 @@ boolean lakeDisruptsPassability(short **grid, short **lakeMap, short dungeonToGr
     return result;
 }
 
-void designLakes(short **lakeMap) {
+static void designLakes(short **lakeMap) {
     short i, j, k;
     short x, y;
     short lakeMaxHeight, lakeMaxWidth;
@@ -2653,7 +2653,7 @@ void designLakes(short **lakeMap) {
     freeGrid(grid);
 }
 
-void createWreath(short shallowLiquid, short wreathWidth, char wreathMap[DCOLS][DROWS]) {
+static void createWreath(short shallowLiquid, short wreathWidth, char wreathMap[DCOLS][DROWS]) {
     short i, j, k, l;
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
@@ -2674,7 +2674,7 @@ void createWreath(short shallowLiquid, short wreathWidth, char wreathMap[DCOLS][
     }
 }
 
-void fillLakes(short **lakeMap) {
+static void fillLakes(short **lakeMap) {
     short deepLiquid = CRYSTAL_WALL, shallowLiquid = CRYSTAL_WALL, shallowLiquidWidth = 0;
     char wreathMap[DCOLS][DROWS];
     short i, j;
@@ -2697,7 +2697,7 @@ void fillLakes(short **lakeMap) {
     }
 }
 
-void finishDoors() {
+static void finishDoors() {
     short i, j;
     const short secretDoorChance = clamp((rogue.depthLevel - 1) * 67 / (gameConst->amuletLevel - 1), 0, 67);
     for (i=1; i<DCOLS-1; i++) {
@@ -2724,7 +2724,7 @@ void finishDoors() {
     }
 }
 
-void clearLevel() {
+static void clearLevel() {
     short i, j;
 
     for( i=0; i<DCOLS; i++ ) {
@@ -2750,7 +2750,7 @@ void clearLevel() {
 
 // Scans the map in random order looking for a good place to build a bridge.
 // If it finds one, it builds a bridge there, halts and returns true.
-boolean buildABridge() {
+static boolean buildABridge() {
     short i, j, k, l, i2, j2, nCols[DCOLS], nRows[DROWS];
     short bridgeRatioX, bridgeRatioY;
     boolean foundExposure;
@@ -3073,7 +3073,7 @@ short oppositeDirection(short theDir) {
 
 // blockingMap is optional.
 // Returns the size of the connected zone, and marks visited[][] with the zoneLabel.
-short connectCell(short x, short y, short zoneLabel, char blockingMap[DCOLS][DROWS], char zoneMap[DCOLS][DROWS]) {
+static short connectCell(short x, short y, short zoneLabel, char blockingMap[DCOLS][DROWS], char zoneMap[DCOLS][DROWS]) {
     enum directions dir;
     short newX, newY, size;
 
@@ -3242,7 +3242,7 @@ boolean fillSpawnMap(enum dungeonLayers layer,
     return accomplishedSomething;
 }
 
-void spawnMapDF(short x, short y,
+static void spawnMapDF(short x, short y,
                 enum tileType propagationTerrain,
                 boolean requirePropTerrain,
                 short startProb,
@@ -3296,7 +3296,7 @@ void spawnMapDF(short x, short y,
     }
 }
 
-void evacuateCreatures(char blockingMap[DCOLS][DROWS]) {
+static void evacuateCreatures(char blockingMap[DCOLS][DROWS]) {
     creature *monst;
 
     for (int i=0; i<DCOLS; i++) {
@@ -3549,7 +3549,7 @@ void restoreItem(item *theItem) {
 
 // Returns true iff the location is a plain wall, three of the four cardinal neighbors are walls, the remaining cardinal neighbor
 // is not a pathing blocker, the two diagonals between the three cardinal walls are also walls, and none of the eight neighbors are in machines.
-boolean validStairLoc(short x, short y) {
+static boolean validStairLoc(short x, short y) {
     short newX, newY, dir, neighborWallCount;
 
     if (x < 1 || x >= DCOLS - 1 || y < 1 || y >= DROWS - 1 || pmap[x][y].layers[DUNGEON] != WALL) {
@@ -3601,7 +3601,7 @@ boolean validStairLoc(short x, short y) {
 
 // The walls on either side become torches. Any adjacent granite then becomes top_wall. All wall neighbors are un-tunnelable.
 // Grid is zeroed out within 5 spaces in all directions.
-void prepareForStairs(short x, short y, char grid[DCOLS][DROWS]) {
+static void prepareForStairs(short x, short y, char grid[DCOLS][DROWS]) {
     short newX, newY, dir;
 
     // Add torches to either side.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -145,7 +145,7 @@ boolean attackHit(creature *attacker, creature *defender) {
     return rand_percent(hitProbability(attacker, defender));
 }
 
-void addMonsterToContiguousMonsterGrid(short x, short y, creature *monst, char grid[DCOLS][DROWS]) {
+static void addMonsterToContiguousMonsterGrid(short x, short y, creature *monst, char grid[DCOLS][DROWS]) {
     short newX, newY;
     enum directions dir;
     creature *tempMonst;
@@ -169,7 +169,7 @@ void addMonsterToContiguousMonsterGrid(short x, short y, creature *monst, char g
 // group of monsters that the monster would not avoid.
 // The contiguous group is supplemented with the given (x, y) coordinates, if any;
 // this is so that jellies et al. can spawn behind the player in a hallway.
-void splitMonster(creature *monst, pos loc) {
+static void splitMonster(creature *monst, pos loc) {
     char buf[DCOLS * 3];
     char monstName[DCOLS];
     char monsterGrid[DCOLS][DROWS], eligibleGrid[DCOLS][DROWS];
@@ -264,7 +264,7 @@ void splitMonster(creature *monst, pos loc) {
     }
 }
 
-short alliedCloneCount(creature *monst) {
+static short alliedCloneCount(creature *monst) {
     short count = 0;
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *temp = nextCreature(&it);
@@ -354,7 +354,7 @@ void moralAttack(creature *attacker, creature *defender) {
     }
 }
 
-boolean playerImmuneToMonster(creature *monst) {
+static boolean playerImmuneToMonster(creature *monst) {
     if (monst != &player
         && rogue.armor
         && (rogue.armor->flags & ITEM_RUNIC)
@@ -367,7 +367,7 @@ boolean playerImmuneToMonster(creature *monst) {
     }
 }
 
-void specialHit(creature *attacker, creature *defender, short damage) {
+static void specialHit(creature *attacker, creature *defender, short damage) {
     short itemCandidates, randItemIndex, stolenQuantity;
     item *theItem = NULL, *itemFromTopOfStack;
     char buf[COLS], buf2[COLS], buf3[COLS];
@@ -483,7 +483,7 @@ void specialHit(creature *attacker, creature *defender, short damage) {
     }
 }
 
-boolean forceWeaponHit(creature *defender, item *theItem) {
+static boolean forceWeaponHit(creature *defender, item *theItem) {
     short forceDamage;
     char buf[DCOLS*3], buf2[COLS], monstName[DCOLS];
     creature *otherMonster = NULL;
@@ -771,7 +771,7 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
     }
 }
 
-void attackVerb(char returnString[DCOLS], creature *attacker, short hitPercentile) {
+static void attackVerb(char returnString[DCOLS], creature *attacker, short hitPercentile) {
     short verbCount, increment;
 
     if (attacker != &player && (player.status[STATUS_HALLUCINATING] || !canSeeMonster(attacker))) {
@@ -966,7 +966,7 @@ void applyArmorRunicEffect(char returnString[DCOLS], creature *attacker, short *
     }
 }
 
-void decrementWeaponAutoIDTimer() {
+static void decrementWeaponAutoIDTimer() {
     char buf[COLS*3], buf2[COLS*3];
 
     if (rogue.weapon
@@ -1341,7 +1341,7 @@ void flashMonster(creature *monst, const color *theColor, short strength) {
     }
 }
 
-boolean canAbsorb(creature *ally, boolean ourBolts[], creature *prey, short **grid) {
+static boolean canAbsorb(creature *ally, boolean ourBolts[], creature *prey, short **grid) {
     short i;
 
     if (ally->creatureState == MONSTER_ALLY
@@ -1375,7 +1375,7 @@ boolean canAbsorb(creature *ally, boolean ourBolts[], creature *prey, short **gr
     return false;
 }
 
-boolean anyoneWantABite(creature *decedent) {
+static boolean anyoneWantABite(creature *decedent) {
     short candidates, randIndex, i;
     short **grid;
     boolean success = false;

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -155,7 +155,7 @@ void drawCircleOnGrid(short **grid, short x, short y, short radius, short value)
     }
 }
 
-void intersectGrids(short **onto, short **from) {
+static void intersectGrids(short **onto, short **from) {
     short i, j;
     for(i = 0; i < DCOLS; i++) {
         for(j = 0; j < DROWS; j++) {
@@ -168,7 +168,7 @@ void intersectGrids(short **onto, short **from) {
     }
 }
 
-void uniteGrids(short **onto, short **from) {
+static void uniteGrids(short **onto, short **from) {
     short i, j;
     for(i = 0; i < DCOLS; i++) {
         for(j = 0; j < DROWS; j++) {
@@ -179,7 +179,7 @@ void uniteGrids(short **onto, short **from) {
     }
 }
 
-void invertGrid(short **grid) {
+static void invertGrid(short **grid) {
     short i, j;
     for(i = 0; i < DCOLS; i++) {
         for(j = 0; j < DROWS; j++) {
@@ -212,7 +212,7 @@ void getTMGrid(short **grid, short value, unsigned long TMflags) {
     }
 }
 
-void getPassableArcGrid(short **grid, short minPassableArc, short maxPassableArc, short value) {
+static void getPassableArcGrid(short **grid, short minPassableArc, short maxPassableArc, short value) {
     short i, j, count;
     for(i = 0; i < DCOLS; i++) {
         for(j = 0; j < DROWS; j++) {
@@ -239,7 +239,7 @@ short validLocationCount(short **grid, short validValue) {
     return count;
 }
 
-short leastPositiveValueInGrid(short **grid) {
+static short leastPositiveValueInGrid(short **grid) {
     short i, j, leastPositiveValue = 0;
     for(i = 0; i < DCOLS; i++) {
         for(j = 0; j < DROWS; j++) {
@@ -278,7 +278,7 @@ void randomLocationInGrid(short **grid, short *x, short *y, short validValue) {
 
 // Finds the lowest positive number in a grid, chooses one location with that number randomly and returns it as (x, y).
 // If there are no valid locations, returns (-1, -1).
-void randomLeastPositiveLocationInGrid(short **grid, short *x, short *y, boolean deterministic) {
+static void randomLeastPositiveLocationInGrid(short **grid, short *x, short *y, boolean deterministic) {
     const short targetValue = leastPositiveValueInGrid(grid);
     short locationCount;
     short i, j, index;
@@ -394,7 +394,7 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
     }
 }
 
-void cellularAutomataRound(short **grid, char birthParameters[9], char survivalParameters[9]) {
+static void cellularAutomataRound(short **grid, char birthParameters[9], char survivalParameters[9]) {
     short i, j, nbCount, newX, newY;
     enum directions dir;
     short **buffer2;
@@ -428,7 +428,7 @@ void cellularAutomataRound(short **grid, char birthParameters[9], char survivalP
 }
 
 // Marks a cell as being a member of blobNumber, then recursively iterates through the rest of the blob
-short fillContiguousRegion(short **grid, short x, short y, short fillValue) {
+static short fillContiguousRegion(short **grid, short x, short y, short fillValue) {
     enum directions dir;
     short newX, newY, numberOfCells = 1;
 

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -155,39 +155,6 @@ void drawCircleOnGrid(short **grid, short x, short y, short radius, short value)
     }
 }
 
-static void intersectGrids(short **onto, short **from) {
-    short i, j;
-    for(i = 0; i < DCOLS; i++) {
-        for(j = 0; j < DROWS; j++) {
-            if (onto[i][j] && from[i][j]) {
-                onto[i][j] = true;
-            } else {
-                onto[i][j] = false;
-            }
-        }
-    }
-}
-
-static void uniteGrids(short **onto, short **from) {
-    short i, j;
-    for(i = 0; i < DCOLS; i++) {
-        for(j = 0; j < DROWS; j++) {
-            if (!onto[i][j] && from[i][j]) {
-                onto[i][j] = from[i][j];
-            }
-        }
-    }
-}
-
-static void invertGrid(short **grid) {
-    short i, j;
-    for(i = 0; i < DCOLS; i++) {
-        for(j = 0; j < DROWS; j++) {
-            grid[i][j] = !grid[i][j];
-        }
-    }
-}
-
 // Fills grid locations with the given value if they match any terrain flags or map flags.
 // Otherwise does not change the grid location.
 void getTerrainGrid(short **grid, short value, unsigned long terrainFlags, unsigned long mapFlags) {

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2975,10 +2975,6 @@ boolean confirm(char *prompt, boolean alsoDuringPlayback) {
     return retVal;
 }
 
-static void clearMonsterFlashes() {
-
-}
-
 void displayMonsterFlashes(boolean flashingEnabled) {
     short x[100], y[100], strength[100], count = 0;
     const color *flashColor[100];

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -104,7 +104,7 @@ void showCursor() {
     }
 }
 
-pos getClosestValidLocationOnMap(short **map, short x, short y) {
+static pos getClosestValidLocationOnMap(short **map, short x, short y) {
     pos answer = INVALID_POS;
 
     int closestDistance = 10000;
@@ -129,7 +129,7 @@ pos getClosestValidLocationOnMap(short **map, short x, short y) {
     return answer;
 }
 
-void processSnapMap(short **map) {
+static void processSnapMap(short **map) {
     short **costMap;
     enum directions dir;
     short i, j, newX, newY;
@@ -165,7 +165,7 @@ void processSnapMap(short **map) {
 // Returns the keystroke to effect the button's command, or -1 if canceled.
 // Some buttons take effect in this function instead of returning a value,
 // i.e. true colors mode and display stealth mode.
-short actionMenu(short x, boolean playingBack) {
+static short actionMenu(short x, boolean playingBack) {
     short buttonCount;
     short y;
     boolean takeActionOurselves[ROWS] = {false};
@@ -430,7 +430,7 @@ short actionMenu(short x, boolean playingBack) {
 
 #define MAX_MENU_BUTTON_COUNT 5
 
-void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
+static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
     short i, x, buttonCount;
     char goldTextEscape[MAX_MENU_BUTTON_COUNT] = "";
     char whiteTextEscape[MAX_MENU_BUTTON_COUNT] = "";
@@ -928,7 +928,7 @@ void storeColorComponents(char components[3], const color *theColor) {
     components[2] = max(0, min(100, theColor->blue + rand_range(0, theColor->blueRand) + rand));
 }
 
-void bakeTerrainColors(color *foreColor, color *backColor, short x, short y) {
+static void bakeTerrainColors(color *foreColor, color *backColor, short x, short y) {
     const short *vals;
     const short neutralColors[8] = {1000, 1000, 1000, 1000, 0, 0, 0, 0};
     if (rogue.trueColorMode) {
@@ -1598,7 +1598,7 @@ void desaturate(color *baseColor, short weight) {
     baseColor->rand += avg * weight / 3 / 100;
 }
 
-short randomizeByPercent(short input, short percent) {
+static short randomizeByPercent(short input, short percent) {
     return (rand_range(input * (100 - percent) / 100, input * (100 + percent) / 100));
 }
 
@@ -1615,7 +1615,7 @@ void swapColors(color *color1, color *color2) {
 }
 
 // Assumes colors are pre-baked.
-void blendAppearances(const color *fromForeColor, const color *fromBackColor, const enum displayGlyph fromChar,
+static void blendAppearances(const color *fromForeColor, const color *fromBackColor, const enum displayGlyph fromChar,
                       const color *toForeColor, const color *toBackColor, const enum displayGlyph toChar,
                       color *retForeColor, color *retBackColor, enum displayGlyph *retChar,
                       const short percent) {
@@ -1742,7 +1742,7 @@ void hiliteCell(short x, short y, const color *hiliteColor, short hiliteStrength
     restoreRNG;
 }
 
-short adjustedLightValue(short x) {
+static short adjustedLightValue(short x) {
     if (x <= LIGHT_SMOOTHING_THRESHOLD) {
         return x;
     } else {
@@ -2220,7 +2220,7 @@ void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart
     restoreRNG;
 }
 
-void displayWaypoints() {
+static void displayWaypoints() {
     short i, j, w, lowestDistance;
 
     for (i=0; i<DCOLS; i++) {
@@ -2239,7 +2239,7 @@ void displayWaypoints() {
     temporaryMessage("Waypoints:", REQUIRE_ACKNOWLEDGMENT);
 }
 
-void displayMachines() {
+static void displayMachines() {
     short i, j;
     color foreColor, backColor, machineColors[50];
     enum displayGlyph dchar;
@@ -2325,7 +2325,7 @@ void displayLoops() {
     waitForAcknowledgment();
 }
 
-void exploreKey(const boolean controlKey) {
+static void exploreKey(const boolean controlKey) {
     short x, y, finalX = 0, finalY = 0;
     short **exploreMap;
     enum directions dir;
@@ -2975,7 +2975,7 @@ boolean confirm(char *prompt, boolean alsoDuringPlayback) {
     return retVal;
 }
 
-void clearMonsterFlashes() {
+static void clearMonsterFlashes() {
 
 }
 
@@ -3012,7 +3012,7 @@ void displayMonsterFlashes(boolean flashingEnabled) {
     restoreRNG;
 }
 
-void dequeueEvent() {
+static void dequeueEvent() {
     rogueEvent returnEvent;
     nextBrogueEvent(&returnEvent, false, false, true);
 }
@@ -3024,11 +3024,11 @@ void clearMessageArchive() {
 
 // Get a pointer to the archivedMessage the given number of entries back in history.
 // Pass zero to get the entry under messageArchivePosition.
-archivedMessage *getArchivedMessage(short back) {
+static archivedMessage *getArchivedMessage(short back) {
     return &messageArchive[(messageArchivePosition + MESSAGE_ARCHIVE_ENTRIES - back) % MESSAGE_ARCHIVE_ENTRIES];
 }
 
-int formatCountedMessage(char *buffer, size_t size, archivedMessage *m) {
+static int formatCountedMessage(char *buffer, size_t size, archivedMessage *m) {
     int length;
 
     if (m->count <= 1) {
@@ -3047,7 +3047,7 @@ int formatCountedMessage(char *buffer, size_t size, archivedMessage *m) {
 // only one message is taken.
 // If turnOutput is not null, it is filled with the player turn number shared
 // by the chosen messages.
-short foldMessages(char buffer[COLS*20], short offset, unsigned long *turnOutput) {
+static short foldMessages(char buffer[COLS*20], short offset, unsigned long *turnOutput) {
     short i, folded, messageLength, lineLength, length;
     unsigned long turn;
     char counted[COLS*2];
@@ -3103,7 +3103,7 @@ short foldMessages(char buffer[COLS*20], short offset, unsigned long *turnOutput
 }
 
 // Change the given newline-delimited sentences in-place to ensure proper writing.
-void capitalizeAndPunctuateSentences(char *text, short length) {
+static void capitalizeAndPunctuateSentences(char *text, short length) {
     short i;
     boolean newSentence;
 
@@ -3127,7 +3127,7 @@ void capitalizeAndPunctuateSentences(char *text, short length) {
 }
 
 // Copy \n-delimited lines to the given buffer.  Carry colors across line breaks.
-void splitLines(short lines, char wrapped[COLS*20], char buffer[][COLS*2], short bufferCursor) {
+static void splitLines(short lines, char wrapped[COLS*20], char buffer[][COLS*2], short bufferCursor) {
     short linesSeen;
     char color[5], line[COLS*2];
     char *start, *end;
@@ -3228,7 +3228,7 @@ void displayRecentMessages() {
 // offset: index of oldest (visually highest) message to draw
 // height: height in rows of the message archive display area
 // rbuf: background display buffer to draw against
-void drawMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
+static void drawMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
     int i, j, k, fadePercent;
     cellDisplayBuffer dbuf[COLS][ROWS];
 
@@ -3260,7 +3260,7 @@ void drawMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short leng
 // offset: index of oldest (visually highest) message to draw in the fully expanded state
 // height: height in rows of the message archive display area in the fully expanded state
 // rbuf: background display buffer to draw against
-void animateMessageArchive(boolean opening, char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
+static void animateMessageArchive(boolean opening, char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
     short i;
     boolean fastForward;
 
@@ -3288,7 +3288,7 @@ void animateMessageArchive(boolean opening, char messages[MESSAGE_ARCHIVE_LINES]
 // rbuf: background display buffer to draw against
 //
 // returns the new offset, which can change if the player scrolled around before closing
-short scrollMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
+static short scrollMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
     short lastOffset;
     boolean exit;
     rogueEvent theEvent;
@@ -3925,7 +3925,7 @@ void printString(const char *theString, short x, short y, const color *foreColor
 
 // Inserts line breaks into really long words. Optionally adds a hyphen, but doesn't do anything
 // clever regarding hyphen placement. Plays nicely with color escapes.
-void breakUpLongWordsIn(char *sourceText, short width, boolean useHyphens) {
+static void breakUpLongWordsIn(char *sourceText, short width, boolean useHyphens) {
     char buf[TEXT_MAX_LENGTH] = "";
     short i, m, nextChar, wordWidth;
     //const short maxLength = useHyphens ? width - 1 : width;
@@ -4129,7 +4129,7 @@ void printHelpScreen() {
     updateMessageDisplay();
 }
 
-void printDiscoveries(short category, short count, unsigned short itemCharacter, short x, short y, cellDisplayBuffer dbuf[COLS][ROWS]) {
+static void printDiscoveries(short category, short count, unsigned short itemCharacter, short x, short y, cellDisplayBuffer dbuf[COLS][ROWS]) {
     color goodColor, badColor;
     const color *theColor;
     char buf[COLS], buf2[COLS];
@@ -4410,7 +4410,7 @@ static short estimatedArmorValue() {
     return max(0, retVal);
 }
 
-short creatureHealthChangePercent(creature *monst) {
+static short creatureHealthChangePercent(creature *monst) {
     if (monst->previousHealthPoints <= 0) {
         return 0;
     }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -78,7 +78,7 @@ item *generateItem(unsigned short theCategory, short theKind) {
     return theItem;
 }
 
-unsigned long pickItemCategory(unsigned long theCategory) {
+static unsigned long pickItemCategory(unsigned long theCategory) {
     short i, sum, randIndex;
     unsigned short correspondingCategories[13] =    {GOLD,  SCROLL, POTION, STAFF,  WAND,   WEAPON, ARMOR,  FOOD,   RING,   CHARM,    AMULET,   GEM,    KEY};
 
@@ -403,7 +403,7 @@ item *placeItemAt(item *theItem, pos dest) {
     return theItem;
 }
 
-void fillItemSpawnHeatMap(unsigned short heatMap[DCOLS][DROWS], unsigned short heatLevel, pos loc) {
+static void fillItemSpawnHeatMap(unsigned short heatMap[DCOLS][DROWS], unsigned short heatLevel, pos loc) {
     if (pmapAt(loc)->layers[DUNGEON] == DOOR) {
         heatLevel += 10;
     } else if (pmapAt(loc)->layers[DUNGEON] == SECRET_DOOR) {
@@ -424,7 +424,7 @@ void fillItemSpawnHeatMap(unsigned short heatMap[DCOLS][DROWS], unsigned short h
     }
 }
 
-void coolHeatMapAt(unsigned short heatMap[DCOLS][DROWS], pos loc, unsigned long *totalHeat) {
+static void coolHeatMapAt(unsigned short heatMap[DCOLS][DROWS], pos loc, unsigned long *totalHeat) {
     short k, l;
     unsigned short currentHeat;
 
@@ -448,7 +448,7 @@ void coolHeatMapAt(unsigned short heatMap[DCOLS][DROWS], pos loc, unsigned long 
 
 // Returns false if no place could be found.
 // That should happen only if the total heat is zero.
-boolean getItemSpawnLoc(unsigned short heatMap[DCOLS][DROWS], short *x, short *y, unsigned long *totalHeat) {
+static boolean getItemSpawnLoc(unsigned short heatMap[DCOLS][DROWS], short *x, short *y, unsigned long *totalHeat) {
     unsigned long randIndex;
     unsigned short currentHeat;
     short i, j;
@@ -746,7 +746,7 @@ void populateItems(pos upstairs) {
 
 // Name of this function is a bit misleading -- basically returns true iff the item will stack without consuming an extra slot
 // i.e. if it's a throwing weapon with a sibling already in your pack. False for potions and scrolls.
-boolean itemWillStackWithPack(item *theItem) {
+static boolean itemWillStackWithPack(item *theItem) {
     item *tempItem;
     if (theItem->category & GEM) {
         for (tempItem = packItems->nextItem;
@@ -866,7 +866,7 @@ void pickUpItemAt(pos loc) {
     }
 }
 
-void conflateItemCharacteristics(item *newItem, item *oldItem) {
+static void conflateItemCharacteristics(item *newItem, item *oldItem) {
 
     // let magic detection and other flags propagate to the new stack...
     newItem->flags |= (oldItem->flags & (ITEM_MAGIC_DETECTED | ITEM_IDENTIFIED | ITEM_PROTECTED | ITEM_RUNIC
@@ -885,7 +885,7 @@ void conflateItemCharacteristics(item *newItem, item *oldItem) {
     }
 }
 
-void stackItems(item *newItem, item *oldItem) {
+static void stackItems(item *newItem, item *oldItem) {
     //Increment the quantity of the old item...
     newItem->quantity += oldItem->quantity;
 
@@ -896,7 +896,7 @@ void stackItems(item *newItem, item *oldItem) {
     deleteItem(oldItem);
 }
 
-boolean inventoryLetterAvailable(char proposedLetter) {
+static boolean inventoryLetterAvailable(char proposedLetter) {
     item *theItem;
     if (proposedLetter >= 'a'
         && proposedLetter <= 'z') {
@@ -1015,7 +1015,7 @@ void checkForDisenchantment(item *theItem) {
     }
 }
 
-boolean itemIsSwappable(const item *theItem) {
+static boolean itemIsSwappable(const item *theItem) {
     if ((theItem->category & CAN_BE_SWAPPED)
         && theItem->quiverNumber == 0) {
 
@@ -1025,7 +1025,7 @@ boolean itemIsSwappable(const item *theItem) {
     }
 }
 
-void swapItemToEnchantLevel(item *theItem, short newEnchant, boolean enchantmentKnown) {
+static void swapItemToEnchantLevel(item *theItem, short newEnchant, boolean enchantmentKnown) {
     short x, y, charmPercent;
     char buf1[COLS * 3], buf2[COLS * 3];
 
@@ -1082,7 +1082,7 @@ void swapItemToEnchantLevel(item *theItem, short newEnchant, boolean enchantment
     }
 }
 
-boolean enchantLevelKnown(const item *theItem) {
+static boolean enchantLevelKnown(const item *theItem) {
     if ((theItem->category & STAFF)
         && (theItem->flags & ITEM_MAX_CHARGES_KNOWN)) {
 
@@ -1092,7 +1092,7 @@ boolean enchantLevelKnown(const item *theItem) {
     }
 }
 
-short effectiveEnchantLevel(const item *theItem) {
+static short effectiveEnchantLevel(const item *theItem) {
     if (theItem->category & WAND) {
         return theItem->charges;
     } else {
@@ -1100,7 +1100,7 @@ short effectiveEnchantLevel(const item *theItem) {
     }
 }
 
-boolean swapItemEnchants(const short machineNumber) {
+static boolean swapItemEnchants(const short machineNumber) {
     item *lockedItem, *tempItem;
     short i, j, oldEnchant;
     boolean enchantmentKnown;
@@ -1229,7 +1229,7 @@ void updateFloorItems() {
     }
 }
 
-boolean inscribeItem(item *theItem) {
+static boolean inscribeItem(item *theItem) {
     char itemText[30], buf[COLS * 3], nameOfItem[COLS * 3], oldInscription[COLS];
 
     strcpy(oldInscription, theItem->inscription);
@@ -1751,7 +1751,7 @@ boolean isVowelish(char *theChar) {
     }
 }
 
-fixpt enchantIncrement(item *theItem) {
+static fixpt enchantIncrement(item *theItem) {
     if (theItem->category & (WEAPON | ARMOR)) {
         if (theItem->strengthRequired == 0) {
             return FP_FACTOR;
@@ -1776,7 +1776,7 @@ boolean itemIsCarried(item *theItem) {
     return false;
 }
 
-short effectiveRingEnchant(item *theItem) {
+static short effectiveRingEnchant(item *theItem) {
     if (theItem->category != RING) {
         return 0;
     }
@@ -1788,7 +1788,7 @@ short effectiveRingEnchant(item *theItem) {
     return theItem->enchant1;
 }
 
-short apparentRingBonus(const enum ringKind kind) {
+static short apparentRingBonus(const enum ringKind kind) {
     item *rings[2] = {rogue.ringLeft, rogue.ringRight}, *ring;
     short retval = 0;
     short i;
@@ -2680,7 +2680,7 @@ void itemDetails(char *buf, item *theItem) {
     }
 }
 
-boolean displayMagicCharForItem(item *theItem) {
+static boolean displayMagicCharForItem(item *theItem) {
     if (!(theItem->flags & ITEM_MAGIC_DETECTED)
         || (theItem->category & PRENAMED_CATEGORY)) {
         return false;
@@ -3222,7 +3222,7 @@ void equip(item *theItem) {
 // (1) it's a key (has ITEM_IS_KEY flag),
 // (2) its originDepth matches the depth, and
 // (3) either its key (x, y) location matches (x, y), or its machine number matches the machine number at (x, y).
-boolean keyMatchesLocation(item *theItem, pos loc) {
+static boolean keyMatchesLocation(item *theItem, pos loc) {
     if ((theItem->flags & ITEM_IS_KEY)
         && theItem->originDepth == rogue.depthLevel) {
 
@@ -3522,7 +3522,7 @@ void getImpactLoc(pos *returnLoc, const pos originLoc, const pos targetLoc,
 
 // Returns true if the two coordinates are unobstructed and diagonally adjacent,
 // but their two common neighbors are obstructed and at least one blocks diagonal movement.
-boolean impermissibleKinkBetween(short x1, short y1, short x2, short y2) {
+static boolean impermissibleKinkBetween(short x1, short y1, short x2, short y2) {
     brogueAssert(coordinatesAreInMap(x1, y1));
     brogueAssert(coordinatesAreInMap(x2, y2));
     if (cellHasTerrainFlag(x1, y1, T_OBSTRUCTS_PASSABILITY)
@@ -3548,7 +3548,7 @@ boolean impermissibleKinkBetween(short x1, short y1, short x2, short y2) {
     return true;
 }
 
-boolean tunnelize(short x, short y) {
+static boolean tunnelize(short x, short y) {
     enum dungeonLayers layer;
     boolean didSomething = false;
     creature *monst;
@@ -3774,7 +3774,7 @@ void weaken(creature *monst, short maxDuration) {
 }
 
 // True if the creature polymorphed; false if not.
-boolean polymorph(creature *monst) {
+static boolean polymorph(creature *monst) {
     short previousDamageTaken, healthFraction, newMonsterIndex;
 
     if (monst == &player || (monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
@@ -3923,7 +3923,7 @@ void heal(creature *monst, short percent, boolean panacea) {
     }
 }
 
-void makePlayerTelepathic(short duration) {
+static void makePlayerTelepathic(short duration) {
     player.status[STATUS_TELEPATHIC] = player.maxStatus[STATUS_TELEPATHIC] = duration;
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
@@ -3936,7 +3936,7 @@ void makePlayerTelepathic(short duration) {
     }
 }
 
-void rechargeItems(unsigned long categories) {
+static void rechargeItems(unsigned long categories) {
     item *tempItem;
     short x, y, z, i, categoryCount;
     char buf[DCOLS * 3];
@@ -4020,7 +4020,7 @@ void rechargeItems(unsigned long categories) {
 //    colorFlash(&redFlashColor, 0, IN_FIELD_OF_VIEW, 15, DCOLS, player.loc.x, player.loc.y);
 //}
 
-void negationBlast(const char *emitterName, const short distance) {
+static void negationBlast(const char *emitterName, const short distance) {
     item *theItem;
     char buf[DCOLS];
 
@@ -4076,7 +4076,7 @@ void negationBlast(const char *emitterName, const short distance) {
     }
 }
 
-void discordBlast(const char *emitterName, const short distance) {
+static void discordBlast(const char *emitterName, const short distance) {
     char buf[DCOLS];
 
     sprintf(buf, "%s emits a wave of unsettling purple radiation!", emitterName);
@@ -4097,7 +4097,7 @@ void discordBlast(const char *emitterName, const short distance) {
     }
 }
 
-void crystalize(short radius) {
+static void crystalize(short radius) {
     extern color forceFieldColor;
     short i, j;
     creature *monst;
@@ -4133,7 +4133,7 @@ void crystalize(short radius) {
     refreshSideBar(-1, -1, false);
 }
 
-boolean imbueInvisibility(creature *monst, short duration) {
+static boolean imbueInvisibility(creature *monst, short duration) {
     boolean autoID = false;
 
     if (monst && !(monst->info.flags & (MONST_INANIMATE | MONST_INVISIBLE | MONST_INVULNERABLE))) {
@@ -4267,7 +4267,7 @@ void checkForMissingKeys(short x, short y) {
     }
 }
 
-void beckonMonster(creature *monst, short x, short y) {
+static void beckonMonster(creature *monst, short x, short y) {
     bolt theBolt = boltCatalog[BOLT_BLINKING];
 
     if (monst->bookkeepingFlags & MB_CAPTIVE) {
@@ -4307,7 +4307,7 @@ enum boltType boltForItem(item *theItem) {
 // *autoID will be set to true. (AutoID can be null.)
 // If the effect causes the level's lighting or vision to change, *lightingChanged
 // will be set to true. (LightingChanged can be null.)
-boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
+static boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                    boolean boltInView, boolean alreadyReflected,
                    boolean *autoID, boolean *lightingChanged) {
     char buf[COLS], monstName[COLS];
@@ -4657,7 +4657,7 @@ boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
 // Pass in true for alreadyReflected if the bolt has already reflected off of something.
 // If the effect is visible enough for the player to identify the shooting item,
 // *autoID will be set to true. (AutoID can be null.)
-void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *autoID) {
+static void detonateBolt(bolt *theBolt, creature *caster, short x, short y, boolean *autoID) {
     dungeonFeature feat;
     short i, x2, y2;
     creature *monst;
@@ -5184,7 +5184,7 @@ boolean nextTargetAfter(short *returnX,
 }
 
 // Returns how far it went before hitting something.
-short hiliteTrajectory(const pos coordinateList[DCOLS], short numCells, boolean eraseHiliting, const bolt *theBolt, const color *hiliteColor) {
+static short hiliteTrajectory(const pos coordinateList[DCOLS], short numCells, boolean eraseHiliting, const bolt *theBolt, const color *hiliteColor) {
     short x, y, i;
     creature *monst;
 
@@ -5440,7 +5440,7 @@ boolean moveCursor(boolean *targetConfirmed,
     return !cursorMovementCommand;
 }
 
-pos pullMouseClickDuringPlayback(void) {
+static pos pullMouseClickDuringPlayback(void) {
     rogueEvent theEvent;
 
     brogueAssert(rogue.playbackMode);
@@ -5839,7 +5839,7 @@ void autoIdentify(item *theItem) {
 }
 
 // returns whether the item disappeared
-boolean hitMonsterWithProjectileWeapon(creature *thrower, creature *monst, item *theItem) {
+static boolean hitMonsterWithProjectileWeapon(creature *thrower, creature *monst, item *theItem) {
     char buf[DCOLS], theItemName[DCOLS], targetName[DCOLS], armorRunicString[DCOLS];
     boolean thrownWeaponHit;
     item *equippedWeapon;
@@ -5916,7 +5916,7 @@ boolean hitMonsterWithProjectileWeapon(creature *thrower, creature *monst, item 
     }
 }
 
-void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistance) {
+static void throwItem(item *theItem, creature *thrower, pos targetLoc, short maxDistance) {
     short i, numCells;
     creature *monst = NULL;
     char buf[COLS*3], buf2[COLS*3], buf3[COLS*3];
@@ -6324,7 +6324,7 @@ void swapLastEquipment() {
 // If the blink trajectory lands in lava based on the player's knowledge, abort.
 // If the blink trajectory might land in lava based on the player's knowledge,
 // prompt for confirmation.
-boolean playerCancelsBlinking(const pos originLoc, const pos targetLoc, const short maxDistance) {
+static boolean playerCancelsBlinking(const pos originLoc, const pos targetLoc, const short maxDistance) {
     short numCells, i, x, y;
     boolean certainDeath = false;
     boolean possibleDeath = false;
@@ -6385,7 +6385,7 @@ boolean playerCancelsBlinking(const pos originLoc, const pos targetLoc, const sh
     return false;
 }
 
-boolean useStaffOrWand(item *theItem, boolean *commandsRecorded) {
+static boolean useStaffOrWand(item *theItem, boolean *commandsRecorded) {
     char buf[COLS], buf2[COLS];
     unsigned char command[10];
     short maxDistance, c;
@@ -6501,7 +6501,7 @@ boolean useStaffOrWand(item *theItem, boolean *commandsRecorded) {
     return true;
 }
 
-void summonGuardian(item *theItem) {
+static void summonGuardian(item *theItem) {
     short x = player.loc.x, y = player.loc.y;
     creature *monst;
 
@@ -6519,7 +6519,7 @@ void summonGuardian(item *theItem) {
     fadeInMonster(monst);
 }
 
-void useCharm(item *theItem) {
+static void useCharm(item *theItem) {
     fixpt enchant = netEnchant(theItem);
 
     rogue.featRecord[FEAT_PURE_WARRIOR] = false;
@@ -6740,7 +6740,7 @@ void identify(item *theItem) {
     identifyItemKind(theItem);
 }
 
-short lotteryDraw(short *frequencies, short itemCount) {
+static short lotteryDraw(short *frequencies, short itemCount) {
     short i, maxFreq, randIndex;
     maxFreq = 0;
     for (i = 0; i < itemCount; i++) {
@@ -6821,7 +6821,7 @@ void updateIdentifiableItems() {
     }
 }
 
-void magicMapCell(short x, short y) {
+static void magicMapCell(short x, short y) {
     pmap[x][y].flags |= MAGIC_MAPPED;
     pmap[x][y].rememberedTerrainFlags = tileCatalog[pmap[x][y].layers[DUNGEON]].flags | tileCatalog[pmap[x][y].layers[LIQUID]].flags;
     pmap[x][y].rememberedTMFlags = tileCatalog[pmap[x][y].layers[DUNGEON]].mechFlags | tileCatalog[pmap[x][y].layers[LIQUID]].mechFlags;
@@ -7083,7 +7083,7 @@ void readScroll(item *theItem) {
     }
 }
 
-void detectMagicOnItem(item *theItem) {
+static void detectMagicOnItem(item *theItem) {
     if (theItem->category & HAS_INTRINSIC_POLARITY) {
         itemTable *theItemTable = tableForItemCategory(theItem->category);
         theItemTable[theItem->kind].magicPolarityRevealed = true;
@@ -7384,7 +7384,7 @@ void unequip(item *theItem) {
     playerTurnEnded();
 }
 
-boolean canDrop() {
+static boolean canDrop() {
     if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_ITEMS)) {
         return false;
     }
@@ -7785,7 +7785,7 @@ void deleteItem(item *theItem) {
     free(theItem);
 }
 
-void resetItemTableEntry(itemTable *theEntry) {
+static void resetItemTableEntry(itemTable *theEntry) {
     theEntry->identified = false;
     theEntry->magicPolarityRevealed = false;
     theEntry->called = false;

--- a/src/brogue/Light.c
+++ b/src/brogue/Light.c
@@ -25,7 +25,7 @@
 #include "GlobalsBase.h"
 #include "Globals.h"
 
-void logLights() {
+static void logLights() {
 
     short i, j;
 
@@ -154,7 +154,7 @@ void updateMinersLightRadius() {
     rogue.minersLight.lightRadius.upperBound = rogue.minersLight.lightRadius.lowerBound = clamp(lightRadius / FP_FACTOR, -30000, 30000);
 }
 
-void updateDisplayDetail() {
+static void updateDisplayDetail() {
     short i, j;
 
     for (i = 0; i < DCOLS; i++) {
@@ -195,7 +195,7 @@ void restoreLighting(short lights[DCOLS][DROWS][3]) {
     }
 }
 
-void recordOldLights() {
+static void recordOldLights() {
     short i, j, k;
     for (i = 0; i < DCOLS; i++) {
         for (j = 0; j < DROWS; j++) {
@@ -319,7 +319,7 @@ void createFlare(short x, short y, enum lightType lightIndex) {
     rogue.flareCount++;
 }
 
-boolean flareIsActive(flare *theFlare) {
+static boolean flareIsActive(flare *theFlare) {
     const boolean increasing = (theFlare->coeffChangeAmount > 0);
     boolean active = true;
 
@@ -339,7 +339,7 @@ boolean flareIsActive(flare *theFlare) {
 }
 
 // Returns true if the flare is still active; false if it's not.
-boolean updateFlare(flare *theFlare) {
+static boolean updateFlare(flare *theFlare) {
     if (!flareIsActive(theFlare)) {
         return false;
     }
@@ -349,7 +349,7 @@ boolean updateFlare(flare *theFlare) {
 }
 
 // Returns whether it overlaps with the field of view.
-boolean drawFlareFrame(flare *theFlare) {
+static boolean drawFlareFrame(flare *theFlare) {
     boolean inView;
     lightSource tempLight = *(theFlare->light);
     color tempColor = *(tempLight.lightColor);

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -39,7 +39,7 @@
 #define MENU_FLAME_DENOMINATOR          (100 + MENU_FLAME_RISE_SPEED + MENU_FLAME_SPREAD_SPEED)
 
 
-void drawMenuFlames(signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3], unsigned char mask[COLS][ROWS]) {
+static void drawMenuFlames(signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3], unsigned char mask[COLS][ROWS]) {
     short i, j, versionStringLength, gameModeStringLength;
     color tempColor = {0};
     const color *maskColor = &black;
@@ -81,7 +81,7 @@ void drawMenuFlames(signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3
     }
 }
 
-void updateMenuFlames(const color *colors[COLS][(ROWS + MENU_FLAME_ROW_PADDING)],
+static void updateMenuFlames(const color *colors[COLS][(ROWS + MENU_FLAME_ROW_PADDING)],
                       signed short colorSources[MENU_FLAME_COLOR_SOURCE_COUNT][4],
                       signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3]) {
 
@@ -158,7 +158,7 @@ void updateMenuFlames(const color *colors[COLS][(ROWS + MENU_FLAME_ROW_PADDING)]
 }
 
 // Takes a grid of values, each of which is 0 or 100, and fills in some middle values in the interstices.
-void antiAlias(unsigned char mask[COLS][ROWS]) {
+static void antiAlias(unsigned char mask[COLS][ROWS]) {
     short i, j, x, y, dir, nbCount;
     const short intensity[5] = {0, 0, 35, 50, 60};
 
@@ -182,7 +182,7 @@ void antiAlias(unsigned char mask[COLS][ROWS]) {
 #define MENU_TITLE_OFFSET_X (-7)
 #define MENU_TITLE_OFFSET_Y (-2)
 
-void initializeMenuFlames(boolean includeTitle,
+static void initializeMenuFlames(boolean includeTitle,
                           const color *colors[COLS][(ROWS + MENU_FLAME_ROW_PADDING)],
                           color colorStorage[COLS],
                           signed short colorSources[MENU_FLAME_COLOR_SOURCE_COUNT][4],
@@ -501,7 +501,7 @@ static void redrawMainMenuButtons(buttonState *menu) {
 
 #define FLYOUT_X 59
 
-void titleMenu() {
+static void titleMenu() {
     signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3]; // red, green and blue
     signed short colorSources[MENU_FLAME_COLOR_SOURCE_COUNT][4]; // red, green, blue, and rand, one for each color source (no more than MENU_FLAME_COLOR_SOURCE_COUNT).
     const color *colors[COLS][(ROWS + MENU_FLAME_ROW_PADDING)];
@@ -640,7 +640,7 @@ void dialogAlert(char *message) {
     overlayDisplayBuffer(rbuf, NULL);
 }
 
-boolean stringsExactlyMatch(const char *string1, const char *string2) {
+static boolean stringsExactlyMatch(const char *string1, const char *string2) {
     short i;
     for (i=0; string1[i] && string2[i]; i++) {
         if (string1[i] != string2[i]) {
@@ -655,7 +655,7 @@ boolean stringsExactlyMatch(const char *string1, const char *string2) {
 //      < 0 if 'b' date is lesser than 'a' date
 //      = 0 if 'b' date is equal to 'a' date,
 //      > 0 if 'b' date is greater than 'a' date
-int fileEntryCompareDates(const void *a, const void *b) {
+static int fileEntryCompareDates(const void *a, const void *b) {
     fileEntry *f1 = (fileEntry *)a;
     fileEntry *f2 = (fileEntry *)b;
     time_t t1, t2;

--- a/src/brogue/Math.c
+++ b/src/brogue/Math.c
@@ -94,7 +94,7 @@ typedef struct ranctx { u4 a; u4 b; u4 c; u4 d; } ranctx;
 static ranctx RNGState[2];
 
 #define rot(x,k) (((x)<<(k))|((x)>>(32-(k))))
-u4 ranval( ranctx *x ) {
+static u4 ranval( ranctx *x ) {
     u4 e = x->a - rot(x->b, 27);
     x->a = x->b ^ rot(x->c, 17);
     x->b = x->c + x->d;
@@ -103,7 +103,7 @@ u4 ranval( ranctx *x ) {
     return x->d;
 }
 
-void raninit( ranctx *x, uint64_t seed ) {
+static void raninit( ranctx *x, uint64_t seed ) {
     u4 i;
     x->a = 0xf1ea5eed, x->b = x->c = x->d = (u4)seed;
     x->c ^= (u4)(seed >> 32);
@@ -122,7 +122,7 @@ void raninit( ranctx *x, uint64_t seed ) {
 
 #define RAND_MAX_COMBO ((unsigned long) UINT32_MAX)
 
-long range(long n, short RNG) {
+static long range(long n, short RNG) {
     unsigned long div;
     long r;
 

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -273,7 +273,7 @@ boolean monsterIsInClass(const creature *monst, const short monsterClass) {
 // Don't attack a revenant if you're not magical.
 // Don't attack a monster embedded in obstruction crystal.
 // Etc.
-boolean attackWouldBeFutile(const creature *attacker, const creature *defender) {
+static boolean attackWouldBeFutile(const creature *attacker, const creature *defender) {
     if (cellHasTerrainFlag(defender->loc.x, defender->loc.y, T_OBSTRUCTS_PASSABILITY)
         && !(defender->info.flags & MONST_ATTACKABLE_THRU_WALLS)) {
         return true;
@@ -668,7 +668,7 @@ boolean monsterCanSubmergeNow(creature *monst) {
 }
 
 // Returns true if at least one minion spawned.
-boolean spawnMinions(short hordeID, creature *leader, boolean summoned, boolean itemPossible) {
+static boolean spawnMinions(short hordeID, creature *leader, boolean summoned, boolean itemPossible) {
     short iSpecies, iMember, count;
     unsigned long forbiddenTerrainFlags;
     const hordeType *theHorde;
@@ -729,7 +729,7 @@ boolean spawnMinions(short hordeID, creature *leader, boolean summoned, boolean 
     return atLeastOneMinion;
 }
 
-boolean drawManacle(pos loc, enum directions dir) {
+static boolean drawManacle(pos loc, enum directions dir) {
     enum tileType manacles[8] = {MANACLE_T, MANACLE_B, MANACLE_L, MANACLE_R, MANACLE_TL, MANACLE_BL, MANACLE_TR, MANACLE_BR};
     pos newLoc = posNeighborInDirection(loc, dir);
     if (isPosInMap(newLoc)
@@ -742,7 +742,7 @@ boolean drawManacle(pos loc, enum directions dir) {
     return false;
 }
 
-void drawManacles(pos loc) {
+static void drawManacles(pos loc) {
     enum directions fallback[4][3] = {{UPLEFT, UP, LEFT}, {DOWNLEFT, DOWN, LEFT}, {UPRIGHT, UP, RIGHT}, {DOWNRIGHT, DOWN, RIGHT}};
     short i, j;
     for (i = 0; i < 4; i++) {
@@ -947,7 +947,7 @@ void freeCreatureList(creatureList *list) {
     list->head = NULL;
 }
 
-boolean summonMinions(creature *summoner) {
+static boolean summonMinions(creature *summoner) {
     enum monsterTypes summonerType = summoner->info.monsterID;
     const short hordeID = pickHordeType(0, summonerType, 0, 0);
     short seenMinionCount = 0, x, y;
@@ -1168,7 +1168,7 @@ void teleport(creature *monst, pos destination, boolean respectTerrainAvoidanceP
     }
 }
 
-boolean isValidWanderDestination(creature *monst, short wpIndex) {
+static boolean isValidWanderDestination(creature *monst, short wpIndex) {
     return (wpIndex >= 0
             && wpIndex < rogue.wpCount
             && !monst->waypointAlreadyVisited[wpIndex]
@@ -1176,7 +1176,7 @@ boolean isValidWanderDestination(creature *monst, short wpIndex) {
             && nextStep(rogue.wpDistance[wpIndex], monst->loc.x, monst->loc.y, monst, false) != NO_DIRECTION);
 }
 
-short closestWaypointIndex(creature *monst) {
+static short closestWaypointIndex(creature *monst) {
     short i, closestDistance, closestIndex;
 
     closestDistance = DCOLS/2;
@@ -1222,7 +1222,7 @@ enum subseqDFTypes {
 };
 
 // Returns the terrain flags of this tile after it's promoted according to the event corresponding to subseqDFTypes.
-unsigned long successorTerrainFlags(enum tileType tile, enum subseqDFTypes promotionType) {
+static unsigned long successorTerrainFlags(enum tileType tile, enum subseqDFTypes promotionType) {
     enum dungeonFeatureTypes DF = 0;
 
     switch (promotionType) {
@@ -1478,7 +1478,7 @@ boolean monsterAvoids(creature *monst, pos p) {
     return false;
 }
 
-boolean moveMonsterPassivelyTowards(creature *monst, pos targetLoc, boolean willingToAttackPlayer) {
+static boolean moveMonsterPassivelyTowards(creature *monst, pos targetLoc, boolean willingToAttackPlayer) {
     const int x = monst->loc.x;
     const int y = monst->loc.y;
 
@@ -1571,7 +1571,7 @@ void wakeUp(creature *monst) {
     }
 }
 
-boolean monsterCanShootWebs(creature *monst) {
+static boolean monsterCanShootWebs(creature *monst) {
     short i;
     for (i=0; monst->info.bolts[i] != 0; i++) {
         const bolt *theBolt = &boltCatalog[monst->info.bolts[i]];
@@ -1584,7 +1584,7 @@ boolean monsterCanShootWebs(creature *monst) {
 
 // Assumes that observer is not the player.
 // Returns approximately double the actual (quasi-euclidian) distance.
-short awarenessDistance(creature *observer, creature *target) {
+static short awarenessDistance(creature *observer, creature *target) {
     long perceivedDistance;
 
     // When determining distance from the player for purposes of monster state changes
@@ -1612,7 +1612,7 @@ short awarenessDistance(creature *observer, creature *target) {
 
 // yes or no -- observer is aware of the target as of this new turn.
 // takes into account whether it is ALREADY aware of the target.
-boolean awareOfTarget(creature *observer, creature *target) {
+static boolean awareOfTarget(creature *observer, creature *target) {
     short perceivedDistance = awarenessDistance(observer, target);
     short awareness = rogue.stealthRange * 2;
     boolean retval;
@@ -1648,7 +1648,7 @@ boolean awareOfTarget(creature *observer, creature *target) {
     return retval;
 }
 
-short closestWaypointIndexTo(pos p) {
+static short closestWaypointIndexTo(pos p) {
     short i, closestDistance, closestIndex;
 
     closestDistance = 1000;
@@ -1662,7 +1662,7 @@ short closestWaypointIndexTo(pos p) {
     return closestIndex;
 }
 
-void wanderToward(creature *monst, pos destination) {
+static void wanderToward(creature *monst, pos destination) {
     if (isPosInMap(destination)) {
         const short theWaypointIndex = closestWaypointIndexTo(destination);
         if (theWaypointIndex != -1) {
@@ -2047,7 +2047,7 @@ creature *dormantMonsterAtLoc(pos p) {
     return NULL;
 }
 
-enum boltType monsterHasBoltEffect(creature *monst, enum boltEffects boltEffectIndex) {
+static enum boltType monsterHasBoltEffect(creature *monst, enum boltEffects boltEffectIndex) {
     short i;
     for (i=0; monst->info.bolts[i] != 0; i++) {
         if (boltCatalog[monst->info.bolts[i]].boltEffect == boltEffectIndex) {
@@ -2057,7 +2057,7 @@ enum boltType monsterHasBoltEffect(creature *monst, enum boltEffects boltEffectI
     return BOLT_NONE;
 }
 
-void pathTowardCreature(creature *monst, creature *target) {
+static void pathTowardCreature(creature *monst, creature *target) {
     if (traversiblePathBetween(monst, target->loc.x, target->loc.y)) {
         if (distanceBetween(monst->loc, target->loc) <= 2) {
             monst->bookkeepingFlags &= ~MB_GIVEN_UP_ON_SCENT;
@@ -2102,7 +2102,7 @@ void pathTowardCreature(creature *monst, creature *target) {
     moveMonsterPassivelyTowards(monst, targetLoc, (monst->creatureState != MONSTER_ALLY));
 }
 
-boolean creatureEligibleForSwarming(creature *monst) {
+static boolean creatureEligibleForSwarming(creature *monst) {
     if ((monst->info.flags & (MONST_IMMOBILE | MONST_GETS_TURN_ON_ACTIVATION | MONST_MAINTAINS_DISTANCE))
         || monst->status[STATUS_ENTRANCED]
         || monst->status[STATUS_CONFUSED]
@@ -2128,7 +2128,7 @@ boolean creatureEligibleForSwarming(creature *monst) {
 // who is not adjacent to another enemy, and there is no empty space adjacent to the tribemate AND the enemy,
 // and there is an empty space adjacent to you AND the enemy, then move into that last space.
 // (In each case, "adjacent" excludes diagonal tiles obstructed by corner walls.)
-enum directions monsterSwarmDirection(creature *monst, creature *enemy) {
+static enum directions monsterSwarmDirection(creature *monst, creature *enemy) {
     enum directions dir, targetDir;
     short dirList[8] = {0, 1, 2, 3, 4, 5, 6, 7};
     boolean alternateDirectionExists;
@@ -2331,7 +2331,7 @@ boolean monsterBlinkToPreferenceMap(creature *monst, short **preferenceMap, bool
     return false;
 }
 
-boolean fleeingMonsterAwareOfPlayer(creature *monst) {
+static boolean fleeingMonsterAwareOfPlayer(creature *monst) {
     if (player.status[STATUS_INVISIBLE]) {
         return (distanceBetween(monst->loc, player.loc) <= 1);
     } else {
@@ -2362,7 +2362,7 @@ static short **getSafetyMap(creature *monst) {
 }
 
 // returns whether the monster did something (and therefore ended its turn)
-boolean monsterBlinkToSafety(creature *monst) {
+static boolean monsterBlinkToSafety(creature *monst) {
     short **blinkSafetyMap;
 
     if (monst->creatureState == MONSTER_ALLY) {
@@ -2430,7 +2430,7 @@ boolean monsterSummons(creature *monst, boolean alwaysUse) {
 
 // Some monsters never make good targets irrespective of what bolt we're contemplating.
 // Return false for those. Otherwise, return true.
-boolean generallyValidBoltTarget(creature *caster, creature *target) {
+static boolean generallyValidBoltTarget(creature *caster, creature *target) {
     if (caster == target) {
         // Can't target yourself; that's the fundamental theorem of Brogue bolts.
         return false;
@@ -2459,7 +2459,7 @@ boolean generallyValidBoltTarget(creature *caster, creature *target) {
     return openPathBetween(caster->loc.x, caster->loc.y, target->loc.x, target->loc.y);
 }
 
-boolean targetEligibleForCombatBuff(creature *caster, creature *target) {
+static boolean targetEligibleForCombatBuff(creature *caster, creature *target) {
     if (caster->creatureState == MONSTER_ALLY) {
         if (canDirectlySeeMonster(caster)) {
             boolean handledPlayer = false;
@@ -2482,7 +2482,7 @@ boolean targetEligibleForCombatBuff(creature *caster, creature *target) {
 
 // Make a decision as to whether the given caster should fire the given bolt at the given target.
 // Assumes that the conditions in generallyValidBoltTarget have already been satisfied.
-boolean specificallyValidBoltTarget(creature *caster, creature *target, enum boltType theBoltType) {
+static boolean specificallyValidBoltTarget(creature *caster, creature *target, enum boltType theBoltType) {
 
     if ((boltCatalog[theBoltType].flags & BF_TARGET_ALLIES)
         && (!monstersAreTeammates(caster, target) || monstersAreEnemies(caster, target))) {
@@ -2649,7 +2649,7 @@ boolean specificallyValidBoltTarget(creature *caster, creature *target, enum bol
     return true;
 }
 
-void monsterCastSpell(creature *caster, creature *target, enum boltType boltIndex) {
+static void monsterCastSpell(creature *caster, creature *target, enum boltType boltIndex) {
     bolt theBolt;
     char buf[200], monstName[100];
 
@@ -2671,7 +2671,7 @@ void monsterCastSpell(creature *caster, creature *target, enum boltType boltInde
 }
 
 // returns whether the monster cast a bolt.
-boolean monstUseBolt(creature *monst) {
+static boolean monstUseBolt(creature *monst) {
     short i;
 
     if (!monst->info.bolts[0]) {
@@ -2702,7 +2702,7 @@ boolean monstUseBolt(creature *monst) {
 }
 
 // returns whether the monster did something (and therefore ended its turn)
-boolean monstUseMagic(creature *monst) {
+static boolean monstUseMagic(creature *monst) {
     if (monsterSummons(monst, (monst->info.flags & MONST_ALWAYS_USE_ABILITY))) {
         return true;
     } else if (monstUseBolt(monst)) {
@@ -2711,7 +2711,7 @@ boolean monstUseMagic(creature *monst) {
     return false;
 }
 
-boolean isLocalScentMaximum(pos loc) {
+static boolean isLocalScentMaximum(pos loc) {
     const short baselineScent = scentMap[loc.x][loc.y];
     for (enum directions dir=0; dir< DIRECTION_COUNT; dir++) {
         pos newLoc = posNeighborInDirection(loc, dir);
@@ -2727,7 +2727,7 @@ boolean isLocalScentMaximum(pos loc) {
 }
 
 // Returns the direction the player's scent points to from a given cell. Returns -1 if the nose comes up blank.
-enum directions scentDirection(creature *monst) {
+static enum directions scentDirection(creature *monst) {
     short newX, newY, x, y, newestX, newestY;
     enum directions bestDirection = NO_DIRECTION, dir, dir2;
     unsigned short bestNearbyScent = 0;
@@ -2875,7 +2875,7 @@ boolean monsterFleesFrom(creature *monst, creature *defender) {
     return false;
 }
 
-boolean allyFlees(creature *ally, creature *closestEnemy) {
+static boolean allyFlees(creature *ally, creature *closestEnemy) {
     const short x = ally->loc.x;
     const short y = ally->loc.y;
 
@@ -2906,7 +2906,7 @@ boolean allyFlees(creature *ally, creature *closestEnemy) {
     return false;
 }
 
-void monsterMillAbout(creature *monst, short movementChance) {
+static void monsterMillAbout(creature *monst, short movementChance) {
     enum directions dir;
 
     const short x = monst->loc.x;
@@ -2924,7 +2924,7 @@ void monsterMillAbout(creature *monst, short movementChance) {
     }
 }
 
-void moveAlly(creature *monst) {
+static void moveAlly(creature *monst) {
     creature *closestMonster = NULL;
     short i, j, x, y, dir, shortestDistance, leashLength;
     short **enemyMap, **costMap;
@@ -3134,7 +3134,7 @@ void moveAlly(creature *monst) {
 }
 
 // Returns whether to abort the turn.
-boolean updateMonsterCorpseAbsorption(creature *monst) {
+static boolean updateMonsterCorpseAbsorption(creature *monst) {
     short i;
     char buf[COLS], buf2[COLS];
 
@@ -4066,7 +4066,7 @@ void toggleMonsterDormancy(creature *monst) {
     }
 }
 
-boolean staffOrWandEffectOnMonsterDescription(char *newText, item *theItem, creature *monst) {
+static boolean staffOrWandEffectOnMonsterDescription(char *newText, item *theItem, creature *monst) {
     char theItemName[COLS], monstName[COLS];
     boolean successfulDescription = false;
     fixpt enchant = netEnchant(theItem);

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1976,41 +1976,6 @@ void autoPlayLevel(boolean fastForward) {
     rogue.autoPlayingLevel = false;
 }
 
-static short directionOfKeypress(unsigned short ch) {
-    switch (ch) {
-        case LEFT_KEY:
-        case LEFT_ARROW:
-        case NUMPAD_4:
-            return LEFT;
-        case RIGHT_KEY:
-        case RIGHT_ARROW:
-        case NUMPAD_6:
-            return RIGHT;
-        case UP_KEY:
-        case UP_ARROW:
-        case NUMPAD_8:
-            return UP;
-        case DOWN_KEY:
-        case DOWN_ARROW:
-        case NUMPAD_2:
-            return DOWN;
-        case UPLEFT_KEY:
-        case NUMPAD_7:
-            return UPLEFT;
-        case UPRIGHT_KEY:
-        case NUMPAD_9:
-            return UPRIGHT;
-        case DOWNLEFT_KEY:
-        case NUMPAD_1:
-            return DOWNLEFT;
-        case DOWNRIGHT_KEY:
-        case NUMPAD_3:
-            return DOWNRIGHT;
-        default:
-            return -1;
-    }
-}
-
 boolean startFighting(enum directions dir, boolean tillDeath) {
     const pos neighborLoc = posNeighborInDirection(player.loc, dir);
     creature * const monst = monsterAtLoc(neighborLoc);

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -121,7 +121,7 @@ void describedItemBasedOnParameters(short theCategory, short theKind, short theQ
 
 // Describes the item in question either by naming it if the player has already seen its name,
 // or by tersely identifying its category otherwise.
-void describedItemName(item *theItem, char *buf) {
+static void describedItemName(item *theItem, char *buf) {
     if (rogue.playbackOmniscience || (!player.status[STATUS_HALLUCINATING])) {
         itemName(theItem, buf, (theItem->category & (WEAPON | ARMOR) ? false : true), true, NULL);
     } else {
@@ -469,7 +469,7 @@ void vomit(creature *monst) {
     }
 }
 
-void moveEntrancedMonsters(enum directions dir) {
+static void moveEntrancedMonsters(enum directions dir) {
     dir = oppositeDirection(dir);
 
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
@@ -527,7 +527,7 @@ boolean freeCaptivesEmbeddedAt(short x, short y) {
 }
 
 // Do we need confirmation so we don't accidently hit an acid mound?
-boolean abortAttackAgainstAcidicTarget(creature *hitList[8]) {
+static boolean abortAttackAgainstAcidicTarget(creature *hitList[8]) {
     short i;
     char monstName[COLS], weaponName[COLS];
     char buf[COLS*3];
@@ -712,7 +712,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
     return false;
 }
 
-void buildFlailHitList(const short x, const short y, const short newX, const short newY, creature *hitList[16]) {
+static void buildFlailHitList(const short x, const short y, const short newX, const short newY, creature *hitList[16]) {
     short mx, my;
     short i = 0;
 
@@ -1446,7 +1446,7 @@ short nextStep(short **distanceMap, short x, short y, creature *monst, boolean p
     return bestDir;
 }
 
-void displayRoute(short **distanceMap, boolean removeRoute) {
+static void displayRoute(short **distanceMap, boolean removeRoute) {
     short currentX = player.loc.x, currentY = player.loc.y, dir, newX, newY;
     boolean advanced;
 
@@ -1521,7 +1521,7 @@ void travelRoute(pos path[1000], short steps) {
     updateFlavorText();
 }
 
-void travelMap(short **distanceMap) {
+static void travelMap(short **distanceMap) {
     short currentX = player.loc.x, currentY = player.loc.y, dir, newX, newY;
     boolean advanced;
 
@@ -1976,7 +1976,7 @@ void autoPlayLevel(boolean fastForward) {
     rogue.autoPlayingLevel = false;
 }
 
-short directionOfKeypress(unsigned short ch) {
+static short directionOfKeypress(unsigned short ch) {
     switch (ch) {
         case LEFT_KEY:
         case LEFT_ARROW:

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -40,19 +40,19 @@ enum recordingSeekModes {
     RECORDING_SEEK_MODE_DEPTH
 };
 
-void recordChar(unsigned char c) {
+static void recordChar(unsigned char c) {
     inputRecordBuffer[locationInRecordingBuffer++] = c;
     recordingLocation++;
 }
 
-void considerFlushingBufferToFile() {
+static void considerFlushingBufferToFile() {
     if (locationInRecordingBuffer >= INPUT_RECORD_BUFFER) {
         flushBufferToFile();
     }
 }
 
 // compresses a int into a char, discarding stuff we don't need
-unsigned char compressKeystroke(long c) {
+static unsigned char compressKeystroke(long c) {
     short i;
 
     for (i = 0; i < keystrokeCount; i++) {
@@ -66,7 +66,7 @@ unsigned char compressKeystroke(long c) {
     return UNKNOWN_KEY;
 }
 
-void numberToString(uint64_t number, short numberOfBytes, unsigned char *recordTo) {
+static void numberToString(uint64_t number, short numberOfBytes, unsigned char *recordTo) {
     short i;
     uint64_t n;
 
@@ -79,7 +79,7 @@ void numberToString(uint64_t number, short numberOfBytes, unsigned char *recordT
 }
 
 // numberOfBytes can't be greater than 10
-void recordNumber(unsigned long number, short numberOfBytes) {
+static void recordNumber(unsigned long number, short numberOfBytes) {
     short i;
     unsigned char c[10];
 
@@ -170,7 +170,7 @@ void recordMouseClick(short x, short y, boolean controlKey, boolean shiftKey) {
     recordEvent(&theEvent);
 }
 
-void writeHeaderInfo(char *path) {
+static void writeHeaderInfo(char *path) {
     unsigned char c[RECORDING_HEADER_LENGTH];
     short i;
     FILE *recordFile;
@@ -262,7 +262,7 @@ void fillBufferFromFile() {
     locationInRecordingBuffer = 0;
 }
 
-unsigned char recallChar() {
+static unsigned char recallChar() {
     unsigned char c;
     if (recordingLocation > lengthOfPlaybackFile) {
         return END_OF_RECORDING;
@@ -275,14 +275,14 @@ unsigned char recallChar() {
     return c;
 }
 
-long uncompressKeystroke(unsigned char c) {
+static long uncompressKeystroke(unsigned char c) {
     if (c >= 128 && (c - 128) < keystrokeCount) {
         return keystrokeTable[c - 128];
     }
     return (long)c;
 }
 
-uint64_t recallNumber(short numberOfBytes) {
+static uint64_t recallNumber(short numberOfBytes) {
     short i;
     uint64_t n;
 
@@ -301,7 +301,7 @@ simply be the result of a bug.\n\n\
 If this is a different computer from the one on which the recording was saved, the recording \
 might succeed on the original computer."
 
-void playbackPanic() {
+static void playbackPanic() {
     cellDisplayBuffer rbuf[COLS][ROWS];
 
     if (!rogue.playbackOOS) {
@@ -381,7 +381,7 @@ void recallEvent(rogueEvent *event) {
     event->shiftKey =   (c & Fl(2)) ? true : false;
 }
 
-void loadNextAnnotation() {
+static void loadNextAnnotation() {
     unsigned long currentReadTurn;
     short i;
     FILE *annotationFile;
@@ -624,7 +624,7 @@ void RNGCheck() {
     rogue.RNG = oldRNG;
 }
 
-boolean unpause() {
+static boolean unpause() {
     if (rogue.playbackOOS) {
         flashTemporaryAlert(" Out of sync ", 2000);
     } else if (rogue.playbackPaused) {
@@ -636,7 +636,7 @@ boolean unpause() {
 
 #define PLAYBACK_HELP_LINE_COUNT    20
 
-void printPlaybackHelpScreen() {
+static void printPlaybackHelpScreen() {
     short i, j;
     cellDisplayBuffer dbuf[COLS][ROWS], rbuf[COLS][ROWS];
     char helpText[PLAYBACK_HELP_LINE_COUNT][80] = {
@@ -806,7 +806,7 @@ static void seek(unsigned long seekTarget, enum recordingSeekModes seekMode) {
     displayLevel();
 }
 
-void promptToAdvanceToLocation(short keystroke) {
+static void promptToAdvanceToLocation(short keystroke) {
     char entryText[30], buf[max(30, DCOLS)];
     unsigned long destinationFrame;
     boolean enteredText;
@@ -1148,7 +1148,7 @@ boolean characterForbiddenInFilename(const char theChar) {
     }
 }
 
-void getDefaultFilePath(char *defaultPath, boolean gameOver) {
+static void getDefaultFilePath(char *defaultPath, boolean gameOver) {
     char seed[21];
 
     // 32-bit numbers are printed in full
@@ -1284,7 +1284,7 @@ void saveRecording(char *filePathWithoutSuffix) {
     deleteMessages();
 }
 
-void copyFile(char *fromFilePath, char *toFilePath, unsigned long fromFileLength) {
+static void copyFile(char *fromFilePath, char *toFilePath, unsigned long fromFileLength) {
     unsigned long m, n;
     unsigned char fileBuffer[INPUT_RECORD_BUFFER];
     FILE *fromFile, *toFile;
@@ -1394,7 +1394,7 @@ boolean loadSavedGame() {
 
 // the following functions are used to create human-readable descriptions of playback files for debugging purposes
 
-void describeKeystroke(unsigned char key, char *description) {
+static void describeKeystroke(unsigned char key, char *description) {
     short i;
     long c;
     const long keyList[50] = {UP_KEY, DOWN_KEY, LEFT_KEY, RIGHT_KEY, UP_ARROW, LEFT_ARROW,
@@ -1426,7 +1426,7 @@ void describeKeystroke(unsigned char key, char *description) {
     }
 }
 
-void appendModifierKeyDescription(char *description) {
+static void appendModifierKeyDescription(char *description) {
     unsigned char c = recallChar();
 
     if (c & Fl(1)) {
@@ -1438,7 +1438,7 @@ void appendModifierKeyDescription(char *description) {
 }
 
 // Deprecated! Only used to parse recordings, a debugging feature.
-boolean selectFile(char *prompt, char *defaultName, char *suffix) {
+static boolean selectFile(char *prompt, char *defaultName, char *suffix) {
     boolean retval;
     char newFilePath[BROGUE_FILENAME_MAX];
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2826,21 +2826,21 @@ extern "C" {
     boolean endswith(const char *str, const char *ending);
     void append(char *str, char *ending, int bufsize);
 
-    int rogueMain();
-    void printBrogueVersion();
+    int rogueMain(void);
+    void printBrogueVersion(void);
     void executeEvent(rogueEvent *theEvent);
     boolean fileExists(const char *pathname);
     boolean chooseFile(char *path, char *prompt, char *defaultName, char *suffix);
     boolean openFile(const char *path);
-    void initializeGameVariant();
+    void initializeGameVariant(void);
     void initializeRogue(uint64_t seed);
     void gameOver(char *killedBy, boolean useCustomPhrasing);
     void victory(boolean superVictory);
-    void setPlayerDisplayChar();
-    void initializeDynamicColors();
-    void enableEasyMode();
+    void setPlayerDisplayChar(void);
+    void initializeDynamicColors(void);
+    void enableEasyMode(void);
     boolean tryParseUint64(char *str, uint64_t *num);
-    uint64_t rand_64bits();
+    uint64_t rand_64bits(void);
     long rand_range(long lowerBound, long upperBound);
     uint64_t seedRandomGenerator(uint64_t seed);
     short randClumpedRange(short lowerBound, short upperBound, short clumpFactor);
@@ -2852,9 +2852,9 @@ extern "C" {
     fixpt fp_pow(fixpt base, int expn);
     fixpt fp_sqrt(fixpt val);
     short unflag(unsigned long flag);
-    void considerCautiousMode();
-    void refreshScreen();
-    void displayLevel();
+    void considerCautiousMode(void);
+    void refreshScreen(void);
+    void displayLevel(void);
     void storeColorComponents(char components[3], const color *theColor);
     boolean separateColors(color *fore, const color *back);
     void bakeColor(color *theColor);
@@ -2875,10 +2875,10 @@ extern "C" {
                           item *parentSpawnedItems[50],
                           creature *parentSpawnedMonsters[50]);
     void attachRooms(short **grid, const dungeonProfile *theDP, short attempts, short maxRoomCount);
-    void digDungeon();
-    void updateMapToShore();
+    void digDungeon(void);
+    void updateMapToShore(void);
     short levelIsDisconnectedWithBlockingMap(char blockingMap[DCOLS][DROWS], boolean countRegionSize);
-    void resetDFMessageEligibility();
+    void resetDFMessageEligibility(void);
     boolean fillSpawnMap(enum dungeonLayers layer,
                          enum tileType surfaceTileType,
                          char spawnMap[DCOLS][DROWS],
@@ -2889,7 +2889,7 @@ extern "C" {
     void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit);
     void restoreItem(item *theItem);
     void refreshWaypoint(short wpIndex);
-    void setUpWaypoints();
+    void setUpWaypoints(void);
     void zeroOutGrid(char grid[DCOLS][DROWS]);
     short oppositeDirection(short theDir);
 
@@ -2898,13 +2898,13 @@ extern "C" {
                   short backRed, short backGreen, short backBlue,
                   short foreRed, short foreGreen, short foreBlue);
     boolean pauseForMilliseconds(short milliseconds);
-    boolean isApplicationActive();
+    boolean isApplicationActive(void);
     void nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance);
     void notifyEvent(short eventId, int data1, int data2, const char *str1, const char *str2);
-    boolean takeScreenshot();
+    boolean takeScreenshot(void);
     enum graphicsModes setGraphicsMode(enum graphicsModes mode);
-    boolean controlKeyIsDown();
-    boolean shiftKeyIsDown();
+    boolean controlKeyIsDown(void);
+    boolean shiftKeyIsDown(void);
     short getHighScoresList(rogueHighScoresEntry returnList[HIGH_SCORES_COUNT]);
     boolean saveHighScore(rogueHighScoresEntry theEntry);
     fileEntry *listFiles(short *fileCount, char **dynamicMemoryBuffer);
@@ -2912,11 +2912,11 @@ extern "C" {
 
     char nextKeyPress(boolean textInput);
     void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst);
-    void printHelpScreen();
-    void printDiscoveriesScreen();
+    void printHelpScreen(void);
+    void printDiscoveriesScreen(void);
     void printHighScores(boolean hiliteMostRecent);
     void displayGrid(short **map);
-    void printSeed();
+    void printSeed(void);
     void printProgressBar(short x, short y, const char barLabel[COLS], long amtFilled, long amtMax, const color *fillColor, boolean dim);
     short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight);
     void describeHallucinatedItem(char *buf);
@@ -2940,8 +2940,8 @@ extern "C" {
     void flashMessage(char *message, short x, short y, int time, const color *fColor, const color *bColor);
     void flashTemporaryAlert(char *message, int time);
     void highlightScreenCell(short x, short y, const color *highlightColor, short strength);
-    void waitForAcknowledgment();
-    void waitForKeystrokeOrMouseClick();
+    void waitForAcknowledgment(void);
+    void waitForKeystrokeOrMouseClick(void);
     boolean confirm(char *prompt, boolean alsoDuringPlayback);
     void refreshDungeonCell(short x, short y);
     void applyColorMultiplier(color *baseColor, const color *multiplierColor);
@@ -2963,10 +2963,10 @@ extern "C" {
     void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *cellForeColor, const color *cellBackColor);
     void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *foreColor, const color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]);
     void plotForegroundChar(enum displayGlyph inputChar, short x, short y, const color *foreColor, boolean affectedByLighting);
-    void commitDraws();
-    void dumpLevelToScreen();
+    void commitDraws(void);
+    void dumpLevelToScreen(void);
     void hiliteCharGrid(char hiliteCharGrid[DCOLS][DROWS], const color *hiliteColor, short hiliteStrength);
-    void blackOutScreen();
+    void blackOutScreen(void);
     void colorOverDungeon(const color *color);
     void copyDisplayBuffer(cellDisplayBuffer toBuf[COLS][ROWS], cellDisplayBuffer fromBuf[COLS][ROWS]);
     void clearDisplayBuffer(cellDisplayBuffer dbuf[COLS][ROWS]);
@@ -2986,20 +2986,20 @@ extern "C" {
                                const char *promptSuffix,
                                short textEntryType,
                                boolean useDialogBox);
-    void displayChokeMap();
-    void displayLoops();
+    void displayChokeMap(void);
+    void displayLoops(void);
     boolean pauseBrogue(short milliseconds);
     boolean pauseAnimation(short milliseconds);
     void nextBrogueEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance, boolean realInputEvenInPlayback);
     void executeMouseClick(rogueEvent *theEvent);
     void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKey);
-    void initializeLevel();
+    void initializeLevel(void);
     void startLevel (short oldLevelNumber, short stairDirection);
-    void updateMinersLightRadius();
+    void updateMinersLightRadius(void);
     void freeCreature(creature *monst);
     void freeCreatureList(creatureList *list);
-    void removeDeadMonsters();
-    void freeEverything();
+    void removeDeadMonsters(void);
+    void freeEverything(void);
     boolean randomMatchingLocation(pos *loc, short dungeonType, short liquidType, short terrainType);
     enum dungeonLayers highestPriorityLayer(short x, short y, boolean skipGas);
     enum dungeonLayers layerWithTMFlag(short x, short y, unsigned long flag);
@@ -3012,8 +3012,8 @@ extern "C" {
     void useKeyAt(item *theItem, short x, short y);
     void playerRuns(short direction);
     void exposeCreatureToFire(creature *monst);
-    void updateFlavorText();
-    void updatePlayerUnderwaterness();
+    void updateFlavorText(void);
+    void updatePlayerUnderwaterness(void);
     boolean monsterShouldFall(creature *monst);
     void applyInstantTileEffectsToCreature(creature *monst);
     void vomit(creature *monst);
@@ -3039,56 +3039,56 @@ extern "C" {
                           unsigned long *tFlags, unsigned long *TMFlags, unsigned long *cellFlags,
                           const boolean limitToPlayerKnowledge);
     void populateCreatureCostMap(short **costMap, creature *monst);
-    enum directions adjacentFightingDir();
+    enum directions adjacentFightingDir(void);
     void getExploreMap(short **map, boolean headingToStairs);
     boolean explore(short frameDelay);
     short getPlayerPathOnMap(pos path[1000], short **map, pos origin);
     void reversePath(pos path[1000], short steps);
     void hilitePath(pos path[1000], short steps, boolean unhilite);
-    void clearCursorPath();
-    void hideCursor();
-    void showCursor();
-    void mainInputLoop();
+    void clearCursorPath(void);
+    void hideCursor(void);
+    void showCursor(void);
+    void mainInputLoop(void);
     boolean isDisturbed(short x, short y);
     void discover(short x, short y);
     short randValidDirectionFrom(creature *monst, short x, short y, boolean respectAvoidancePreferences);
     boolean exposeTileToElectricity(short x, short y);
     boolean exposeTileToFire(short x, short y, boolean alwaysIgnite);
     boolean cellCanHoldGas(short x, short y);
-    void monstersFall();
-    void updateEnvironment();
-    void updateAllySafetyMap();
-    void updateSafetyMap();
-    void updateSafeTerrainMap();
+    void monstersFall(void);
+    void updateEnvironment(void);
+    void updateAllySafetyMap(void);
+    void updateSafetyMap(void);
+    void updateSafeTerrainMap(void);
     short staffChargeDuration(const item *theItem);
     void rechargeItemsIncrementally(short multiplier);
     void extinguishFireOnCreature(creature *monst);
-    void autoRest();
-    void manualSearch();
+    void autoRest(void);
+    void manualSearch(void);
     boolean startFighting(enum directions dir, boolean tillDeath);
     void autoFight(boolean tillDeath);
-    void synchronizePlayerTimeState();
+    void synchronizePlayerTimeState(void);
     void playerRecoversFromAttacking(boolean anAttackHit);
-    void playerTurnEnded();
-    void resetScentTurnNumber();
+    void playerTurnEnded(void);
+    void resetScentTurnNumber(void);
     void displayMonsterFlashes(boolean flashingEnabled);
-    void clearMessageArchive();
+    void clearMessageArchive(void);
     void formatRecentMessages(char buf[][COLS*2], size_t height, short *linesFormatted, short *latestMessageLines);
-    void displayRecentMessages();
-    void displayMessageArchive();
+    void displayRecentMessages(void);
+    void displayMessageArchive(void);
     void temporaryMessage(const char *msg1, unsigned long flags);
     void messageWithColor(const char *msg, const color *theColor, unsigned long flags);
     void flavorMessage(const char *msg);
     void message(const char *msg, unsigned long flags);
-    void displayMoreSignWithoutWaitingForAcknowledgment();
-    void displayMoreSign();
+    void displayMoreSignWithoutWaitingForAcknowledgment(void);
+    void displayMoreSign(void);
     short encodeMessageColor(char *msg, short i, const color *theColor);
     short decodeMessageColor(const char *msg, short i, color *returnColor);
     const color *messageColorFromVictim(creature *monst);
     void upperCase(char *theChar);
-    void updateMessageDisplay();
-    void deleteMessages();
-    void confirmMessages();
+    void updateMessageDisplay(void);
+    void deleteMessages(void);
+    void confirmMessages(void);
     void stripShiftFromMovementKeystroke(signed long *keystroke);
 
     void storeMemories(const short x, const short y);
@@ -3109,7 +3109,7 @@ extern "C" {
     creature *spawnHorde(short hordeID, pos loc, unsigned long forbiddenFlags, unsigned long requiredFlags);
     void fadeInMonster(creature *monst);
 
-    creatureList createCreatureList();
+    creatureList createCreatureList(void);
     creatureIterator iterateCreatures(creatureList *list);
     boolean hasNextCreature(creatureIterator iter);
     creature *nextCreature(creatureIterator *iter);
@@ -3129,7 +3129,7 @@ extern "C" {
     unsigned long forbiddenFlagsForMonster(creatureType *monsterType);
     unsigned long avoidedFlagsForMonster(creatureType *monsterType);
     boolean monsterCanSubmergeNow(creature *monst);
-    void populateMonsters();
+    void populateMonsters(void);
     void updateMonsterState(creature *monst);
     void decrementMonsterStatus(creature *monst);
     boolean specifiedPathBetween(short x1, short y1, short x2, short y2,
@@ -3146,7 +3146,7 @@ extern "C" {
     boolean monsterFleesFrom(creature *monst, creature *defender);
     void monstersTurn(creature *monst);
     boolean getRandomMonsterSpawnLocation(short *x, short *y);
-    void spawnPeriodicHorde();
+    void spawnPeriodicHorde(void);
     void clearStatus(creature *monst);
     void moralAttack(creature *attacker, creature *defender);
     short runicWeaponChance(item *theItem, boolean customEnchantLevel, fixpt enchantLevel);
@@ -3232,10 +3232,10 @@ extern "C" {
                        boolean targetCanLeaveMap);
     void identifyItemKind(item *theItem);
     void autoIdentify(item *theItem);
-    short numberOfItemsInPack();
-    char nextAvailableInventoryCharacter();
+    short numberOfItemsInPack(void);
+    char nextAvailableInventoryCharacter(void);
     void checkForDisenchantment(item *theItem);
-    void updateFloorItems();
+    void updateFloorItems(void);
     void itemKindName(item *theItem, char *kindName);
     void itemRunicName(item *theItem, char *runicName);
     void itemName(item *theItem, char *root, boolean includeDetails, boolean includeArticle, const color *baseColor);
@@ -3249,15 +3249,15 @@ extern "C" {
                                     unsigned long requiredFlags, unsigned long forbiddenFlags,
                                     boolean displayErrors);
     void clearInventory(char keystroke);
-    item *initializeItem();
+    item *initializeItem(void);
     item *generateItem(unsigned short theCategory, short theKind);
     short chooseKind(const itemTable *theTable, short numKinds);
     item *makeItemInto(item *theItem, unsigned long itemCategory, short itemKind);
-    void updateEncumbrance();
-    short displayedArmorValue();
+    void updateEncumbrance(void);
+    short displayedArmorValue(void);
     short armorValueIfUnenchanted(item *theItem);
     void strengthCheck(item *theItem, boolean noisy);
-    void recalculateEquipmentBonuses();
+    void recalculateEquipmentBonuses(void);
     boolean equipItem(item *theItem, boolean force, item *unequipHint);
     void equip(item *theItem);
     item *keyInPackFor(pos loc);
@@ -3279,7 +3279,7 @@ extern "C" {
                                      boolean deterministic);
 
     // Grid operations
-    short **allocGrid();
+    short **allocGrid(void);
     void freeGrid(short **array);
     void copyGrid(short **to, short **from);
     void fillGrid(short **grid, short fillValue);
@@ -3314,18 +3314,18 @@ extern "C" {
     void makeMonsterDropItem(creature *monst);
     void throwCommand(item *theItem, boolean autoThrow);
     void relabel(item *theItem);
-    void swapLastEquipment();
+    void swapLastEquipment(void);
     void apply(item *theItem, boolean recordCommands);
     boolean itemCanBeCalled(item *theItem);
     void call(item *theItem);
-    short chooseVorpalEnemy();
+    short chooseVorpalEnemy(void);
     void describeMonsterClass(char *buf, const short classID, boolean conjunctionAnd);
     void identify(item *theItem);
     void updateIdentifiableItem(item *theItem);
-    void updateIdentifiableItems();
+    void updateIdentifiableItems(void);
     void readScroll(item *theItem);
-    void updateRingBonuses();
-    void updatePlayerRegenerationDelay();
+    void updateRingBonuses(void);
+    void updatePlayerRegenerationDelay(void);
     boolean removeItemFromChain(item *theItem, item *theChain);
     void addItemToChain(item *theItem, item *theChain);
     void drinkPotion(item *theItem);
@@ -3347,23 +3347,23 @@ extern "C" {
     boolean itemIsCarried(item *theItem);
     void itemDetails(char *buf, item *theItem);
     void deleteItem(item *theItem);
-    void shuffleFlavors();
+    void shuffleFlavors(void);
     unsigned long itemValue(item *theItem);
     short strLenWithoutEscapes(const char *str);
     void combatMessage(char *theMsg, const color *theColor);
-    void displayCombatText();
+    void displayCombatText(void);
     void flashMonster(creature *monst, const color *theColor, short strength);
 
     boolean paintLight(const lightSource *theLight, short x, short y, boolean isMinersLight, boolean maintainShadows);
     void backUpLighting(short lights[DCOLS][DROWS][3]);
     void restoreLighting(short lights[DCOLS][DROWS][3]);
-    void updateLighting();
-    boolean playerInDarkness();
+    void updateLighting(void);
+    boolean playerInDarkness(void);
     flare *newFlare(const lightSource *light, short x, short y, short changePerFrame, short limit);
     void createFlare(short x, short y, enum lightType lightIndex);
     void animateFlares(flare **flares, short count);
-    void deleteAllFlares();
-    void demoteVisibility();
+    void deleteAllFlares(void);
+    void demoteVisibility(void);
     void discoverCell(const short x, const short y);
     void updateVision(boolean refreshDisplay);
     void burnItem(item *theItem);
@@ -3371,34 +3371,34 @@ extern "C" {
     boolean circuitBreakersPreventActivation(short machineNumber);
     void promoteTile(short x, short y, enum dungeonLayers layer, boolean useFireDF);
     void autoPlayLevel(boolean fastForward);
-    void updateClairvoyance();
+    void updateClairvoyance(void);
     short scentDistance(short x1, short y1, short x2, short y2);
     short armorStealthAdjustment(item *theArmor);
-    short currentStealthRange();
+    short currentStealthRange(void);
 
-    void initRecording();
-    void flushBufferToFile();
-    void fillBufferFromFile();
+    void initRecording(void);
+    void flushBufferToFile(void);
+    void fillBufferFromFile(void);
     void recordEvent(rogueEvent *event);
     void recallEvent(rogueEvent *event);
-    void pausePlayback();
-    void displayAnnotation();
-    boolean loadSavedGame();
-    void switchToPlaying();
+    void pausePlayback(void);
+    void displayAnnotation(void);
+    boolean loadSavedGame(void);
+    void switchToPlaying(void);
     void recordKeystroke(int keystroke, boolean controlKey, boolean shiftKey);
-    void cancelKeystroke();
+    void cancelKeystroke(void);
     void recordKeystrokeSequence(unsigned char *commandSequence);
     void recordMouseClick(short x, short y, boolean controlKey, boolean shiftKey);
     void OOSCheck(unsigned long x, short numberOfBytes);
-    void RNGCheck();
+    void RNGCheck(void);
     boolean executePlaybackInput(rogueEvent *recordingInput);
     void getAvailableFilePath(char *filePath, const char *defaultPath, const char *suffix);
     boolean characterForbiddenInFilename(const char theChar);
-    void saveGame();
-    void saveGameNoPrompt();
+    void saveGame(void);
+    void saveGameNoPrompt(void);
     void saveRecording(char *filePath);
     void saveRecordingNoPrompt(char *filePath);
-    void parseFile();
+    void parseFile(void);
     void RNGLog(char *message);
 
     short wandDominate(creature *monst);
@@ -3433,13 +3433,13 @@ extern "C" {
     fixpt accuracyFraction(fixpt netEnchant);
     fixpt defenseFraction(fixpt netDefense);
 
-    void checkForDungeonErrors();
+    void checkForDungeonErrors(void);
 
     boolean dialogChooseFile(char *path, const char *suffix, const char *prompt);
-    void dialogCreateItemOrMonster();
-    int quitImmediately();
+    void dialogCreateItemOrMonster(void);
+    int quitImmediately(void);
     void dialogAlert(char *message);
-    void mainBrogueJunction();
+    void mainBrogueJunction(void);
     void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat);
 
     void initializeButton(brogueButton *button);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -112,7 +112,7 @@ boolean openFile(const char *path) {
     return retval;
 }
 
-void benchmark() {
+static void benchmark() {
     short i, j, k;
     const color sparklesauce = {10, 0, 20,  60, 40, 100, 30, true};
     enum displayGlyph theChar;
@@ -130,7 +130,7 @@ void benchmark() {
     printf("\n\nBenchmark took a total of %lu seconds.", ((unsigned long) time(NULL)) - initialTime);
 }
 
-void welcome() {
+static void welcome() {
     char buf[DCOLS*3], buf2[DCOLS*3];
     message("Hello and welcome, adventurer, to the Dungeons of Doom!", 0);
     strcpy(buf, "Retrieve the ");
@@ -504,7 +504,7 @@ void initializeRogue(uint64_t seed) {
 }
 
 // call this once per level to set all the dynamic colors as a function of depth
-void updateColors() {
+static void updateColors() {
     short i;
 
     for (i=0; i<NUMBER_DYNAMIC_COLORS; i++) {
@@ -876,7 +876,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     hideCursor();
 }
 
-void freeGlobalDynamicGrid(short ***grid) {
+static void freeGlobalDynamicGrid(short ***grid) {
     if (*grid) {
         freeGrid(*grid);
         *grid = NULL;

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -454,7 +454,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     }
 }
 
-void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
+static void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
     short itemCandidates, randItemIndex;
     short x = monst->loc.x, y = monst->loc.y, damage;
     char buf[COLS * 5], buf2[COLS * 3];
@@ -597,7 +597,7 @@ void updateClairvoyance() {
     }
 }
 
-void updateTelepathy() {
+static void updateTelepathy() {
     short i, j;
     boolean grid[DCOLS][DROWS];
 
@@ -646,7 +646,7 @@ short scentDistance(short x1, short y1, short x2, short y2) {
     }
 }
 
-void updateScent() {
+static void updateScent() {
     short i, j;
     char grid[DCOLS][DROWS];
 
@@ -801,7 +801,7 @@ void updateVision(boolean refreshDisplay) {
     }
 }
 
-void checkNutrition() {
+static void checkNutrition() {
     item *theItem;
     char buf[DCOLS*3], foodWarning[DCOLS*3];
 
@@ -862,7 +862,7 @@ void burnItem(item *theItem) {
     spawnDungeonFeature(x, y, &(dungeonFeatureCatalog[DF_ITEM_FIRE]), true, false);
 }
 
-void flashCreatureAlert(creature *monst, char msg[200], const color *foreColor, const color *backColor) {
+static void flashCreatureAlert(creature *monst, char msg[200], const color *foreColor, const color *backColor) {
     short x, y;
     if (monst->loc.y > DROWS / 2) {
         y = mapToWindowY(monst->loc.y - 2);
@@ -878,7 +878,7 @@ void flashCreatureAlert(creature *monst, char msg[200], const color *foreColor, 
     rogue.autoPlayingLevel = false;
 }
 
-void handleHealthAlerts() {
+static void handleHealthAlerts() {
     short i, currentPercent, previousPercent,
     thresholds[] = {5, 10, 25, 40},
     pThresholds[] = {100, 90, 50};
@@ -924,7 +924,7 @@ void handleHealthAlerts() {
     restoreRNG;
 }
 
-void addXPXPToAlly(short XPXP, creature *monst) {
+static void addXPXPToAlly(short XPXP, creature *monst) {
     char theMonsterName[100], buf[200];
     if (!(monst->info.flags & (MONST_INANIMATE | MONST_IMMOBILE))
         && !(monst->bookkeepingFlags & MB_TELEPATHICALLY_REVEALED)
@@ -949,7 +949,7 @@ void addXPXPToAlly(short XPXP, creature *monst) {
     }
 }
 
-void handleXPXP() {
+static void handleXPXP() {
     //char buf[DCOLS*2], theMonsterName[50];
 
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
@@ -971,7 +971,7 @@ void handleXPXP() {
     rogue.xpxpThisTurn = 0;
 }
 
-void playerFalls() {
+static void playerFalls() {
     short damage;
     short layer;
 
@@ -1218,7 +1218,7 @@ boolean exposeTileToFire(short x, short y, boolean alwaysIgnite) {
 }
 
 // Only the gas layer can be volumetric.
-void updateVolumetricMedia() {
+static void updateVolumetricMedia() {
     short i, j, newX, newY, numSpaces;
     unsigned long highestNeighborVolume;
     unsigned long sum;
@@ -1318,7 +1318,7 @@ void updateVolumetricMedia() {
     }
 }
 
-void updateYendorWardenTracking() {
+static void updateYendorWardenTracking() {
     short n;
 
     if (!rogue.yendorWarden) {
@@ -1578,7 +1578,7 @@ void updateAllySafetyMap() {
     freeGrid(monsterCostMap);
 }
 
-void resetDistanceCellInGrid(short **grid, short x, short y) {
+static void resetDistanceCellInGrid(short **grid, short x, short y) {
     enum directions dir;
     short newX, newY;
     for (dir = 0; dir < 4; dir++) {
@@ -1766,7 +1766,7 @@ void updateSafeTerrainMap() {
     freeGrid(costMap);
 }
 
-void processIncrementalAutoID() {
+static void processIncrementalAutoID() {
     item *theItem, *autoIdentifyItems[3] = {rogue.armor, rogue.ringLeft, rogue.ringRight};
     char buf[DCOLS*3], theItemName[DCOLS*3];
     short i;
@@ -1865,7 +1865,7 @@ void extinguishFireOnCreature(creature *monst) {
 }
 
 // n is the monster's depthLevel - 1.
-void monsterEntersLevel(creature *monst, short n) {
+static void monsterEntersLevel(creature *monst, short n) {
     char monstName[COLS], buf[COLS];
     boolean pit = false;
 
@@ -1940,7 +1940,7 @@ void monsterEntersLevel(creature *monst, short n) {
     }
 }
 
-void monstersApproachStairs() {
+static void monstersApproachStairs() {
     short n;
 
     for (n = rogue.depthLevel - 2; n <= rogue.depthLevel; n += 2) { // cycle through previous and next level
@@ -1963,7 +1963,7 @@ void monstersApproachStairs() {
     }
 }
 
-void decrementPlayerStatus() {
+static void decrementPlayerStatus() {
     // Handle hunger.
     if (!player.status[STATUS_PARALYZED]) {
         // No nutrition is expended while paralyzed.
@@ -2071,7 +2071,7 @@ void decrementPlayerStatus() {
     }
 }
 
-boolean dangerChanged(boolean danger[4]) {
+static boolean dangerChanged(boolean danger[4]) {
     for (enum directions dir = 0; dir < 4; dir++) {
         const pos newLoc = posNeighborInDirection(player.loc, dir);
         if (danger[dir] != monsterAvoids(&player, newLoc)) {

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -24,7 +24,7 @@
 #include "GlobalsBase.h"
 #include "Globals.h"
 
-void initializeCreateItemButton(brogueButton *button, char *text) {
+static void initializeCreateItemButton(brogueButton *button, char *text) {
     char buttonText[COLS * 3];
 
     initializeButton(button);

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -87,8 +87,8 @@ struct brogueConsole {
 };
 
 // defined in platform
-void loadKeymap();
-void dumpScores();
+void loadKeymap(void);
+void dumpScores(void);
 unsigned int glyphToUnicode(enum displayGlyph glyph);
 boolean isEnvironmentGlyph(enum displayGlyph glyph);
 void setHighScoresFilename(char *buffer, int bufferMaxLength);

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -228,10 +228,6 @@ void plotChar(enum displayGlyph inputChar,
     currentConsole.plotChar(inputChar, xLoc, yLoc, foreRed, foreGreen, foreBlue, backRed, backGreen, backBlue);
 }
 
-static void pausingTimerStartsNow() {
-
-}
-
 boolean shiftKeyIsDown() {
     return currentConsole.modifierHeld(0);
 }

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -228,7 +228,7 @@ void plotChar(enum displayGlyph inputChar,
     currentConsole.plotChar(inputChar, xLoc, yLoc, foreRed, foreGreen, foreBlue, backRed, backGreen, backBlue);
 }
 
-void pausingTimerStartsNow() {
+static void pausingTimerStartsNow() {
 
 }
 
@@ -270,7 +270,7 @@ enum graphicsModes setGraphicsMode(enum graphicsModes mode) {
 }
 
 // creates an empty high scores file
-void initScores() {
+static void initScores() {
     short i;
     FILE *scoresFile;
     char highScoresFilename[BROGUE_FILENAME_MAX];
@@ -286,7 +286,7 @@ void initScores() {
 
 // sorts the entries of the scoreBuffer global variable by score in descending order;
 // returns the sorted line number of the most recent entry
-short sortScoreBuffer() {
+static short sortScoreBuffer() {
     short i, j, highestUnsortedLine, mostRecentSortedLine = 0;
     long highestUnsortedScore, mostRecentDate;
     brogueScoreEntry sortedScoreBuffer[HIGH_SCORES_COUNT];
@@ -330,7 +330,7 @@ void setHighScoresFilename(char *buffer, int bufferMaxLength) {
 
 // loads the ([V]ariantName)HighScores.txt file into the scoreBuffer global variable
 // score file format is: score, tab, date in seconds, tab, description, newline.
-short loadScoreBuffer() {
+static short loadScoreBuffer() {
     short i;
     FILE *scoresFile;
     time_t rawtime;
@@ -405,7 +405,7 @@ void loadKeymap() {
 // thus overwriting whatever is already there.
 // The numerical version of the date is what gets saved; the "mm/dd/yy" version is ignored.
 // Does NOT do any sorting.
-void saveScoreBuffer() {
+static void saveScoreBuffer() {
     short i;
     FILE *scoresFile;
     char highScoresFilename[BROGUE_FILENAME_MAX];
@@ -485,7 +485,7 @@ struct filelist {
     int nextname, maxname;
 };
 
-struct filelist *newFilelist() {
+static struct filelist *newFilelist() {
     struct filelist *list = malloc(sizeof(*list));
 
     list->nfiles = 0;
@@ -499,7 +499,7 @@ struct filelist *newFilelist() {
     return list;
 }
 
-fileEntry *addfile(struct filelist *list, const char *name) {
+static fileEntry *addfile(struct filelist *list, const char *name) {
     int len = strlen(name);
     if (len + list->nextname >= list->maxname) {
         int newmax = (list->maxname + len) * 2;
@@ -537,13 +537,13 @@ fileEntry *addfile(struct filelist *list, const char *name) {
     return list->files + (list->nfiles - 1);
 }
 
-void freeFilelist(struct filelist *list) {
+static void freeFilelist(struct filelist *list) {
     //if (list->names != NULL) free(list->names);
     //if (list->files != NULL) free(list->files);
     free(list);
 }
 
-fileEntry *commitFilelist(struct filelist *list, char **namebuffer) {
+static fileEntry *commitFilelist(struct filelist *list, char **namebuffer) {
     int i;
     /*fileEntry *files = malloc(list->nfiles * sizeof(fileEntry) + list->nextname); // enough space for all the names and all the files
 

--- a/src/platform/tiles.h
+++ b/src/platform/tiles.h
@@ -3,12 +3,12 @@
 
 #include <SDL.h>
 
-void initTiles();
+void initTiles(void);
 void resizeWindow(int width, int height);
 void updateTile(int row, int column, short charIndex,
     short foreRed, short foreGreen, short foreBlue,
     short backRed, short backGreen, short backBlue);
-void updateScreen();
-SDL_Surface *captureScreen();
+void updateScreen(void);
+SDL_Surface *captureScreen(void);
 
 #endif

--- a/src/variants/GlobalsBrogue.c
+++ b/src/variants/GlobalsBrogue.c
@@ -38,6 +38,7 @@
 #include "Rogue.h"
 #include "GlobalsBase.h"
 #include "Globals.h"
+#include "GlobalsBrogue.h"
 
 #define AMULET_LEVEL            26          
 #define DEEPEST_LEVEL           40          

--- a/src/variants/GlobalsBrogue.h
+++ b/src/variants/GlobalsBrogue.h
@@ -21,7 +21,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-void initializeGameVariantBrogue();
+void initializeGameVariantBrogue(void);
 
 // Brogue version: what the user sees in the menu and title
 extern const char *brogueVersion;

--- a/src/variants/GlobalsRapidBrogue.c
+++ b/src/variants/GlobalsRapidBrogue.c
@@ -38,6 +38,7 @@
 #include "Rogue.h"
 #include "GlobalsBase.h"
 #include "Globals.h"
+#include "GlobalsRapidBrogue.h"
 
 #define AMULET_LEVEL            6          // how deep before the amulet appears
 #define DEEPEST_LEVEL           10         // how deep the universe goes

--- a/src/variants/GlobalsRapidBrogue.h
+++ b/src/variants/GlobalsRapidBrogue.h
@@ -21,7 +21,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-void initializeGameVariantRapidBrogue();
+void initializeGameVariantRapidBrogue(void);
 
 // Brogue version: what the user sees in the menu and title
 extern const char *rapidBrogueVersion;


### PR DESCRIPTION
This PR does several things:
* Adds `-Wmissing-prototypes` to warn about functions that don't have a prototype
* Adds `(void)` to prototypes of functions that take no arguments (otherwise the warning doesn't work properly)
* I ran a script to add "static" to functions that should have it, based on the compiler output (the script isn't included in this PR since I don't think it's useful after this, but I can add it if requested)
* Removes most static functions that the compiler now warns are unused (I kept some that seem to be for debugging)

This doesn't have any gameplay changes.