### PR TITLE
Adding the correct floor ordinal in the welcome message

### DIFF
--- a/changes/floor-ordinals.md
+++ b/changes/floor-ordinals.md
@@ -1,0 +1,1 @@
+Updating the welcome message to use the correct ordinal for the number of floors - supporting non '-th' numbers of floors

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -130,6 +130,26 @@ static void benchmark() {
     printf("\n\nBenchmark took a total of %lu seconds.", ((unsigned long) time(NULL)) - initialTime);
 }
 
+static const char *getOrdinalSuffix(int number) {
+    // Handle special cases for 11, 12, and 13
+    if (number == 11 || number == 12 || number == 13) {
+        return "th";
+    }
+
+    // Determine the suffix based on the last digit
+    int lastDigit = number % 10;
+    switch (lastDigit) {
+        case 1:
+            return "st";
+        case 2:
+            return "nd";
+        case 3:
+            return "rd";
+        default:
+            return "th";
+    }
+}
+
 static void welcome() {
     char buf[DCOLS*3], buf2[DCOLS*3];
     message("Hello and welcome, adventurer, to the Dungeons of Doom!", 0);
@@ -137,7 +157,7 @@ static void welcome() {
     encodeMessageColor(buf, strlen(buf), &itemMessageColor);
     strcat(buf, "Amulet of Yendor");
     encodeMessageColor(buf, strlen(buf), &white);
-    sprintf(buf2, " from the %ith floor and escape with it!", gameConst->amuletLevel);
+    sprintf(buf2, " from the %i%s floor and escape with it!", gameConst->amuletLevel, getOrdinalSuffix(gameConst->amuletLevel));
     strcat(buf, buf2);
     message(buf, 0);
     if (KEYBOARD_LABELS) {


### PR DESCRIPTION
The welcome message previously assumed the Amulet of Yendor was on a -th floor. But, for example, in bullet brogue, it's on the 3-rd floor. This change supports all floor numbers.