### PR TITLE
Don't round armor ratings to integers in the UI

### DIFF
--- a/changes/armor-rating-rounding.md
+++ b/changes/armor-rating-rounding.md
@@ -1,0 +1,1 @@
+Fix armor ratings like "3.5" being rounded to integers in the UI.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4405,8 +4405,8 @@ void highlightScreenCell(short x, short y, const color *highlightColor, short st
 
 // Like `armorValueIfUnenchanted` for the currently-equipped armor, but takes the penalty from
 // donning into account.
-static short estimatedArmorValue() {
-    short retVal = armorValueIfUnenchanted(rogue.armor) - player.status[STATUS_DONNING];
+static float estimatedArmorValue() {
+    float retVal = armorValueIfUnenchanted(rogue.armor) - player.status[STATUS_DONNING];
     return max(0, retVal);
 }
 
@@ -4680,13 +4680,13 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
 
                 if (!rogue.armor || rogue.armor->flags & ITEM_IDENTIFIED || rogue.playbackOmniscience) {
 
-                    sprintf(buf, "Str: %s%i%s  Armor: %i",
+                    sprintf(buf, "Str: %s%i%s  Armor: %g",
                             tempColorEscape,
                             rogue.strength - player.weaknessAmount,
                             grayColorEscape,
                             displayedArmorValue());
                 } else {
-                    sprintf(buf, "Str: %s%i%s  Armor: %i?",
+                    sprintf(buf, "Str: %s%i%s  Armor: %g?",
                             tempColorEscape,
                             rogue.strength - player.weaknessAmount,
                             grayColorEscape,

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2053,23 +2053,23 @@ void itemDetails(char *buf, item *theItem) {
                             abs((short) damageChange),
                             whiteColorEscape);
                 } else {
-                    new = 0;
+                    float armorValue;
 
                     if ((theItem->flags & ITEM_IDENTIFIED) || rogue.playbackOmniscience) {
-                        new = theItem->armor;
-                        new += 10 * netEnchant(theItem) / FP_FACTOR;
-                        new /= 10;
+                        armorValue = theItem->armor;
+                        armorValue += 10 * netEnchant(theItem) / FP_FACTOR;
+                        armorValue /= 10;
                     } else {
-                        new = armorValueIfUnenchanted(theItem);
+                        armorValue = armorValueIfUnenchanted(theItem);
                     }
 
-                    new = max(0, new);
+                    armorValue = max(0, armorValue);
 
-                    sprintf(buf2, "Wearing the %s%s will result in an armor rating of %s%i%s. ",
+                    sprintf(buf2, "Wearing the %s%s will result in an armor rating of %s%g%s. ",
                             theName,
                             ((theItem->flags & ITEM_IDENTIFIED) || rogue.playbackOmniscience) ? "" : ", assuming it has no hidden properties,",
-                            (new > displayedArmorValue() ? goodColorEscape : (new < displayedArmorValue() ? badColorEscape : whiteColorEscape)),
-                            new, whiteColorEscape);
+                            (armorValue > displayedArmorValue() ? goodColorEscape : (armorValue < displayedArmorValue() ? badColorEscape : whiteColorEscape)),
+                            armorValue, whiteColorEscape);
                 }
                 strcat(buf, buf2);
             }
@@ -3105,16 +3105,16 @@ void updateEncumbrance() {
 }
 
 // Estimates the armor value of the given item, assuming the item is unenchanted.
-short armorValueIfUnenchanted(item *theItem) {
-    short averageValue = (armorTable[theItem->kind].range.upperBound + armorTable[theItem->kind].range.lowerBound) / 2;
-    short strengthAdjusted = averageValue + 10 * strengthModifier(theItem) / FP_FACTOR;
+float armorValueIfUnenchanted(item *theItem) {
+    float averageValue = (armorTable[theItem->kind].range.upperBound + armorTable[theItem->kind].range.lowerBound) / 2;
+    float strengthAdjusted = averageValue + 10 * strengthModifier(theItem) / FP_FACTOR;
     return max(0, strengthAdjusted / 10);
 }
 
 // Calculates the armor value to display to the player (estimated if the item is unidentified).
-short displayedArmorValue() {
+float displayedArmorValue() {
     if (!rogue.armor || (rogue.armor->flags & ITEM_IDENTIFIED)) {
-        return player.info.defense / 10;
+        return ((float) player.info.defense) / 10;
     } else {
         return armorValueIfUnenchanted(rogue.armor);
     }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3254,8 +3254,8 @@ extern "C" {
     short chooseKind(const itemTable *theTable, short numKinds);
     item *makeItemInto(item *theItem, unsigned long itemCategory, short itemKind);
     void updateEncumbrance();
-    short displayedArmorValue();
-    short armorValueIfUnenchanted(item *theItem);
+    float displayedArmorValue();
+    float armorValueIfUnenchanted(item *theItem);
     void strengthCheck(item *theItem, boolean noisy);
     void recalculateEquipmentBonuses();
     boolean equipItem(item *theItem, boolean force, item *unequipHint);


### PR DESCRIPTION
Fixes #596

Edit: this still rounds armor ratings like 4.75 to "4.7"; is this worth fixing? My guess is no, since it doesn't make much difference and I'm not sure if the left sidebar is wide enough for an extra decimal place without putting the armor rating on a new line.

Also, it appears that an armor rating of e.g. 4.75 isn't better than 4.5; only increments of 0.5 seem to reduce enemy hit chance. More testing is probably needed to check whether this is always true.