### PR TITLE
Change the color of the message when you try to pick up an item when your inventory is full

### DIFF
--- a/changes/inventory-full-color.md
+++ b/changes/inventory-full-color.md
@@ -1,0 +1,1 @@
+Change the color of the message when you try to pick up an item when your inventory is full, so it stands out more.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -862,7 +862,7 @@ void pickUpItemAt(pos loc) {
         theItem->flags |= ITEM_PLAYER_AVOIDS; // explore shouldn't try to pick it up more than once.
         itemName(theItem, buf2, false, true, NULL); // include article
         sprintf(buf, "Your pack is too full to pick up %s.", buf2);
-        message(buf, 0);
+        messageWithColor(buf, &itemMessageColor, 0);
     }
 }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -862,7 +862,7 @@ void pickUpItemAt(pos loc) {
         theItem->flags |= ITEM_PLAYER_AVOIDS; // explore shouldn't try to pick it up more than once.
         itemName(theItem, buf2, false, true, NULL); // include article
         sprintf(buf, "Your pack is too full to pick up %s.", buf2);
-        messageWithColor(buf, &itemMessageColor, 0);
+        messageWithColor(buf, &badMessageColor, 0);
     }
 }
 


### PR DESCRIPTION
This makes the message stand out more, so it's harder to miss.