### PR TITLE
convert several helper macros into ordinary functions

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -27,12 +27,32 @@
 
 short topBlobMinX, topBlobMinY, blobWidth, blobHeight;
 
-#ifdef BROGUE_ASSERTS // otherwise handled as a macro in rogue.h
 boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask) {
-    assert(coordinatesAreInMap(x, y));
-    return ((flagMask) & terrainFlags((x), (y)) ? true : false);
+    brogueAssert(coordinatesAreInMap(x, y));
+    return ((flagMask) & terrainFlags(x, y) ? true : false);
 }
-#endif
+
+boolean cellHasTMFlag(short x, short y, unsigned long flagMask) {
+    return (flagMask & terrainMechFlags(x, y)) ? true : false;
+}
+
+boolean cellHasTerrainType(short x, short y, enum tileType terrain) {
+    return (
+        pmap[x][y].layers[DUNGEON] == terrain
+        || pmap[x][y].layers[LIQUID] == terrain
+        || pmap[x][y].layers[SURFACE] == terrain
+        || pmap[x][y].layers[GAS] == terrain
+    ) ? true : false;
+}
+
+static inline boolean cellIsPassableOrDoor(short x, short y) {
+    if (!cellHasTerrainFlag(x, y, T_PATHING_BLOCKER)) {
+        return true;
+    }
+    return (
+        (cellHasTMFlag(x, y, (TM_IS_SECRET | TM_PROMOTES_WITH_KEY | TM_CONNECTS_LEVEL)) && cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY))
+    );
+}
 
 static boolean checkLoopiness(short x, short y) {
     short newX, newY, dir, sdir;

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -575,6 +575,25 @@ const floorTileType tileCatalog[NUMBER_TILETYPES] = {
     {G_DOORWAY,    &mudWallForeColor,      &refuseBackColor,       25, 50, DF_EMBERS,      0,          0,              0,              NO_LIGHT,       (T_OBSTRUCTS_VISION | T_OBSTRUCTS_GAS | T_IS_FLAMMABLE), (TM_STAND_IN_TILE | TM_VISUALLY_DISTINCT), "hanging animal skins", "you push through the animal skins that hang across the threshold."},
 };
 
+unsigned long terrainFlags(short x, short y) {
+    return (
+        tileCatalog[pmap[x][y].layers[DUNGEON]].flags
+        | tileCatalog[pmap[x][y].layers[LIQUID]].flags 
+        | tileCatalog[pmap[x][y].layers[SURFACE]].flags 
+        | tileCatalog[pmap[x][y].layers[GAS]].flags
+    );
+}
+
+unsigned long terrainMechFlags(short x, short y) {
+    return (
+        tileCatalog[pmap[x][y].layers[DUNGEON]].mechFlags
+        | tileCatalog[pmap[x][y].layers[LIQUID]].mechFlags
+        | tileCatalog[pmap[x][y].layers[SURFACE]].mechFlags
+        | tileCatalog[pmap[x][y].layers[GAS]].mechFlags
+    );
+}
+
+
 // Features in the gas layer use the startprob as volume, ignore probdecr, and spawn in only a single point.
 // Intercepts and slopes are in units of 0.01.
 // This cannot be const, since messageDisplayed is set

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1210,35 +1210,17 @@ enum tileFlags {
 #define max(x, y)       (((x) > (y)) ? (x) : (y))
 #define clamp(x, low, hi)   (min(hi, max(x, low))) // pins x to the [y, z] interval
 
-#define terrainFlags(x, y)                  (tileCatalog[pmap[x][y].layers[DUNGEON]].flags \
-                                            | tileCatalog[pmap[x][y].layers[LIQUID]].flags \
-                                            | tileCatalog[pmap[x][y].layers[SURFACE]].flags \
-                                            | tileCatalog[pmap[x][y].layers[GAS]].flags)
+unsigned long terrainFlags(short x, short y);
+unsigned long terrainMechFlags(short x, short y);
 
-#define terrainMechFlags(x, y)              (tileCatalog[pmap[x][y].layers[DUNGEON]].mechFlags \
-                                            | tileCatalog[pmap[x][y].layers[LIQUID]].mechFlags \
-                                            | tileCatalog[pmap[x][y].layers[SURFACE]].mechFlags \
-                                            | tileCatalog[pmap[x][y].layers[GAS]].mechFlags)
-
-#ifdef BROGUE_ASSERTS
 boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask);
-#else
-#define cellHasTerrainFlag(x, y, flagMask)  ((flagMask) & terrainFlags((x), (y)) ? true : false)
-#endif
-#define cellHasTMFlag(x, y, flagMask)       ((flagMask) & terrainMechFlags((x), (y)) ? true : false)
+boolean cellHasTMFlag(short x, short y, unsigned long flagMask);
 
-#define cellHasTerrainType(x, y, terrain)   ((pmap[x][y].layers[DUNGEON] == (terrain) \
-                                            || pmap[x][y].layers[LIQUID] == (terrain) \
-                                            || pmap[x][y].layers[SURFACE] == (terrain) \
-                                            || pmap[x][y].layers[GAS] == (terrain)) ? true : false)
+boolean cellHasTerrainType(short x, short y, enum tileType terrain);
 
-#define cellHasKnownTerrainFlag(x, y, flagMask) ((flagMask) & pmap[(x)][(y)].rememberedTerrainFlags ? true : false)
-
-#define cellIsPassableOrDoor(x, y)          (!cellHasTerrainFlag((x), (y), T_PATHING_BLOCKER) \
-                                            || (cellHasTMFlag((x), (y), (TM_IS_SECRET | TM_PROMOTES_WITH_KEY | TM_CONNECTS_LEVEL)) \
-                                                && cellHasTerrainFlag((x), (y), T_OBSTRUCTS_PASSABILITY)))
-
-#define coordinatesAreInMap(x, y)           ((x) >= 0 && (x) < DCOLS    && (y) >= 0 && (y) < DROWS)
+static inline boolean coordinatesAreInMap(short x, short y) {
+    return (x >= 0 && x < DCOLS && y >= 0 && y < DROWS);
+}
 
 inline static boolean isPosInMap(pos p) {
     return p.x >= 0 && p.x < DCOLS && p.y >= 0 && p.y < DROWS;


### PR DESCRIPTION
This should be a no-behavior change. Here are a few of the macros defined in Brogue.h converted into regular functions.

Some of them are `inline static`s declared in the same spot as the old macro; others need to be moved into `.c` files because they rely on globals being in scope.