### PR TITLE
Fix bonuses for enchanted, unidentified rings

### DIFF
--- a/changes/issue-602.md
+++ b/changes/issue-602.md
@@ -1,0 +1,4 @@
+-
+  Fixed issue where unidentified rings could have higher bonuses than they would have once identified
+-
+  Fixed issue where unidentified positive rings give bonuses of `1 + timesEnchanted - 1` prior to identification, not `1 + timesEnchanted` as intended

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1775,7 +1775,7 @@ short effectiveRingEnchant(item *theItem) {
         return 0;
     }
     if (theItem->flags & ITEM_IDENTIFIED) {
-	    return theItem->enchant1;
+        return theItem->enchant1;
     } else {
         return min(theItem->enchant1, theItem->timesEnchanted + 1);
     }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1774,12 +1774,11 @@ short effectiveRingEnchant(item *theItem) {
     if (theItem->category != RING) {
         return 0;
     }
-    if (!(theItem->flags & ITEM_IDENTIFIED)
-        && theItem->enchant1 > 0) {
-
-        return theItem->timesEnchanted + 1; // Unidentified positive rings act as +1 until identified.
+    if (theItem->flags & ITEM_IDENTIFIED) {
+	    return theItem->enchant1;
+    } else {
+        return min(theItem->enchant1, theItem->timesEnchanted + 1);
     }
-    return theItem->enchant1;
 }
 
 short apparentRingBonus(const enum ringKind kind) {
@@ -6966,6 +6965,8 @@ void readScroll(item *theItem) {
             } while (theItem == NULL || !(theItem->category & (WEAPON | ARMOR | RING | STAFF | WAND | CHARM)));
             recordKeystroke(theItem->inventoryLetter, false, false);
             confirmMessages();
+
+            theItem->timesEnchanted += enchantMagnitude();
             switch (theItem->category) {
                 case WEAPON:
                     theItem->strengthRequired = max(0, theItem->strengthRequired - enchantMagnitude());
@@ -7005,7 +7006,6 @@ void readScroll(item *theItem) {
                 default:
                     break;
             }
-            theItem->timesEnchanted += enchantMagnitude();
             if ((theItem->category & (WEAPON | ARMOR | STAFF | RING | CHARM))
                 && theItem->enchant1 >= 16) {
 


### PR DESCRIPTION
Fixes issue #602.

- Unidentified rings can no longer have higher bonuses than they will have once identified
- Unidentified positive rings give `1 + timesEnchanted` prior to identification, not  `1 + timesEnchanted - 1` 

Test evidence:

```
Unidentified +1 ring of regen, 2 enchants

1774        if (theItem->category != RING) {
(gdb) n
1777        if (!(theItem->flags & ITEM_IDENTIFIED)
(gdb)
1782            return min(theItem->enchant1, theItem->timesEnchanted + 1);
(gdb) print theItem->enchant1
$1 = 3
(gdb) print theItem->timesEnchanted
$2 = 2
(gdb) n
updateRingBonuses () at src/brogue/Items.c:7776
7776                        break;
(gdb) print rogue.regenerationBonus
$3 = 3

Unidentified +3 ring of regen, 3 enchants

1774        if (theItem->category != RING) {
(gdb) n
1777        if (!(theItem->flags & ITEM_IDENTIFIED)
(gdb)
1782            return min(theItem->enchant1, theItem->timesEnchanted + 1);
(gdb) print theItem->enchant1
$4 = 6
(gdb) print theItem->timesEnchanted
$5 = 3
(gdb) n
updateRingBonuses () at src/brogue/Items.c:7776
7776                        break;
(gdb) print rogue.regenerationBonus
$6 = 4

Unidentified -3 ring of regen, 4 enchants

1774        if (theItem->category != RING) {
(gdb) n
1777        if (!(theItem->flags & ITEM_IDENTIFIED)
(gdb)
1782            return min(theItem->enchant1, theItem->timesEnchanted + 1);
(gdb) print theItem->enchant1
$1 = 1
(gdb) print theItem->timesEnchanted
$2 = 4
(gdb) n
updateRingBonuses () at src/brogue/Items.c:7776
7776                        break;
(gdb) print rogue.regenerationBonus
$3 = 1
(gdb) c
Continuing.

Identifying ring

Thread 1 "brogue" hit Breakpoint 1, effectiveRingEnchant (theItem=0x555556e51770) at src/brogue/Items.c:1774
1774        if (theItem->category != RING) {
(gdb) n
1777        if (!(theItem->flags & ITEM_IDENTIFIED)
(gdb) n
1784        return theItem->enchant1;
(gdb) print theItem->enchant1
$4 = 1
(gdb) n
updateRingBonuses () at src/brogue/Items.c:7776
7776                        break;
(gdb) print rogue.regenerationBonus
$5 = 1
(gdb)
```
