### PR TITLE
use 'pos' type to look up terrain flag values

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -498,7 +498,7 @@ static boolean forceWeaponHit(creature *defender, item *theItem) {
         .y = defender->loc.y + clamp(defender->loc.y - player.loc.y, -1, 1)
     };
     if (canDirectlySeeMonster(defender)
-        && !cellHasTerrainFlag(newLoc.x, newLoc.y, T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION)
+        && !cellHasTerrainFlag(newLoc, T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION)
         && !(pmapAt(newLoc)->flags & (HAS_MONSTER | HAS_PLAYER))) {
         sprintf(buf, "you launch %s backward with the force of your blow", monstName);
         buf[DCOLS] = '\0';
@@ -985,14 +985,14 @@ static void decrementWeaponAutoIDTimer() {
 void processStaggerHit(creature *attacker, creature *defender) {
     if ((defender->info.flags & (MONST_INVULNERABLE | MONST_IMMOBILE | MONST_INANIMATE))
         || (defender->bookkeepingFlags & MB_CAPTIVE)
-        || cellHasTerrainFlag(defender->loc.x, defender->loc.y, T_OBSTRUCTS_PASSABILITY)) {
+        || cellHasTerrainFlag(defender->loc, T_OBSTRUCTS_PASSABILITY)) {
 
         return;
     }
     short newX = clamp(defender->loc.x - attacker->loc.x, -1, 1) + defender->loc.x;
     short newY = clamp(defender->loc.y - attacker->loc.y, -1, 1) + defender->loc.y;
     if (coordinatesAreInMap(newX, newY)
-        && !cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY)
+        && !cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_PASSABILITY)
         && !(pmap[newX][newY].flags & (HAS_MONSTER | HAS_PLAYER))) {
 
         setMonsterLocation(defender, (pos){ newX, newY });
@@ -1387,7 +1387,7 @@ static boolean anyoneWantABite(creature *decedent) {
     if ((!(decedent->info.abilityFlags & LEARNABLE_ABILITIES)
          && !(decedent->info.flags & LEARNABLE_BEHAVIORS)
          && decedent->info.bolts[0] == BOLT_NONE)
-        || (cellHasTerrainFlag(decedent->loc.x, decedent->loc.y, T_PATHING_BLOCKER))
+        || (cellHasTerrainFlag(decedent->loc, T_PATHING_BLOCKER))
         || decedent->info.monsterID == MK_SPECTRAL_IMAGE
         || (decedent->info.flags & (MONST_INANIMATE | MONST_IMMOBILE))) {
 
@@ -1748,7 +1748,7 @@ void buildHitList(creature **hitList, const creature *attacker, creature *defend
                 defender = monsterAtLoc((pos){ newestX, newestY });
                 if (defender
                     && monsterWillAttackTarget(attacker, defender)
-                    && (!cellHasTerrainFlag(defender->loc.x, defender->loc.y, T_OBSTRUCTS_PASSABILITY) || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
+                    && (!cellHasTerrainFlag(defender->loc, T_OBSTRUCTS_PASSABILITY) || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
 
                     hitList[i] = defender;
                 }

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -147,7 +147,7 @@ static void pdsBatchInput(pdsMap *map, short **distanceMap, short **costMap, sho
             if (i == 0 || j == 0 || i == DCOLS - 1 || j == DROWS - 1) {
                 cost = PDS_OBSTRUCTION;
             } else if (costMap == NULL) {
-                if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY) && cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT)) cost = PDS_OBSTRUCTION;
+                if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY) && cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT)) cost = PDS_OBSTRUCTION;
                 else cost = PDS_FORBIDDEN;
             } else {
                 cost = costMap[i][j];
@@ -226,15 +226,15 @@ void calculateDistances(short **distanceMap,
                 cost = PDS_FORBIDDEN;
             } else if (canUseSecretDoors
                 && cellHasTMFlag(i, j, TM_IS_SECRET)
-                && cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)) {
+                && cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
+                && !(discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)) {
 
                 cost = 1;
-            } else if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
+            } else if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
                        || (traveler && traveler == &player && !(pmap[i][j].flags & (DISCOVERED | MAGIC_MAPPED)))) {
 
-                cost = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
-            } else if ((traveler && monsterAvoids(traveler, (pos){i, j})) || cellHasTerrainFlag(i, j, blockingTerrainFlags)) {
+                cost = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+            } else if ((traveler && monsterAvoids(traveler, (pos){i, j})) || cellHasTerrainFlag((pos){ i, j }, blockingTerrainFlags)) {
                 cost = PDS_FORBIDDEN;
             } else {
                 cost = 1;

--- a/src/brogue/Dijkstra.c
+++ b/src/brogue/Dijkstra.c
@@ -227,7 +227,7 @@ void calculateDistances(short **distanceMap,
             } else if (canUseSecretDoors
                 && cellHasTMFlag(i, j, TM_IS_SECRET)
                 && cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
-                && !(discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)) {
+                && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)) {
 
                 cost = 1;
             } else if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -575,21 +575,21 @@ const floorTileType tileCatalog[NUMBER_TILETYPES] = {
     {G_DOORWAY,    &mudWallForeColor,      &refuseBackColor,       25, 50, DF_EMBERS,      0,          0,              0,              NO_LIGHT,       (T_OBSTRUCTS_VISION | T_OBSTRUCTS_GAS | T_IS_FLAMMABLE), (TM_STAND_IN_TILE | TM_VISUALLY_DISTINCT), "hanging animal skins", "you push through the animal skins that hang across the threshold."},
 };
 
-unsigned long terrainFlags(short x, short y) {
+unsigned long terrainFlags(pos p) {
     return (
-        tileCatalog[pmap[x][y].layers[DUNGEON]].flags
-        | tileCatalog[pmap[x][y].layers[LIQUID]].flags 
-        | tileCatalog[pmap[x][y].layers[SURFACE]].flags 
-        | tileCatalog[pmap[x][y].layers[GAS]].flags
+        tileCatalog[pmapAt(p)->layers[DUNGEON]].flags
+        | tileCatalog[pmapAt(p)->layers[LIQUID]].flags 
+        | tileCatalog[pmapAt(p)->layers[SURFACE]].flags 
+        | tileCatalog[pmapAt(p)->layers[GAS]].flags
     );
 }
 
-unsigned long terrainMechFlags(short x, short y) {
+unsigned long terrainMechFlags(pos loc) {
     return (
-        tileCatalog[pmap[x][y].layers[DUNGEON]].mechFlags
-        | tileCatalog[pmap[x][y].layers[LIQUID]].mechFlags
-        | tileCatalog[pmap[x][y].layers[SURFACE]].mechFlags
-        | tileCatalog[pmap[x][y].layers[GAS]].mechFlags
+        tileCatalog[pmapAt(loc)->layers[DUNGEON]].mechFlags
+        | tileCatalog[pmapAt(loc)->layers[LIQUID]].mechFlags
+        | tileCatalog[pmapAt(loc)->layers[SURFACE]].mechFlags
+        | tileCatalog[pmapAt(loc)->layers[GAS]].mechFlags
     );
 }
 

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -161,7 +161,7 @@ void getTerrainGrid(short **grid, short value, unsigned long terrainFlags, unsig
     short i, j;
     for(i = 0; i < DCOLS; i++) {
         for(j = 0; j < DROWS; j++) {
-            if (grid[i][j] != value && cellHasTerrainFlag(i, j, terrainFlags) || (pmap[i][j].flags & mapFlags)) {
+            if (grid[i][j] != value && cellHasTerrainFlag((pos){ i, j }, terrainFlags) || (pmap[i][j].flags & mapFlags)) {
                 grid[i][j] = value;
             }
         }
@@ -295,7 +295,7 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
     short **grid, **costMap;
 
     // First check the given location to see if it works, as an optimization.
-    if (!cellHasTerrainFlag(x, y, blockingTerrainFlags | forbiddenTerrainFlags)
+    if (!cellHasTerrainFlag((pos){ x, y }, blockingTerrainFlags | forbiddenTerrainFlags)
         && !(pmap[x][y].flags & (blockingMapFlags | forbiddenMapFlags))
         && (hallwaysAllowed || passableArcCount(x, y) <= 1)) {
 

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -789,7 +789,7 @@ void mainInputLoop() {
                            || (distanceBetween(player.loc, rogue.cursorLoc) == 1 // includes diagonals
                                && (!diagonalBlocked(player.loc.x, player.loc.y, rogue.cursorLoc.x, rogue.cursorLoc.y, !rogue.playbackOmniscience)
                                    || ((pmapAt(rogue.cursorLoc)->flags & HAS_MONSTER) && (monsterAtLoc(rogue.cursorLoc)->info.flags & MONST_ATTACKABLE_THRU_WALLS)) // there's a turret there
-                                   || ((terrainFlags(rogue.cursorLoc.x, rogue.cursorLoc.y) & T_OBSTRUCTS_PASSABILITY) && (terrainMechFlags(rogue.cursorLoc.x, rogue.cursorLoc.y) & TM_PROMOTES_ON_PLAYER_ENTRY))))) { // there's a lever there
+                                   || ((terrainFlags(rogue.cursorLoc) & T_OBSTRUCTS_PASSABILITY) && (terrainMechFlags(rogue.cursorLoc) & TM_PROMOTES_ON_PLAYER_ENTRY))))) { // there's a lever there
                                                                                                                                                                                       // Clicking one space away will cause the player to try to move there directly irrespective of path.
                                    for (dir=0;
                                         dir < DIRECTION_COUNT && (player.loc.x + nbDirs[dir][0] != rogue.cursorLoc.x || player.loc.y + nbDirs[dir][1] != rogue.cursorLoc.y);
@@ -1280,8 +1280,8 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
                 cellBackColor = black;
                 gasAugmentColor = black;
             }
-        } else if ((pmap[x][y].flags & HAS_ITEM) && !cellHasTerrainFlag(x, y, T_OBSTRUCTS_ITEMS)
-                   && (playerCanSeeOrSense(x, y) || ((pmap[x][y].flags & DISCOVERED) && !cellHasTerrainFlag(x, y, T_MOVES_ITEMS)))) {
+        } else if ((pmap[x][y].flags & HAS_ITEM) && !cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_ITEMS)
+                   && (playerCanSeeOrSense(x, y) || ((pmap[x][y].flags & DISCOVERED) && !cellHasTerrainFlag((pos){ x, y }, T_MOVES_ITEMS)))) {
             needDistinctness = true;
             if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience) {
                 cellChar = itemChars[rand_range(0, 9)];
@@ -1449,7 +1449,7 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
     }
 //   DEBUG cellBackColor.red = max(0,((scentMap[x][y] - rogue.scentTurnNumber) * 2) + 100);
 //   DEBUG if (pmap[x][y].flags & KNOWN_TO_BE_TRAP_FREE) cellBackColor.red += 20;
-//   DEBUG if (cellHasTerrainFlag(x, y, T_IS_FLAMMABLE)) cellBackColor.red += 50;
+//   DEBUG if (cellHasTerrainFlag((pos){ x, y }, T_IS_FLAMMABLE)) cellBackColor.red += 50;
 
     if (pmap[x][y].flags & IS_IN_PATH) {
         if (cellHasTMFlag(x, y, TM_INVERT_WHEN_HIGHLIGHTED)) {
@@ -2083,7 +2083,7 @@ void colorFlash(const color *theColor, unsigned long reqTerrainFlags,
 
     for (i = max(x - maxRadius, 0); i <= min(x + maxRadius, DCOLS - 1); i++) {
         for (j = max(y - maxRadius, 0); j <= min(y + maxRadius, DROWS - 1); j++) {
-            if ((!reqTerrainFlags || cellHasTerrainFlag(reqTerrainFlags, i, j))
+            if ((!reqTerrainFlags || cellHasTerrainFlag((pos){ reqTerrainFlags, i }, j))
                 && (!reqTileFlags || (pmap[i][j].flags & reqTileFlags))
                 && (i-x) * (i-x) + (j-y) * (j-y) <= maxRadius * maxRadius) {
 
@@ -4285,7 +4285,7 @@ void displayGrid(short **map) {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (cellHasTerrainFlag(i, j, T_WAYPOINT_BLOCKER) || (map[i][j] == map[0][0]) || (i == player.loc.x && j == player.loc.y)) {
+            if (cellHasTerrainFlag((pos){ i, j }, T_WAYPOINT_BLOCKER) || (map[i][j] == map[0][0]) || (i == player.loc.x && j == player.loc.y)) {
                 continue;
             }
             if (map[i][j] > topRange) {
@@ -4302,7 +4302,7 @@ void displayGrid(short **map) {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY | T_LAVA_INSTA_DEATH)
+            if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY | T_LAVA_INSTA_DEATH)
                 || (map[i][j] == map[0][0])
                 || (i == player.loc.x && j == player.loc.y)) {
                 continue;

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1246,7 +1246,7 @@ static unsigned long successorTerrainFlags(enum tileType tile, enum subseqDFType
     }
 }
 
-unsigned long burnedterrainFlagsLoc(pos loc) {
+unsigned long burnedTerrainFlagsAtLoc(pos loc) {
     short layer;
     unsigned long flags = 0;
 
@@ -1262,7 +1262,7 @@ unsigned long burnedterrainFlagsLoc(pos loc) {
     return flags;
 }
 
-unsigned long discoveredterrainFlagsLoc(pos loc) {
+unsigned long discoveredTerrainFlagsAtLoc(pos loc) {
     short layer;
     unsigned long flags = 0;
 
@@ -1304,7 +1304,7 @@ boolean monsterAvoids(creature *monst, pos p) {
     if (tFlags & T_OBSTRUCTS_PASSABILITY) {
         if (monst != &player
             && cellHasTMFlag(p.x, p.y, TM_IS_SECRET)
-            && !(discoveredterrainFlagsLoc(p) & avoidedFlagsForMonster(&(monst->info)))) {
+            && !(discoveredTerrainFlagsAtLoc(p) & avoidedFlagsForMonster(&(monst->info)))) {
             // This is so monsters can use secret doors but won't embed themselves in secret levers.
             return false;
         }
@@ -1408,7 +1408,7 @@ boolean monsterAvoids(creature *monst, pos p) {
     // burning monsters avoid explosive terrain and steam-emitting terrain
     if (monst != &player
         && monst->status[STATUS_BURNING]
-        && (burnedterrainFlagsLoc(p) & (T_CAUSES_EXPLOSIVE_DAMAGE | T_CAUSES_DAMAGE | T_AUTO_DESCENT) & ~terrainImmunities)) {
+        && (burnedTerrainFlagsAtLoc(p) & (T_CAUSES_EXPLOSIVE_DAMAGE | T_CAUSES_DAMAGE | T_AUTO_DESCENT) & ~terrainImmunities)) {
 
         return true;
     }
@@ -2515,7 +2515,7 @@ static boolean specificallyValidBoltTarget(creature *caster, creature *target, e
         return false;
     }
     if ((boltCatalog[theBoltType].flags & BF_FIERY)
-        && burnedterrainFlagsLoc(caster->loc) & avoidedFlagsForMonster(&(caster->info))) {
+        && burnedTerrainFlagsAtLoc(caster->loc) & avoidedFlagsForMonster(&(caster->info))) {
         // Don't shoot fireballs if you're standing on a tile that could combust into something that harms you.
         return false;
     }
@@ -3549,14 +3549,14 @@ boolean canPass(creature *mover, creature *blocker) {
 
 boolean isPassableOrSecretDoor(pos loc) {
     return (!cellHasTerrainFlag(loc, T_OBSTRUCTS_PASSABILITY)
-            || (cellHasTMFlag(loc.x, loc.y, TM_IS_SECRET) && !(discoveredterrainFlagsLoc(loc) & T_OBSTRUCTS_PASSABILITY)));
+            || (cellHasTMFlag(loc.x, loc.y, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc(loc) & T_OBSTRUCTS_PASSABILITY)));
 }
 
 boolean knownToPlayerAsPassableOrSecretDoor(pos loc) {
     unsigned long tFlags, TMFlags;
     getLocationFlags(loc.x, loc.y, &tFlags, &TMFlags, NULL, true);
     return (!(tFlags & T_OBSTRUCTS_PASSABILITY)
-            || ((TMFlags & TM_IS_SECRET) && !(discoveredterrainFlagsLoc(loc) & T_OBSTRUCTS_PASSABILITY)));
+            || ((TMFlags & TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc(loc) & T_OBSTRUCTS_PASSABILITY)));
 }
 
 void setMonsterLocation(creature *monst, pos newLoc) {

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -179,7 +179,7 @@ boolean monsterRevealed(creature *monst) {
 boolean monsterHiddenBySubmersion(const creature *monst, const creature *observer) {
     if (monst->bookkeepingFlags & MB_SUBMERGED) {
         if (observer
-            && (terrainFlags(observer->loc.x, observer->loc.y) & T_IS_DEEP_WATER)
+            && (terrainFlags(observer->loc) & T_IS_DEEP_WATER)
             && !observer->status[STATUS_LEVITATING]) {
             // observer is in deep water, so target is not hidden by water
             return false;
@@ -274,7 +274,7 @@ boolean monsterIsInClass(const creature *monst, const short monsterClass) {
 // Don't attack a monster embedded in obstruction crystal.
 // Etc.
 static boolean attackWouldBeFutile(const creature *attacker, const creature *defender) {
-    if (cellHasTerrainFlag(defender->loc.x, defender->loc.y, T_OBSTRUCTS_PASSABILITY)
+    if (cellHasTerrainFlag(defender->loc, T_OBSTRUCTS_PASSABILITY)
         && !(defender->info.flags & MONST_ATTACKABLE_THRU_WALLS)) {
         return true;
     }
@@ -362,12 +362,12 @@ boolean monstersAreEnemies(const creature *monst1, const creature *monst2) {
     if (((monst1->info.flags & MONST_RESTRICTED_TO_LIQUID)
          && !(monst2->info.flags & MONST_IMMUNE_TO_WATER)
          && !(monst2->status[STATUS_LEVITATING])
-         && cellHasTerrainFlag(monst2->loc.x, monst2->loc.y, T_IS_DEEP_WATER))
+         && cellHasTerrainFlag(monst2->loc, T_IS_DEEP_WATER))
 
         || ((monst2->info.flags & MONST_RESTRICTED_TO_LIQUID)
             && !(monst1->info.flags & MONST_IMMUNE_TO_WATER)
             && !(monst1->status[STATUS_LEVITATING])
-            && cellHasTerrainFlag(monst1->loc.x, monst1->loc.y, T_IS_DEEP_WATER))) {
+            && cellHasTerrainFlag(monst1->loc, T_IS_DEEP_WATER))) {
 
             return true;
         }
@@ -660,11 +660,11 @@ unsigned long avoidedFlagsForMonster(creatureType *monsterType) {
 boolean monsterCanSubmergeNow(creature *monst) {
     return ((monst->info.flags & MONST_SUBMERGES)
             && cellHasTMFlag(monst->loc.x, monst->loc.y, TM_ALLOWS_SUBMERGING)
-            && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY)
+            && !cellHasTerrainFlag(monst->loc, T_OBSTRUCTS_PASSABILITY)
             && !(monst->bookkeepingFlags & (MB_SEIZING | MB_SEIZED | MB_CAPTIVE))
             && ((monst->info.flags & (MONST_IMMUNE_TO_FIRE | MONST_INVULNERABLE))
                 || monst->status[STATUS_IMMUNE_TO_FIRE]
-                || !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_LAVA_INSTA_DEATH)));
+                || !cellHasTerrainFlag(monst->loc, T_LAVA_INSTA_DEATH)));
 }
 
 // Returns true if at least one minion spawned.
@@ -778,7 +778,7 @@ creature *spawnHorde(short hordeID, pos loc, unsigned long forbiddenFlags, unsig
                 return NULL;
             }
             if (isPosInMap(loc)) {
-                if (cellHasTerrainFlag(loc.x, loc.y, T_PATHING_BLOCKER)
+                if (cellHasTerrainFlag(loc, T_PATHING_BLOCKER)
                     && (!hordeCatalog[hordeID].spawnsIn || !cellHasTerrainType(loc.x, loc.y, hordeCatalog[hordeID].spawnsIn))) {
 
                     // don't spawn a horde in special terrain unless it's meant to spawn there
@@ -1246,7 +1246,7 @@ static unsigned long successorTerrainFlags(enum tileType tile, enum subseqDFType
     }
 }
 
-unsigned long burnedTerrainFlagsAtLoc(pos loc) {
+unsigned long burnedterrainFlagsLoc(pos loc) {
     short layer;
     unsigned long flags = 0;
 
@@ -1262,7 +1262,7 @@ unsigned long burnedTerrainFlagsAtLoc(pos loc) {
     return flags;
 }
 
-unsigned long discoveredTerrainFlagsAtLoc(pos loc) {
+unsigned long discoveredterrainFlagsLoc(pos loc) {
     short layer;
     unsigned long flags = 0;
 
@@ -1304,7 +1304,7 @@ boolean monsterAvoids(creature *monst, pos p) {
     if (tFlags & T_OBSTRUCTS_PASSABILITY) {
         if (monst != &player
             && cellHasTMFlag(p.x, p.y, TM_IS_SECRET)
-            && !(discoveredTerrainFlagsAtLoc(p) & avoidedFlagsForMonster(&(monst->info)))) {
+            && !(discoveredterrainFlagsLoc(p) & avoidedFlagsForMonster(&(monst->info)))) {
             // This is so monsters can use secret doors but won't embed themselves in secret levers.
             return false;
         }
@@ -1391,7 +1391,7 @@ boolean monsterAvoids(creature *monst, pos p) {
         && !(monst->info.flags & MONST_INVULNERABLE)
         && (tFlags & T_SPONTANEOUSLY_IGNITES)
         && !(cFlags & (HAS_MONSTER | HAS_PLAYER))
-        && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_IS_FIRE | T_SPONTANEOUSLY_IGNITES)
+        && !cellHasTerrainFlag(monst->loc, T_IS_FIRE | T_SPONTANEOUSLY_IGNITES)
         && (monst == &player || (monst->creatureState != MONSTER_TRACKING_SCENT && monst->creatureState != MONSTER_FLEEING))) {
         return true;
     }
@@ -1408,14 +1408,14 @@ boolean monsterAvoids(creature *monst, pos p) {
     // burning monsters avoid explosive terrain and steam-emitting terrain
     if (monst != &player
         && monst->status[STATUS_BURNING]
-        && (burnedTerrainFlagsAtLoc(p) & (T_CAUSES_EXPLOSIVE_DAMAGE | T_CAUSES_DAMAGE | T_AUTO_DESCENT) & ~terrainImmunities)) {
+        && (burnedterrainFlagsLoc(p) & (T_CAUSES_EXPLOSIVE_DAMAGE | T_CAUSES_DAMAGE | T_AUTO_DESCENT) & ~terrainImmunities)) {
 
         return true;
     }
 
     // fire
     if ((tFlags & T_IS_FIRE & ~terrainImmunities)
-        && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_IS_FIRE)
+        && !cellHasTerrainFlag(monst->loc, T_IS_FIRE)
         && !(cFlags & (HAS_MONSTER | HAS_PLAYER))
         && (monst != &player || rogue.mapToShore[p.x][p.y] >= player.status[STATUS_IMMUNE_TO_FIRE])) {
         return true;
@@ -1423,7 +1423,7 @@ boolean monsterAvoids(creature *monst, pos p) {
 
     // non-fire harmful terrain
     if ((tFlags & T_HARMFUL_TERRAIN & ~T_IS_FIRE & ~terrainImmunities)
-        && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, (T_HARMFUL_TERRAIN & ~T_IS_FIRE))) {
+        && !cellHasTerrainFlag(monst->loc, (T_HARMFUL_TERRAIN & ~T_IS_FIRE))) {
         return true;
     }
 
@@ -1453,13 +1453,13 @@ boolean monsterAvoids(creature *monst, pos p) {
     // deep water
     if ((tFlags & T_IS_DEEP_WATER & ~terrainImmunities)
         && (!(tFlags & T_ENTANGLES) || !(monst->info.flags & MONST_IMMUNE_TO_WEBS))
-        && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_IS_DEEP_WATER)) {
+        && !cellHasTerrainFlag(monst->loc, T_IS_DEEP_WATER)) {
         return true; // avoid only if not already in it
     }
 
     // poisonous lichen
     if ((tFlags & T_CAUSES_POISON & ~terrainImmunities)
-        && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_CAUSES_POISON)
+        && !cellHasTerrainFlag(monst->loc, T_CAUSES_POISON)
         && (monst == &player || monst->creatureState != MONSTER_TRACKING_SCENT || monst->currentHP < 10)) {
         return true;
     }
@@ -1471,7 +1471,7 @@ boolean monsterAvoids(creature *monst, pos p) {
         && (monst->bookkeepingFlags & (MB_FOLLOWER | MB_LEADER))
         && passableArcCount(p.x, p.y) >= 2
         && passableArcCount(monst->loc.x, monst->loc.y) < 2
-        && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, (T_HARMFUL_TERRAIN & ~terrainImmunities))) {
+        && !cellHasTerrainFlag(monst->loc, (T_HARMFUL_TERRAIN & ~terrainImmunities))) {
         return true;
     }
 
@@ -1888,7 +1888,7 @@ void decrementMonsterStatus(creature *monst) {
                 }
                 break;
             case STATUS_STUCK:
-                if (monst->status[i] && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_ENTANGLES)) {
+                if (monst->status[i] && !cellHasTerrainFlag(monst->loc, T_ENTANGLES)) {
                     monst->status[i] = 0;
                 }
                 break;
@@ -1987,7 +1987,7 @@ boolean specifiedPathBetween(short x1, short y1, short x2, short y2,
     for (int i=0; i<n; i++) {
         short x = coords[i].x;
         short y = coords[i].y;
-        if (cellHasTerrainFlag(x, y, blockingTerrain) || (pmap[x][y].flags & blockingFlags)) {
+        if (cellHasTerrainFlag((pos){ x, y }, blockingTerrain) || (pmap[x][y].flags & blockingFlags)) {
             return false;
         }
         if (x == x2 && y == y2) {
@@ -2308,8 +2308,8 @@ boolean monsterBlinkToPreferenceMap(creature *monst, short **preferenceMap, bool
 
             if ((abs(impact.x - origin.x) > 1 || abs(impact.y - origin.y) > 1)
                 // Note: these are deliberately backwards:
-                || (cellHasTerrainFlag(impact.x, origin.y, T_OBSTRUCTS_PASSABILITY))
-                || (cellHasTerrainFlag(origin.x, impact.y, T_OBSTRUCTS_PASSABILITY))) {
+                || (cellHasTerrainFlag((pos){ impact.x, origin.y }, T_OBSTRUCTS_PASSABILITY))
+                || (cellHasTerrainFlag((pos){ origin.x, impact.y }, T_OBSTRUCTS_PASSABILITY))) {
                 gotOne = true;
             } else {
                 gotOne = false;
@@ -2515,7 +2515,7 @@ static boolean specificallyValidBoltTarget(creature *caster, creature *target, e
         return false;
     }
     if ((boltCatalog[theBoltType].flags & BF_FIERY)
-        && burnedTerrainFlagsAtLoc(caster->loc) & avoidedFlagsForMonster(&(caster->info))) {
+        && burnedterrainFlagsLoc(caster->loc) & avoidedFlagsForMonster(&(caster->info))) {
         // Don't shoot fireballs if you're standing on a tile that could combust into something that harms you.
         return false;
     }
@@ -2528,7 +2528,7 @@ static boolean specificallyValidBoltTarget(creature *caster, creature *target, e
             }
             break;
         case BE_ATTACK:
-            if (cellHasTerrainFlag(target->loc.x, target->loc.y, T_OBSTRUCTS_PASSABILITY)
+            if (cellHasTerrainFlag(target->loc, T_OBSTRUCTS_PASSABILITY)
                 && !(target->info.flags & MONST_ATTACKABLE_THRU_WALLS)) {
                 // Don't shoot an arrow at an embedded creature.
                 return false;
@@ -2578,7 +2578,7 @@ static boolean specificallyValidBoltTarget(creature *caster, creature *target, e
                     return true;
                 }
                 if ((target->status[STATUS_IMMUNE_TO_FIRE] || target->status[STATUS_LEVITATING])
-                    && cellHasTerrainFlag(target->loc.x, target->loc.y, (T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT))) {
+                    && cellHasTerrainFlag(target->loc, (T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT))) {
                     // Drop the target into lava or a chasm if opportunity knocks.
                     return true;
                 }
@@ -2717,7 +2717,7 @@ static boolean isLocalScentMaximum(pos loc) {
         pos newLoc = posNeighborInDirection(loc, dir);
         if (isPosInMap(newLoc)
             && (scentMap[newLoc.x][newLoc.y] > baselineScent)
-            && !cellHasTerrainFlag(newLoc.x, newLoc.y, T_OBSTRUCTS_PASSABILITY)
+            && !cellHasTerrainFlag(newLoc, T_OBSTRUCTS_PASSABILITY)
             && !diagonalBlocked(loc.x, loc.y, newLoc.x, newLoc.y, false)) {
 
             return false;
@@ -2746,7 +2746,7 @@ static enum directions scentDirection(creature *monst) {
             if (coordinatesAreInMap(newX, newY)
                 && (scentMap[newX][newY] > bestNearbyScent)
                 && (!(pmap[newX][newY].flags & HAS_MONSTER) || (otherMonst && canPass(monst, otherMonst)))
-                && !cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY)
+                && !cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_PASSABILITY)
                 && !diagonalBlocked(x, y, newX, newY, false)
                 && !monsterAvoids(monst, (pos){newX, newY})) {
 
@@ -2941,9 +2941,9 @@ static void moveAlly(creature *monst) {
     }
 
     // If we're standing in harmful terrain and there is a way to escape it, spend this turn escaping it.
-    if (cellHasTerrainFlag(x, y, (T_HARMFUL_TERRAIN & ~(T_IS_FIRE | T_CAUSES_DAMAGE | T_CAUSES_PARALYSIS | T_CAUSES_CONFUSION)))
-        || (cellHasTerrainFlag(x, y, T_IS_FIRE) && !monst->status[STATUS_IMMUNE_TO_FIRE])
-        || (cellHasTerrainFlag(x, y, T_CAUSES_DAMAGE | T_CAUSES_PARALYSIS | T_CAUSES_CONFUSION) && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE)))) {
+    if (cellHasTerrainFlag((pos){ x, y }, (T_HARMFUL_TERRAIN & ~(T_IS_FIRE | T_CAUSES_DAMAGE | T_CAUSES_PARALYSIS | T_CAUSES_CONFUSION)))
+        || (cellHasTerrainFlag((pos){ x, y }, T_IS_FIRE) && !monst->status[STATUS_IMMUNE_TO_FIRE])
+        || (cellHasTerrainFlag((pos){ x, y }, T_CAUSES_DAMAGE | T_CAUSES_PARALYSIS | T_CAUSES_CONFUSION) && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE)))) {
 
         if (!rogue.updatedMapToSafeTerrainThisTurn) {
             updateSafeTerrainMap();
@@ -2975,7 +2975,7 @@ static void moveAlly(creature *monst) {
             && monsterWillAttackTarget(monst, target)
             && distanceBetween((pos){x, y}, target->loc) < shortestDistance
             && traversiblePathBetween(monst, target->loc.x, target->loc.y)
-            && (!cellHasTerrainFlag(target->loc.x, target->loc.y, T_OBSTRUCTS_PASSABILITY) || (target->info.flags & MONST_ATTACKABLE_THRU_WALLS))
+            && (!cellHasTerrainFlag(target->loc, T_OBSTRUCTS_PASSABILITY) || (target->info.flags & MONST_ATTACKABLE_THRU_WALLS))
             && (!target->status[STATUS_INVISIBLE] || rand_percent(33))) {
 
             shortestDistance = distanceBetween((pos){x, y}, target->loc);
@@ -3051,8 +3051,8 @@ static void moveAlly(creature *monst) {
 
             for (i=0; i<DCOLS; i++) {
                 for (j=0; j<DROWS; j++) {
-                    if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)) {
-                        costMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+                    if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)) {
+                        costMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                         enemyMap[i][j] = 0; // safeguard against OOS
                     } else if (monsterAvoids(monst, (pos){i, j})) {
                         costMap[i][j] = PDS_FORBIDDEN;
@@ -3405,8 +3405,8 @@ void monstersTurn(creature *monst) {
                || ((monst->info.flags & MONST_RESTRICTED_TO_LIQUID) && !cellHasTMFlag(player.loc.x, player.loc.y, TM_ALLOWS_SUBMERGING))) {
 
         // if we're standing in harmful terrain and there is a way to escape it, spend this turn escaping it.
-        if (cellHasTerrainFlag(x, y, (T_HARMFUL_TERRAIN & ~T_IS_FIRE))
-            || (cellHasTerrainFlag(x, y, T_IS_FIRE) && !monst->status[STATUS_IMMUNE_TO_FIRE] && !(monst->info.flags & MONST_INVULNERABLE))) {
+        if (cellHasTerrainFlag((pos){ x, y }, (T_HARMFUL_TERRAIN & ~T_IS_FIRE))
+            || (cellHasTerrainFlag((pos){ x, y }, T_IS_FIRE) && !monst->status[STATUS_IMMUNE_TO_FIRE] && !(monst->info.flags & MONST_INVULNERABLE))) {
             if (!rogue.updatedMapToSafeTerrainThisTurn) {
                 updateSafeTerrainMap();
             }
@@ -3548,15 +3548,15 @@ boolean canPass(creature *mover, creature *blocker) {
 }
 
 boolean isPassableOrSecretDoor(pos loc) {
-    return (!cellHasTerrainFlag(loc.x, loc.y, T_OBSTRUCTS_PASSABILITY)
-            || (cellHasTMFlag(loc.x, loc.y, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc(loc) & T_OBSTRUCTS_PASSABILITY)));
+    return (!cellHasTerrainFlag(loc, T_OBSTRUCTS_PASSABILITY)
+            || (cellHasTMFlag(loc.x, loc.y, TM_IS_SECRET) && !(discoveredterrainFlagsLoc(loc) & T_OBSTRUCTS_PASSABILITY)));
 }
 
 boolean knownToPlayerAsPassableOrSecretDoor(pos loc) {
     unsigned long tFlags, TMFlags;
     getLocationFlags(loc.x, loc.y, &tFlags, &TMFlags, NULL, true);
     return (!(tFlags & T_OBSTRUCTS_PASSABILITY)
-            || ((TMFlags & TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc(loc) & T_OBSTRUCTS_PASSABILITY)));
+            || ((TMFlags & TM_IS_SECRET) && !(discoveredterrainFlagsLoc(loc) & T_OBSTRUCTS_PASSABILITY)));
 }
 
 void setMonsterLocation(creature *monst, pos newLoc) {
@@ -3571,7 +3571,7 @@ void setMonsterLocation(creature *monst, pos newLoc) {
     }
     if (playerCanSee(newLoc.x, newLoc.y)
         && cellHasTMFlag(newLoc.x, newLoc.y, TM_IS_SECRET)
-        && cellHasTerrainFlag(newLoc.x, newLoc.y, T_OBSTRUCTS_PASSABILITY)) {
+        && cellHasTerrainFlag(newLoc, T_OBSTRUCTS_PASSABILITY)) {
 
         discover(newLoc.x, newLoc.y); // if you see a monster use a secret door, you discover it
     }
@@ -3644,7 +3644,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
 
     // Caught in spiderweb?
     if (monst->status[STATUS_STUCK] && !(pmap[newX][newY].flags & (HAS_PLAYER | HAS_MONSTER))
-        && cellHasTerrainFlag(x, y, T_ENTANGLES) && !(monst->info.flags & MONST_IMMUNE_TO_WEBS)) {
+        && cellHasTerrainFlag((pos){ x, y }, T_ENTANGLES) && !(monst->info.flags & MONST_IMMUNE_TO_WEBS)) {
         if (!(monst->info.flags & MONST_INVULNERABLE)
             && --monst->status[STATUS_STUCK]) {
 
@@ -3798,7 +3798,7 @@ void findAlternativeHomeFor(creature *monst, short *x, short *y, boolean chooseR
                     && dist > 0
                     && !(pmap[sCols[i]][sRows[j]].flags & (HAS_PLAYER | HAS_MONSTER))
                     && !monsterAvoids(monst, (pos){sCols[i], sRows[j]})
-                    && !(monst == &player && cellHasTerrainFlag(sCols[i], sRows[j], T_PATHING_BLOCKER))) {
+                    && !(monst == &player && cellHasTerrainFlag((pos){ sCols[i], sRows[j] }, T_PATHING_BLOCKER))) {
 
                     // Success!
                     *x = sCols[i];
@@ -3830,7 +3830,7 @@ boolean getQualifyingLocNear(pos *loc,
                 if (coordinatesAreInMap(i, j)
                     && (i == target.x-k || i == target.x+k || j == target.y-k || j == target.y+k)
                     && (!blockingMap || !blockingMap[i][j])
-                    && !cellHasTerrainFlag(i, j, forbiddenTerrainFlags)
+                    && !cellHasTerrainFlag((pos){ i, j }, forbiddenTerrainFlags)
                     && !(pmap[i][j].flags & forbiddenMapFlags)
                     && (!forbidLiquid || pmap[i][j].layers[LIQUID] == NOTHING)
                     && (hallwaysAllowed || passableArcCount(i, j) < 2)) {
@@ -3858,7 +3858,7 @@ boolean getQualifyingLocNear(pos *loc,
                 if (coordinatesAreInMap(i, j)
                     && (i == target.x-k || i == target.x+k || j == target.y-k || j == target.y+k)
                     && (!blockingMap || !blockingMap[i][j])
-                    && !cellHasTerrainFlag(i, j, forbiddenTerrainFlags)
+                    && !cellHasTerrainFlag((pos){ i, j }, forbiddenTerrainFlags)
                     && !(pmap[i][j].flags & forbiddenMapFlags)
                     && (!forbidLiquid || pmap[i][j].layers[LIQUID] == NOTHING)
                     && (hallwaysAllowed || passableArcCount(i, j) < 2)) {
@@ -4183,7 +4183,7 @@ void monsterDetails(char buf[], creature *monst) {
     }
 
     if (!(monst->info.flags & MONST_ATTACKABLE_THRU_WALLS)
-        && cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY)) {
+        && cellHasTerrainFlag(monst->loc, T_OBSTRUCTS_PASSABILITY)) {
         // If the monster is trapped in impassible terrain, explain as much.
         sprintf(newText, "%s is trapped %s %s.\n     ",
                 capMonstName,

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -268,9 +268,9 @@ void describeLocation(char *buf, short x, short y) {
                          && monst->creatureState != MONSTER_SLEEPING
                          && !(monst->bookkeepingFlags & (MB_SEIZED | MB_CAPTIVE)));
         if ((monst->info.flags & MONST_ATTACKABLE_THRU_WALLS)
-            && cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY)) {
+            && cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_PASSABILITY)) {
             strcpy(verb, "is embedded");
-        } else if (cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY)) {
+        } else if (cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_PASSABILITY)) {
             strcpy(verb, "is trapped");
             subjectMoving = false;
         } else if (monst->bookkeepingFlags & MB_CAPTIVE) {
@@ -288,9 +288,9 @@ void describeLocation(char *buf, short x, short y) {
             prepositionLocked = true;
         } else if (monsterCanSubmergeNow(monst)) {
             strcpy(verb, (subjectMoving ? "is gliding" : "is drifting"));
-        } else if (cellHasTerrainFlag(x, y, T_MOVES_ITEMS) && !(monst->info.flags & MONST_SUBMERGES)) {
+        } else if (cellHasTerrainFlag((pos){ x, y }, T_MOVES_ITEMS) && !(monst->info.flags & MONST_SUBMERGES)) {
             strcpy(verb, (subjectMoving ? "is swimming" : "is struggling"));
-        } else if (cellHasTerrainFlag(x, y, T_AUTO_DESCENT)) {
+        } else if (cellHasTerrainFlag((pos){ x, y }, T_AUTO_DESCENT)) {
             strcpy(verb, "is suspended in mid-air");
             strcpy(preposition, "over");
             prepositionLocked = true;
@@ -346,13 +346,13 @@ void describeLocation(char *buf, short x, short y) {
         strcpy(object, tileText(x, y));
         if (theItem) {
             describedItemName(theItem, subject);
-            subjectMoving = cellHasTerrainFlag(x, y, T_MOVES_ITEMS);
+            subjectMoving = cellHasTerrainFlag((pos){ x, y }, T_MOVES_ITEMS);
             if (player.status[STATUS_HALLUCINATING] && !rogue.playbackOmniscience) {
                 strcpy(verb, "is");
             } else {
                 strcpy(verb, (theItem->quantity > 1 || (theItem->category & GOLD)) ? "are" : "is");
             }
-            if (cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY)) {
+            if (cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_PASSABILITY)) {
                 strcat(verb, " enclosed");
             } else {
                 strcat(verb, subjectMoving ? " drifting" : " lying");
@@ -441,7 +441,7 @@ short randValidDirectionFrom(creature *monst, short x, short y, boolean respectA
         newX = x + nbDirs[i][0];
         newY = y + nbDirs[i][1];
         if (coordinatesAreInMap(newX, newY)
-            && !cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY)
+            && !cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_PASSABILITY)
             && !diagonalBlocked(x, y, newX, newY, false)
             && (!respectAvoidancePreferences
                 || (!monsterAvoids(monst, (pos){newX, newY}))
@@ -518,7 +518,7 @@ boolean freeCaptivesEmbeddedAt(short x, short y) {
         monst = monsterAtLoc((pos){ x, y });
         if ((monst->bookkeepingFlags & MB_CAPTIVE)
             && !(monst->info.flags & MONST_ATTACKABLE_THRU_WALLS)
-            && (cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY))) {
+            && (cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_PASSABILITY))) {
             freeCaptive(monst);
             return true;
         }
@@ -645,7 +645,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         trigger the attack. */
         defender = monsterAtLoc(targetLoc);
         if (defender
-            && (!cellHasTerrainFlag(targetLoc.x, targetLoc.y, T_OBSTRUCTS_PASSABILITY)
+            && (!cellHasTerrainFlag(targetLoc, T_OBSTRUCTS_PASSABILITY)
                 || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))
             && monsterWillAttackTarget(attacker, defender)) {
 
@@ -661,7 +661,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
             }
         }
 
-        if (cellHasTerrainFlag(targetLoc.x, targetLoc.y, (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION))) {
+        if (cellHasTerrainFlag(targetLoc, (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION))) {
             break;
         }
     }
@@ -726,7 +726,7 @@ static void buildFlailHitList(const short x, const short y, const short newX, co
             && monstersAreEnemies(&player, monst)
             && monst->creatureState != MONSTER_ALLY
             && !(monst->bookkeepingFlags & MB_IS_DYING)
-            && (!cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
+            && (!cellHasTerrainFlag(monst->loc, T_OBSTRUCTS_PASSABILITY) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
 
             while (hitList[i]) {
                 i++;
@@ -788,8 +788,8 @@ boolean playerMoves(short direction) {
                 if (coordinatesAreInMap(newestX, newestY)
                     && (pmap[newestX][newestY].flags & (DISCOVERED | MAGIC_MAPPED))
                     && !diagonalBlocked(x, y, newestX, newestY, false)
-                    && cellHasTerrainFlag(newestX, newestY, T_LAVA_INSTA_DEATH)
-                    && !cellHasTerrainFlag(newestX, newestY, T_OBSTRUCTS_PASSABILITY | T_ENTANGLES)
+                    && cellHasTerrainFlag((pos){ newestX, newestY }, T_LAVA_INSTA_DEATH)
+                    && !cellHasTerrainFlag((pos){ newestX, newestY }, T_OBSTRUCTS_PASSABILITY | T_ENTANGLES)
                     && !((pmap[newestX][newestY].flags & HAS_MONSTER)
                          && canSeeMonster(monsterAtLoc((pos){ newestX, newestY }))
                          && monsterAtLoc((pos){ newestX, newestY })->creatureState != MONSTER_ALLY)) {
@@ -828,7 +828,7 @@ boolean playerMoves(short direction) {
         || (!canSeeMonster(defender) && !monsterRevealed(defender))
         || !monstersAreEnemies(&player, defender)) {
 
-        if (cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY) && cellHasTMFlag(newX, newY, TM_PROMOTES_ON_PLAYER_ENTRY)) {
+        if (cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_PASSABILITY) && cellHasTMFlag(newX, newY, TM_PROMOTES_ON_PLAYER_ENTRY)) {
             layer = layerWithTMFlag(newX, newY, TM_PROMOTES_ON_PLAYER_ENTRY);
             if (tileCatalog[pmap[newX][newY].layers[layer]].flags & T_OBSTRUCTS_PASSABILITY) {
                 committed = true;
@@ -841,9 +841,9 @@ boolean playerMoves(short direction) {
 
     }
 
-    if (((!cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY) || (cellHasTMFlag(newX, newY, TM_PROMOTES_WITH_KEY) && keyInPackFor((pos){ newX, newY })))
+    if (((!cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_PASSABILITY) || (cellHasTMFlag(newX, newY, TM_PROMOTES_WITH_KEY) && keyInPackFor((pos){ newX, newY })))
          && !diagonalBlocked(x, y, newX, newY, false)
-         && (!cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY) || (cellHasTMFlag(x, y, TM_PROMOTES_WITH_KEY) && keyInPackFor((pos){ x, y }))))
+         && (!cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_PASSABILITY) || (cellHasTMFlag(x, y, TM_PROMOTES_WITH_KEY) && keyInPackFor((pos){ x, y }))))
         || (defender && defender->info.flags & MONST_ATTACKABLE_THRU_WALLS)) {
         // if the move is not blocked
 
@@ -961,9 +961,9 @@ boolean playerMoves(short direction) {
         if (pmap[newX][newY].flags & (DISCOVERED | MAGIC_MAPPED)
             && player.status[STATUS_LEVITATING] <= 1
             && !player.status[STATUS_CONFUSED]
-            && cellHasTerrainFlag(newX, newY, T_LAVA_INSTA_DEATH)
+            && cellHasTerrainFlag((pos){ newX, newY }, T_LAVA_INSTA_DEATH)
             && player.status[STATUS_IMMUNE_TO_FIRE] <= 1
-            && !cellHasTerrainFlag(newX, newY, T_ENTANGLES)
+            && !cellHasTerrainFlag((pos){ newX, newY }, T_ENTANGLES)
             && !cellHasTMFlag(newX, newY, TM_IS_SECRET)) {
             message("that would be certain death!", 0);
             brogueAssert(!committed);
@@ -973,8 +973,8 @@ boolean playerMoves(short direction) {
         } else if (pmap[newX][newY].flags & (DISCOVERED | MAGIC_MAPPED)
                    && player.status[STATUS_LEVITATING] <= 1
                    && !player.status[STATUS_CONFUSED]
-                   && cellHasTerrainFlag(newX, newY, T_AUTO_DESCENT)
-                   && (!cellHasTerrainFlag(newX, newY, T_ENTANGLES) || cellHasTMFlag(newX, newY, TM_PROMOTES_ON_PLAYER_ENTRY))
+                   && cellHasTerrainFlag((pos){ newX, newY }, T_AUTO_DESCENT)
+                   && (!cellHasTerrainFlag((pos){ newX, newY }, T_ENTANGLES) || cellHasTMFlag(newX, newY, TM_PROMOTES_ON_PLAYER_ENTRY))
                    && !cellHasTMFlag(newX, newY, TM_IS_SECRET)
                    && !confirm("Dive into the depths?", false)) {
 
@@ -986,7 +986,7 @@ boolean playerMoves(short direction) {
                    && !player.status[STATUS_CONFUSED]
                    && !player.status[STATUS_BURNING]
                    && player.status[STATUS_IMMUNE_TO_FIRE] <= 1
-                   && cellHasTerrainFlag(newX, newY, T_IS_FIRE)
+                   && cellHasTerrainFlag((pos){ newX, newY }, T_IS_FIRE)
                    && !cellHasTMFlag(newX, newY, TM_EXTINGUISHES_FIRE)
                    && !confirm("Venture into flame?", false)) {
 
@@ -997,7 +997,7 @@ boolean playerMoves(short direction) {
         } else if (playerCanSee(newX, newY)
                    && !player.status[STATUS_CONFUSED]
                    && !player.status[STATUS_BURNING]
-                   && cellHasTerrainFlag(newX, newY, T_CAUSES_CONFUSION | T_CAUSES_PARALYSIS)
+                   && cellHasTerrainFlag((pos){ newX, newY }, T_CAUSES_CONFUSION | T_CAUSES_PARALYSIS)
                    && (!rogue.armor || !(rogue.armor->flags & ITEM_RUNIC) || !(rogue.armor->flags & ITEM_RUNIC_IDENTIFIED) || rogue.armor->enchant2 != A_RESPIRATION)
                    && !confirm("Venture into dangerous gas?", false)) {
 
@@ -1008,7 +1008,7 @@ boolean playerMoves(short direction) {
         } else if (pmap[newX][newY].flags & (ANY_KIND_OF_VISIBLE | MAGIC_MAPPED)
                    && player.status[STATUS_LEVITATING] <= 1
                    && !player.status[STATUS_CONFUSED]
-                   && cellHasTerrainFlag(newX, newY, T_IS_DF_TRAP)
+                   && cellHasTerrainFlag((pos){ newX, newY }, T_IS_DF_TRAP)
                    && !(pmap[newX][newY].flags & PRESSURE_PLATE_DEPRESSED)
                    && !cellHasTMFlag(newX, newY, TM_IS_SECRET)
                    && (!rogue.armor || !(rogue.armor->flags & ITEM_RUNIC) || !(rogue.armor->flags & ITEM_RUNIC_IDENTIFIED) || rogue.armor->enchant2 != A_RESPIRATION ||
@@ -1032,7 +1032,7 @@ boolean playerMoves(short direction) {
                     && monstersAreEnemies(&player, tempMonst)
                     && tempMonst->creatureState != MONSTER_ALLY
                     && !(tempMonst->bookkeepingFlags & MB_IS_DYING)
-                    && (!cellHasTerrainFlag(tempMonst->loc.x, tempMonst->loc.y, T_OBSTRUCTS_PASSABILITY) || (tempMonst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
+                    && (!cellHasTerrainFlag(tempMonst->loc, T_OBSTRUCTS_PASSABILITY) || (tempMonst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
 
                     hitList[0] = tempMonst;
                     if (abortAttackAgainstAcidicTarget(hitList)) { // Acid mound attack confirmation.
@@ -1054,7 +1054,7 @@ boolean playerMoves(short direction) {
             }
         }
 
-        if (player.status[STATUS_STUCK] && cellHasTerrainFlag(x, y, T_ENTANGLES)) {
+        if (player.status[STATUS_STUCK] && cellHasTerrainFlag((pos){ x, y }, T_ENTANGLES)) {
                 // Don't interrupt exploration with this message.
             if (--player.status[STATUS_STUCK]) {
                 if (!rogue.automationActive) {
@@ -1140,7 +1140,7 @@ boolean playerMoves(short direction) {
 
             playerTurnEnded();
         }
-    } else if (cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_PASSABILITY)) {
+    } else if (cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_PASSABILITY)) {
         i = pmap[newX][newY].layers[layerWithFlag(newX, newY, T_OBSTRUCTS_PASSABILITY)];
         if ((tileCatalog[i].flags & T_OBSTRUCTS_PASSABILITY)
             && (!diagonalBlocked(x, y, newX, newY, false) || !cellHasTMFlag(newX, newY, TM_PROMOTES_WITH_KEY))) {
@@ -1367,7 +1367,7 @@ void calculateDistances(short **distanceMap, short destinationX, short destinati
         for (j=0; j<DROWS; j++) {
             distanceMap[i][j] = ((traveler && traveler == &player && !(pmap[i][j].flags & (DISCOVERED | MAGIC_MAPPED)))
                                  || ((traveler && monsterAvoids(traveler, (pos){i, j}))
-                                     || cellHasTerrainFlag(i, j, blockingTerrainFlags))) ? -1 : 30000;
+                                     || cellHasTerrainFlag((pos){ i, j }, blockingTerrainFlags))) ? -1 : 30000;
         }
     }
 
@@ -1650,11 +1650,11 @@ void populateGenericCostMap(short **costMap) {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
+            if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
-                costMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
-            } else if (cellHasTerrainFlag(i, j, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
+                costMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+            } else if (cellHasTerrainFlag((pos){ i, j }, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
                 costMap[i][j] = PDS_FORBIDDEN;
             } else {
                 costMap[i][j] = 1;
@@ -1681,10 +1681,10 @@ void getLocationFlags(const short x, const short y,
         }
     } else {
         if (tFlags) {
-            *tFlags = terrainFlags(x, y);
+            *tFlags = terrainFlags((pos){ x, y });
         }
         if (TMFlags) {
-            *TMFlags = terrainMechFlags(x, y);
+            *TMFlags = terrainMechFlags((pos){ x, y });
         }
         if (cellFlags) {
             *cellFlags = pmap[x][y].flags;
@@ -1710,7 +1710,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
             getLocationFlags(i, j, &tFlags, NULL, &cFlags, monst == &player);
 
             if ((tFlags & T_OBSTRUCTS_PASSABILITY)
-                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY) || monst == &player)) {
+                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY) || monst == &player)) {
 
                 costMap[i][j] = (tFlags & T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                 continue;
@@ -1785,7 +1785,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
 }
 
 enum directions adjacentFightingDir() {
-    if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY)) {
+    if (cellHasTerrainFlag(player.loc, T_OBSTRUCTS_PASSABILITY)) {
         return NO_DIRECTION;
     }
     for (enum directions dir = 0; dir < DIRECTION_COUNT; dir++) {
@@ -1821,7 +1821,7 @@ void getExploreMap(short **map, boolean headingToStairs) {// calculate explore m
                 if ((pmap[i][j].flags & MAGIC_MAPPED)
                     && (tileCatalog[pmap[i][j].layers[DUNGEON]].flags | tileCatalog[pmap[i][j].layers[LIQUID]].flags) & T_PATHING_BLOCKER) {
                     // Magic-mapped cells revealed as obstructions should be treated as such even though they're not discovered.
-                    costMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+                    costMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                 } else {
                     costMap[i][j] = 1;
                     map[i][j] = exploreGoalValue(i, j);
@@ -1866,7 +1866,7 @@ boolean explore(short frameDelay) {
         message("Not while you're confused.", 0);
         return false;
     }
-    if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY)) {
+    if (cellHasTerrainFlag(player.loc, T_OBSTRUCTS_PASSABILITY)) {
         message("Not while you're trapped.", 0);
         return false;
     }
@@ -2056,7 +2056,7 @@ boolean search(short searchStrength) {
                 && playerCanDirectlySee(i, j)) {
 
                 percent = searchStrength - distanceBetween((pos){x, y}, (pos){i, j}) * 10;
-                if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)) {
+                if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)) {
                     percent = percent * 2/3;
                 }
                 if (percent >= 100) {
@@ -2145,8 +2145,8 @@ boolean useStairs(short stairDirection) {
 }
 
 void storeMemories(const short x, const short y) {
-    pmap[x][y].rememberedTerrainFlags = terrainFlags(x, y);
-    pmap[x][y].rememberedTMFlags = terrainMechFlags(x, y);
+    pmap[x][y].rememberedTerrainFlags = terrainFlags((pos){ x, y });
+    pmap[x][y].rememberedTMFlags = terrainMechFlags((pos){ x, y });
     pmap[x][y].rememberedCellFlags = pmap[x][y].flags;
     pmap[x][y].rememberedTerrain = pmap[x][y].layers[highestPriorityLayer(x, y, false)];
 }
@@ -2213,7 +2213,7 @@ void updateFieldOfViewDisplay(boolean updateDancingTerrain, boolean refreshDispl
                 }
             } else if (!(pmap[i][j].flags & WAS_TELEPATHIC_VISIBLE) && (pmap[i][j].flags & TELEPATHIC_VISIBLE)) { // became telepathically visible
                 if (!(pmap[i][j].flags & DISCOVERED)
-                    && !cellHasTerrainFlag(i, j, T_PATHING_BLOCKER)) {
+                    && !cellHasTerrainFlag((pos){ i, j }, T_PATHING_BLOCKER)) {
                     rogue.xpxpThisTurn++;
                 }
 
@@ -2341,7 +2341,7 @@ void scanOctantFOV(char grid[DCOLS][DROWS], short xLoc, short yLoc, short octant
     x = loc.x + columnsRightFromOrigin;
     y = loc.y + iStart;
     betweenOctant1andN(&x, &y, loc.x, loc.y, octant);
-    boolean currentlyLit = coordinatesAreInMap(x, y) && !(cellHasTerrainFlag(x, y, forbiddenTerrain) ||
+    boolean currentlyLit = coordinatesAreInMap(x, y) && !(cellHasTerrainFlag((pos){ x, y }, forbiddenTerrain) ||
                                                           (pmap[x][y].flags & forbiddenFlags));
     for (i = iStart; i <= iEnd; i++) {
         x = loc.x + columnsRightFromOrigin;
@@ -2351,7 +2351,7 @@ void scanOctantFOV(char grid[DCOLS][DROWS], short xLoc, short yLoc, short octant
             // We're off the map -- here there be memory corruption.
             continue;
         }
-        cellObstructed = (cellHasTerrainFlag(x, y, forbiddenTerrain) || (pmap[x][y].flags & forbiddenFlags));
+        cellObstructed = (cellHasTerrainFlag((pos){ x, y }, forbiddenTerrain) || (pmap[x][y].flags & forbiddenFlags));
         // if we're cautious on walls and this is a wall:
         if (cautiousOnWalls && cellObstructed) {
             // (x2, y2) is the tile one space closer to the origin from the tile we're on:
@@ -2398,7 +2398,7 @@ void scanOctantFOV(char grid[DCOLS][DROWS], short xLoc, short yLoc, short octant
 
 void addScentToCell(short x, short y, short distance) {
     unsigned short value;
-    if (!cellHasTerrainFlag(x, y, T_OBSTRUCTS_SCENT) || !cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY)) {
+    if (!cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_SCENT) || !cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_PASSABILITY)) {
         value = rogue.scentTurnNumber - distance;
         scentMap[x][y] = max(value, (unsigned short) scentMap[x][y]);
     }

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1651,7 +1651,7 @@ void populateGenericCostMap(short **costMap) {
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
                 costMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag((pos){ i, j }, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
@@ -1710,7 +1710,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
             getLocationFlags(i, j, &tFlags, NULL, &cFlags, monst == &player);
 
             if ((tFlags & T_OBSTRUCTS_PASSABILITY)
-                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY) || monst == &player)) {
+                 && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY) || monst == &player)) {
 
                 costMap[i][j] = (tFlags & T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                 continue;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1210,10 +1210,10 @@ enum tileFlags {
 #define max(x, y)       (((x) > (y)) ? (x) : (y))
 #define clamp(x, low, hi)   (min(hi, max(x, low))) // pins x to the [y, z] interval
 
-unsigned long terrainFlags(short x, short y);
-unsigned long terrainMechFlags(short x, short y);
+unsigned long terrainFlags(pos loc);
+unsigned long terrainMechFlags(pos loc);
 
-boolean cellHasTerrainFlag(short x, short y, unsigned long flagMask);
+boolean cellHasTerrainFlag(pos loc, unsigned long flagMask);
 boolean cellHasTMFlag(short x, short y, unsigned long flagMask);
 
 boolean cellHasTerrainType(short x, short y, enum tileType terrain);
@@ -3142,8 +3142,8 @@ extern "C" {
     boolean knownToPlayerAsPassableOrSecretDoor(pos loc);
     void setMonsterLocation(creature *monst, pos newLoc);
     boolean moveMonster(creature *monst, short dx, short dy);
-    unsigned long burnedTerrainFlagsAtLoc(pos loc);
-    unsigned long discoveredTerrainFlagsAtLoc(pos loc);
+    unsigned long burnedterrainFlagsLoc(pos loc);
+    unsigned long discoveredterrainFlagsLoc(pos loc);
     boolean monsterAvoids(creature *monst, pos p);
     short distanceBetween(pos loc1, pos loc2);
     void alertMonster(creature *monst);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3142,8 +3142,8 @@ extern "C" {
     boolean knownToPlayerAsPassableOrSecretDoor(pos loc);
     void setMonsterLocation(creature *monst, pos newLoc);
     boolean moveMonster(creature *monst, short dx, short dy);
-    unsigned long burnedterrainFlagsLoc(pos loc);
-    unsigned long discoveredterrainFlagsLoc(pos loc);
+    unsigned long burnedTerrainFlagsAtLoc(pos loc);
+    unsigned long discoveredTerrainFlagsAtLoc(pos loc);
     boolean monsterAvoids(creature *monst, pos p);
     short distanceBetween(pos loc1, pos loc2);
     void alertMonster(creature *monst);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -545,9 +545,9 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     if (oldLevelNumber != rogue.depthLevel) {
         px = player.loc.x;
         py = player.loc.y;
-        if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_AUTO_DESCENT)) {
+        if (cellHasTerrainFlag(player.loc, T_AUTO_DESCENT)) {
             for (i=0; i<8; i++) {
-                if (!cellHasTerrainFlag(player.loc.x+nbDirs[i][0], player.loc.y+nbDirs[i][1], (T_PATHING_BLOCKER))) {
+                if (!cellHasTerrainFlag((pos){ player.loc.x+nbDirs[i][0], player.loc.y+nbDirs[i][1] }, (T_PATHING_BLOCKER))) {
                     px = player.loc.x+nbDirs[i][0];
                     py = player.loc.y+nbDirs[i][1];
                     break;
@@ -567,11 +567,11 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                      || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)
                     && (stairDirection != 0 || monst->currentHP > 10 || monst->status[STATUS_LEVITATING])
                     && ((flying != 0) == ((monst->status[STATUS_LEVITATING] != 0)
-                                          || cellHasTerrainFlag(x, y, T_PATHING_BLOCKER)
-                                          || cellHasTerrainFlag(px, py, T_AUTO_DESCENT)))
+                                          || cellHasTerrainFlag((pos){ x, y }, T_PATHING_BLOCKER)
+                                          || cellHasTerrainFlag((pos){ px, py }, T_AUTO_DESCENT)))
                     && !(monst->bookkeepingFlags & MB_CAPTIVE)
                     && !(monst->info.flags & (MONST_WILL_NOT_USE_STAIRS | MONST_RESTRICTED_TO_LIQUID))
-                    && !(cellHasTerrainFlag(x, y, T_OBSTRUCTS_PASSABILITY))
+                    && !(cellHasTerrainFlag((pos){ x, y }, T_OBSTRUCTS_PASSABILITY))
                     && !monst->status[STATUS_ENTRANCED]
                     && !monst->status[STATUS_PARALYZED]
                     && (mapToStairs[monst->loc.x][monst->loc.y] < 30000 || monst->creatureState == MONSTER_ALLY || monst == rogue.yendorWarden)) {
@@ -779,7 +779,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
                              (T_PATHING_BLOCKER & ~T_IS_DEEP_WATER),
                              (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
 
-        if (cellHasTerrainFlag(loc.x, loc.y, T_IS_DEEP_WATER)) {
+        if (cellHasTerrainFlag(loc, T_IS_DEEP_WATER)) {
             // Fell into deep water... can we swim out of it?
             pos dryLoc;
             getQualifyingLocNear(&dryLoc, player.loc, true, 0,
@@ -803,7 +803,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
         placedPlayer = false;
         for (dir=0; dir<4 && !placedPlayer; dir++) {
             loc = posNeighborInDirection(player.loc, dir);
-            if (!cellHasTerrainFlag(loc.x, loc.y, T_PATHING_BLOCKER)
+            if (!cellHasTerrainFlag(loc, T_PATHING_BLOCKER)
                 && !(pmapAt(loc)->flags & (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE))) {
                 placedPlayer = true;
             }
@@ -830,8 +830,8 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             }
         }
     }
-    if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
-        && !cellHasTerrainFlag(player.loc.x, player.loc.y, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
+    if (cellHasTerrainFlag(player.loc, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
+        && !cellHasTerrainFlag(player.loc, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
         rogue.inWater = true;
     }
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -70,8 +70,8 @@ void updateFlavorText() {
 
 void updatePlayerUnderwaterness() {
     if (rogue.inWater) {
-        if (!cellHasTerrainFlag(player.loc.x, player.loc.y, T_IS_DEEP_WATER) || player.status[STATUS_LEVITATING]
-            || cellHasTerrainFlag(player.loc.x, player.loc.y, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
+        if (!cellHasTerrainFlag(player.loc, T_IS_DEEP_WATER) || player.status[STATUS_LEVITATING]
+            || cellHasTerrainFlag(player.loc, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
 
             rogue.inWater = false;
             updateMinersLightRadius();
@@ -79,8 +79,8 @@ void updatePlayerUnderwaterness() {
             displayLevel();
         }
     } else {
-        if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
-            && !cellHasTerrainFlag(player.loc.x, player.loc.y, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
+        if (cellHasTerrainFlag(player.loc, T_IS_DEEP_WATER) && !player.status[STATUS_LEVITATING]
+            && !cellHasTerrainFlag(player.loc, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
 
             rogue.inWater = true;
             updateMinersLightRadius();
@@ -92,8 +92,8 @@ void updatePlayerUnderwaterness() {
 
 boolean monsterShouldFall(creature *monst) {
     return (!(monst->status[STATUS_LEVITATING])
-            && cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_AUTO_DESCENT)
-            && !cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_ENTANGLES | T_OBSTRUCTS_PASSABILITY)
+            && cellHasTerrainFlag(monst->loc, T_AUTO_DESCENT)
+            && !cellHasTerrainFlag(monst->loc, T_ENTANGLES | T_OBSTRUCTS_PASSABILITY)
             && !(monst->bookkeepingFlags & MB_PREPLACED));
 }
 
@@ -116,7 +116,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     } else if (!player.status[STATUS_HALLUCINATING]
                && !monst->status[STATUS_LEVITATING]
                && canSeeMonster(monst)
-               && !(cellHasTerrainFlag(*x, *y, T_IS_DF_TRAP))) {
+               && !(cellHasTerrainFlag((pos){ *x, *y }, T_IS_DF_TRAP))) {
         pmap[*x][*y].flags |= KNOWN_TO_BE_TRAP_FREE;
     }
 
@@ -141,7 +141,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
 
     // Obstructed krakens can't seize their prey.
     if ((monst->bookkeepingFlags & MB_SEIZING)
-        && (cellHasTerrainFlag(*x, *y, T_OBSTRUCTS_PASSABILITY))
+        && (cellHasTerrainFlag((pos){ *x, *y }, T_OBSTRUCTS_PASSABILITY))
         && !(monst->info.flags & MONST_ATTACKABLE_THRU_WALLS)) {
 
         monst->bookkeepingFlags &= ~MB_SEIZING;
@@ -164,9 +164,9 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     if (!(monst->status[STATUS_LEVITATING])
         && !(monst->status[STATUS_IMMUNE_TO_FIRE])
         && !(monst->info.flags & MONST_INVULNERABLE)
-        && !cellHasTerrainFlag(*x, *y, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))
+        && !cellHasTerrainFlag((pos){ *x, *y }, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))
         && !cellHasTMFlag(*x, *y, TM_EXTINGUISHES_FIRE)
-        && cellHasTerrainFlag(*x, *y, T_LAVA_INSTA_DEATH)) {
+        && cellHasTerrainFlag((pos){ *x, *y }, T_LAVA_INSTA_DEATH)) {
 
         if (monst == &player) {
             sprintf(buf, "you plunge into %s!",
@@ -208,7 +208,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     // If you see a monster use a secret door, you discover it.
     if (playerCanSee(*x, *y)
         && cellHasTMFlag(*x, *y, TM_IS_SECRET)
-        && (cellHasTerrainFlag(*x, *y, T_OBSTRUCTS_PASSABILITY))) {
+        && (cellHasTerrainFlag((pos){ *x, *y }, T_OBSTRUCTS_PASSABILITY))) {
         discover(*x, *y);
     }
 
@@ -216,7 +216,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     if (!(monst->status[STATUS_LEVITATING])
         && !(monst->bookkeepingFlags & MB_SUBMERGED)
         && (!cellHasTMFlag(*x, *y, TM_ALLOWS_SUBMERGING) || !(monst->info.flags & MONST_SUBMERGES))
-        && cellHasTerrainFlag(*x, *y, T_IS_DF_TRAP)
+        && cellHasTerrainFlag((pos){ *x, *y }, T_IS_DF_TRAP)
         && !(pmap[*x][*y].flags & PRESSURE_PLATE_DEPRESSED)) {
 
         pmap[*x][*y].flags |= PRESSURE_PLATE_DEPRESSED;
@@ -275,7 +275,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     }
 
     // spiderwebs
-    if (cellHasTerrainFlag(*x, *y, T_ENTANGLES) && !monst->status[STATUS_STUCK]
+    if (cellHasTerrainFlag((pos){ *x, *y }, T_ENTANGLES) && !monst->status[STATUS_STUCK]
         && !(monst->info.flags & (MONST_IMMUNE_TO_WEBS | MONST_INVULNERABLE))
         && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
 
@@ -298,7 +298,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     }
 
     // explosions
-    if (cellHasTerrainFlag(*x, *y, T_CAUSES_EXPLOSIVE_DAMAGE) && !monst->status[STATUS_EXPLOSION_IMMUNITY]
+    if (cellHasTerrainFlag((pos){ *x, *y }, T_CAUSES_EXPLOSIVE_DAMAGE) && !monst->status[STATUS_EXPLOSION_IMMUNITY]
         && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
         damage = rand_range(15, 20);
         damage = max(damage, monst->info.maxHP / 2);
@@ -348,7 +348,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     // Toxic gases!
     // If it's the player, and he's wearing armor of respiration, then no effect from toxic gases.
     if (monst == &player
-        && cellHasTerrainFlag(*x, *y, T_RESPIRATION_IMMUNITIES)
+        && cellHasTerrainFlag((pos){ *x, *y }, T_RESPIRATION_IMMUNITIES)
         && rogue.armor
         && (rogue.armor->flags & ITEM_RUNIC)
         && rogue.armor->enchant2 == A_RESPIRATION) {
@@ -359,7 +359,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     } else {
 
         // zombie gas
-        if (cellHasTerrainFlag(*x, *y, T_CAUSES_NAUSEA)
+        if (cellHasTerrainFlag((pos){ *x, *y }, T_CAUSES_NAUSEA)
             && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))
             && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
             if (monst == &player) {
@@ -379,7 +379,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
         }
 
         // confusion gas
-        if (cellHasTerrainFlag(*x, *y, T_CAUSES_CONFUSION) && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
+        if (cellHasTerrainFlag((pos){ *x, *y }, T_CAUSES_CONFUSION) && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))) {
             if (monst == &player) {
                 rogue.disturbed = true;
             }
@@ -396,7 +396,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
         }
 
         // paralysis gas
-        if (cellHasTerrainFlag(*x, *y, T_CAUSES_PARALYSIS)
+        if (cellHasTerrainFlag((pos){ *x, *y }, T_CAUSES_PARALYSIS)
             && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))
             && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
 
@@ -414,7 +414,7 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     }
 
     // poisonous lichen
-    if (cellHasTerrainFlag(*x, *y, T_CAUSES_POISON)
+    if (cellHasTerrainFlag((pos){ *x, *y }, T_CAUSES_POISON)
         && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))
         && !monst->status[STATUS_LEVITATING]) {
 
@@ -435,14 +435,14 @@ void applyInstantTileEffectsToCreature(creature *monst) {
     }
 
     // fire
-    if (cellHasTerrainFlag(*x, *y, T_IS_FIRE)) {
+    if (cellHasTerrainFlag((pos){ *x, *y }, T_IS_FIRE)) {
         exposeCreatureToFire(monst);
-    } else if (cellHasTerrainFlag(*x, *y, T_IS_FLAMMABLE)
+    } else if (cellHasTerrainFlag((pos){ *x, *y }, T_IS_FLAMMABLE)
             // We should only expose to fire if it is flammable and not on fire. However, when
             // gas burns, it only sets the volume to 0 and doesn't clear the layer (for visual
             // reasons). This can cause crashes if the fire tile fails to spawn, so we also exclude it.
                && !(pmap[*x][*y].layers[GAS] != NOTHING && pmap[*x][*y].volume == 0)
-               && !cellHasTerrainFlag(*x, *y, T_IS_FIRE)
+               && !cellHasTerrainFlag((pos){ *x, *y }, T_IS_FIRE)
                && monst->status[STATUS_BURNING]
                && !(monst->bookkeepingFlags & (MB_SUBMERGED | MB_IS_FALLING))) {
         exposeTileToFire(*x, *y, true);
@@ -462,8 +462,8 @@ static void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
     enum dungeonLayers layer;
 
     if (!(monst->status[STATUS_LEVITATING])
-        && cellHasTerrainFlag(x, y, T_IS_DEEP_WATER)
-        && !cellHasTerrainFlag(x, y, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))
+        && cellHasTerrainFlag((pos){ x, y }, T_IS_DEEP_WATER)
+        && !cellHasTerrainFlag((pos){ x, y }, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))
         && !(monst->info.flags & MONST_IMMUNE_TO_WATER)) {
         if (monst == &player) {
             if (!(pmap[x][y].flags & HAS_ITEM) && rand_percent(ticks * 50 / 100)) {
@@ -494,7 +494,7 @@ static void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
         }
     }
 
-    if (cellHasTerrainFlag(x, y, T_CAUSES_DAMAGE)
+    if (cellHasTerrainFlag((pos){ x, y }, T_CAUSES_DAMAGE)
         && !(monst->info.flags & (MONST_INANIMATE | MONST_INVULNERABLE))
         && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
 
@@ -534,7 +534,7 @@ static void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
         }
     }
 
-    if (cellHasTerrainFlag(x, y, T_CAUSES_HEALING)
+    if (cellHasTerrainFlag((pos){ x, y }, T_CAUSES_HEALING)
         && !(monst->info.flags & MONST_INANIMATE)
         && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
 
@@ -733,7 +733,7 @@ void discoverCell(const short x, const short y) {
     pmap[x][y].flags &= ~STABLE_MEMORY;
     if (!(pmap[x][y].flags & DISCOVERED)) {
         pmap[x][y].flags |= DISCOVERED;
-        if (!cellHasTerrainFlag(x, y, T_PATHING_BLOCKER)) {
+        if (!cellHasTerrainFlag((pos){ x, y }, T_PATHING_BLOCKER)) {
             rogue.xpxpThisTurn++;
         }
     }
@@ -999,7 +999,7 @@ static void playerFalls() {
         startLevel(rogue.depthLevel - 1, 0);
         damage = randClumpedRange(gameConst->fallDamageMin, gameConst->fallDamageMax, 2);
         boolean killed = false;
-        if (terrainFlags(player.loc.x, player.loc.y) & T_IS_DEEP_WATER) {
+        if (terrainFlags(player.loc) & T_IS_DEEP_WATER) {
             messageWithColor("You fall into deep water, unharmed.", &badMessageColor, 0);
         } else {
             if (cellHasTMFlag(player.loc.x, player.loc.y, TM_ALLOWS_SUBMERGING)) {
@@ -1159,7 +1159,7 @@ boolean exposeTileToFire(short x, short y, boolean alwaysIgnite) {
     enum directions dir;
     boolean fireIgnited = false, explosivePromotion = false;
 
-    if (!cellHasTerrainFlag(x, y, T_IS_FLAMMABLE) || pmap[x][y].exposedToFire >= 12) {
+    if (!cellHasTerrainFlag((pos){ x, y }, T_IS_FLAMMABLE) || pmap[x][y].exposedToFire >= 12) {
         return false;
     }
 
@@ -1191,7 +1191,7 @@ boolean exposeTileToFire(short x, short y, boolean alwaysIgnite) {
                 newX = x + nbDirs[dir][0];
                 newY = y + nbDirs[dir][1];
                 if (coordinatesAreInMap(newX, newY)
-                    && (cellHasTerrainFlag(newX, newY, T_IS_FIRE | T_OBSTRUCTS_GAS) || cellHasTMFlag(newX, newY, TM_EXPLOSIVE_PROMOTE))) {
+                    && (cellHasTerrainFlag((pos){ newX, newY }, T_IS_FIRE | T_OBSTRUCTS_GAS) || cellHasTMFlag(newX, newY, TM_EXPLOSIVE_PROMOTE))) {
 
                     explosiveNeighborCount++;
                 }
@@ -1234,7 +1234,7 @@ static void updateVolumetricMedia() {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (!cellHasTerrainFlag(i, j, T_OBSTRUCTS_GAS)) {
+            if (!cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_GAS)) {
                 sum = pmap[i][j].volume;
                 numSpaces = 1;
                 highestNeighborVolume = pmap[i][j].volume;
@@ -1243,7 +1243,7 @@ static void updateVolumetricMedia() {
                     newX = i + nbDirs[dir][0];
                     newY = j + nbDirs[dir][1];
                     if (coordinatesAreInMap(newX, newY)
-                        && !cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_GAS)) {
+                        && !cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_GAS)) {
 
                         sum += pmap[newX][newY].volume;
                         numSpaces++;
@@ -1253,7 +1253,7 @@ static void updateVolumetricMedia() {
                         }
                     }
                 }
-                if (cellHasTerrainFlag(i, j, T_AUTO_DESCENT)) { // if it's a chasm tile or trap door,
+                if (cellHasTerrainFlag((pos){ i, j }, T_AUTO_DESCENT)) { // if it's a chasm tile or trap door,
                     numSpaces++; // this will allow gas to escape from the level entirely
                 }
                 newGasVolume[i][j] += sum / max(1, numSpaces);
@@ -1283,7 +1283,7 @@ static void updateVolumetricMedia() {
                     newX = i + nbDirs[dir][0];
                     newY = j + nbDirs[dir][1];
                     if (coordinatesAreInMap(newX, newY)
-                        && !cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_GAS)) {
+                        && !cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_GAS)) {
 
                         numSpaces++;
                     }
@@ -1293,7 +1293,7 @@ static void updateVolumetricMedia() {
                         newX = i + nbDirs[dir][0];
                         newY = j + nbDirs[dir][1];
                         if (coordinatesAreInMap(newX, newY)
-                            && !cellHasTerrainFlag(newX, newY, T_OBSTRUCTS_GAS)) {
+                            && !cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_GAS)) {
 
                             newGasVolume[newX][newY] += (pmap[i][j].volume / numSpaces);
                             if (pmap[i][j].volume / numSpaces) {
@@ -1446,7 +1446,7 @@ void updateEnvironment() {
                     promoteChance = 0;
                     for (direction = 0; direction < 4; direction++) {
                         if (coordinatesAreInMap(i + nbDirs[direction][0], j + nbDirs[direction][1])
-                            && !cellHasTerrainFlag(i + nbDirs[direction][0], j + nbDirs[direction][1], T_OBSTRUCTS_PASSABILITY)
+                            && !cellHasTerrainFlag((pos){ i + nbDirs[direction][0], j + nbDirs[direction][1] }, T_OBSTRUCTS_PASSABILITY)
                             && pmap[i + nbDirs[direction][0]][j + nbDirs[direction][1]].layers[layer] != pmap[i][j].layers[layer]
                             && !(pmap[i][j].flags & CAUGHT_FIRE_THIS_TURN)) {
                             promoteChance += -1 * tile->promoteChance;
@@ -1499,7 +1499,7 @@ void updateEnvironment() {
     // Update fire.
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (cellHasTerrainFlag(i, j, T_IS_FIRE) && !(pmap[i][j].flags & CAUGHT_FIRE_THIS_TURN)) {
+            if (cellHasTerrainFlag((pos){ i, j }, T_IS_FIRE) && !(pmap[i][j].flags & CAUGHT_FIRE_THIS_TURN)) {
                 exposeTileToFire(i, j, false);
                 for (direction=0; direction<4; direction++) {
                     newX = i + nbDirs[direction][0];
@@ -1531,13 +1531,13 @@ void updateAllySafetyMap() {
 
             playerCostMap[i][j] = monsterCostMap[i][j] = 1;
 
-            if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
+            if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
-                playerCostMap[i][j] = monsterCostMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
-            } else if (cellHasTerrainFlag(i, j, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
+                playerCostMap[i][j] = monsterCostMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+            } else if (cellHasTerrainFlag((pos){ i, j }, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
                 playerCostMap[i][j] = monsterCostMap[i][j] = PDS_FORBIDDEN;
-            } else if (cellHasTerrainFlag(i, j, T_SACRED)) {
+            } else if (cellHasTerrainFlag((pos){ i, j }, T_SACRED)) {
                 playerCostMap[i][j] = 1;
                 monsterCostMap[i][j] = PDS_FORBIDDEN;
             } else if ((pmap[i][j].flags & HAS_MONSTER) && monstersAreEnemies(&player, monsterAtLoc((pos){ i, j }))) {
@@ -1608,14 +1608,14 @@ void updateSafetyMap() {
 
             playerCostMap[i][j] = monsterCostMap[i][j] = 1; // prophylactic
 
-            if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
+            if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
-                playerCostMap[i][j] = monsterCostMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
-            } else if (cellHasTerrainFlag(i, j, T_SACRED)) {
+                playerCostMap[i][j] = monsterCostMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+            } else if (cellHasTerrainFlag((pos){ i, j }, T_SACRED)) {
                 playerCostMap[i][j] = 1;
                 monsterCostMap[i][j] = PDS_FORBIDDEN;
-            } else if (cellHasTerrainFlag(i, j, T_LAVA_INSTA_DEATH)) {
+            } else if (cellHasTerrainFlag((pos){ i, j }, T_LAVA_INSTA_DEATH)) {
                 monsterCostMap[i][j] = PDS_FORBIDDEN;
                 if (player.status[STATUS_LEVITATING] || !player.status[STATUS_IMMUNE_TO_FIRE]) {
                     playerCostMap[i][j] = 1;
@@ -1637,29 +1637,29 @@ void updateSafetyMap() {
                     }
                 }
 
-                if (cellHasTerrainFlag(i, j, (T_AUTO_DESCENT | T_IS_DF_TRAP))) {
+                if (cellHasTerrainFlag((pos){ i, j }, (T_AUTO_DESCENT | T_IS_DF_TRAP))) {
                     monsterCostMap[i][j] = PDS_FORBIDDEN;
                     if (player.status[STATUS_LEVITATING]) {
                         playerCostMap[i][j] = 1;
                     } else {
                         playerCostMap[i][j] = PDS_FORBIDDEN;
                     }
-                } else if (cellHasTerrainFlag(i, j, T_IS_FIRE)) {
+                } else if (cellHasTerrainFlag((pos){ i, j }, T_IS_FIRE)) {
                     monsterCostMap[i][j] = PDS_FORBIDDEN;
                     if (player.status[STATUS_IMMUNE_TO_FIRE]) {
                         playerCostMap[i][j] = 1;
                     } else {
                         playerCostMap[i][j] = PDS_FORBIDDEN;
                     }
-                } else if (cellHasTerrainFlag(i, j, (T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES))) {
+                } else if (cellHasTerrainFlag((pos){ i, j }, (T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES))) {
                     if (player.status[STATUS_LEVITATING]) {
                         playerCostMap[i][j] = 1;
                     } else {
                         playerCostMap[i][j] = 5;
                     }
                     monsterCostMap[i][j] = 5;
-                } else if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                           && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
+                } else if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
+                           && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
                            && !(pmap[i][j].flags & IN_FIELD_OF_VIEW)) {
                     // Secret door that the player can't currently see
                     playerCostMap[i][j] = 100;
@@ -1684,8 +1684,8 @@ void updateSafetyMap() {
 
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
-            if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
+            if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
+                && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
                 && !(pmap[i][j].flags & IN_FIELD_OF_VIEW)) {
 
                 // Secret doors that the player can't see are not particularly safe themselves;
@@ -1737,17 +1737,17 @@ void updateSafeTerrainMap() {
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             monst = monsterAtLoc((pos){ i, j });
-            if (cellHasTerrainFlag(i, j, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
+            if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
-                costMap[i][j] = cellHasTerrainFlag(i, j, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
+                costMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                 rogue.mapToSafeTerrain[i][j] = 30000; // OOS prophylactic
             } else if ((monst && (monst->turnsSpentStationary > 1 || (monst->info.flags & MONST_GETS_TURN_ON_ACTIVATION)))
-                       || (cellHasTerrainFlag(i, j, T_PATHING_BLOCKER & ~T_HARMFUL_TERRAIN) && !cellHasTMFlag(i, j, TM_IS_SECRET))) {
+                       || (cellHasTerrainFlag((pos){ i, j }, T_PATHING_BLOCKER & ~T_HARMFUL_TERRAIN) && !cellHasTMFlag(i, j, TM_IS_SECRET))) {
 
                 costMap[i][j] = PDS_FORBIDDEN;
                 rogue.mapToSafeTerrain[i][j] = 30000;
-            } else if (cellHasTerrainFlag(i, j, T_HARMFUL_TERRAIN) || pmap[i][j].layers[DUNGEON] == DOOR) {
+            } else if (cellHasTerrainFlag((pos){ i, j }, T_HARMFUL_TERRAIN) || pmap[i][j].layers[DUNGEON] == DOOR) {
                 // The door thing is an aesthetically offensive but necessary hack to make sure
                 // that monsters trying to find their way out of caustic gas do not sprint for
                 // the doors. Doors are superficially free of gas, but as soon as they are opened,
@@ -1892,7 +1892,7 @@ static void monsterEntersLevel(creature *monst, short n) {
     }
     if (!pit
         && (pmapAt(monst->loc)->flags & (HAS_PLAYER | HAS_MONSTER))
-        && !(terrainFlags(monst->loc.x, monst->loc.y) & avoidedFlagsForMonster(&(monst->info)))) {
+        && !(terrainFlags(monst->loc) & avoidedFlagsForMonster(&(monst->info)))) {
         // Monsters using the stairs will displace any creatures already located there, to thwart stair-dancing.
         creature *prevMonst = monsterAtLoc(monst->loc);
         brogueAssert(prevMonst);
@@ -2038,7 +2038,7 @@ static void decrementPlayerStatus() {
         message("you no longer feel immune to fire.", 0);
     }
 
-    if (player.status[STATUS_STUCK] && !cellHasTerrainFlag(player.loc.x, player.loc.y, T_ENTANGLES)) {
+    if (player.status[STATUS_STUCK] && !cellHasTerrainFlag(player.loc, T_ENTANGLES)) {
         player.status[STATUS_STUCK] = 0;
     }
 
@@ -2091,7 +2091,7 @@ void autoRest() {
     rogue.disturbed = false;
     rogue.automationActive = true;
     // Stop as soon as we're free from crystal.
-    const boolean initiallyEmbedded = cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY);
+    const boolean initiallyEmbedded = cellHasTerrainFlag(player.loc, T_OBSTRUCTS_PASSABILITY);
 
     if ((player.currentHP < player.info.maxHP
          || player.status[STATUS_HALLUCINATING]
@@ -2110,9 +2110,9 @@ void autoRest() {
                    || player.status[STATUS_NAUSEOUS]
                    || player.status[STATUS_POISONED]
                    || player.status[STATUS_DARKNESS]
-                   || cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY))
+                   || cellHasTerrainFlag(player.loc, T_OBSTRUCTS_PASSABILITY))
                && !rogue.disturbed
-               && (!initiallyEmbedded || cellHasTerrainFlag(player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY))) {
+               && (!initiallyEmbedded || cellHasTerrainFlag(player.loc, T_OBSTRUCTS_PASSABILITY))) {
 
             recordKeystroke(REST_KEY, false, false);
             rogue.justRested = true;
@@ -2497,7 +2497,7 @@ void playerTurnEnded() {
 
             if (canSeeMonster(monst)) {
                 monst->bookkeepingFlags |= MB_WAS_VISIBLE;
-                if (cellHasTerrainFlag(monst->loc.x, monst->loc.y, T_OBSTRUCTS_PASSABILITY)
+                if (cellHasTerrainFlag(monst->loc, T_OBSTRUCTS_PASSABILITY)
                     && cellHasTMFlag(monst->loc.x, monst->loc.y, TM_IS_SECRET)) {
 
                     discover(monst->loc.x, monst->loc.y);
@@ -2579,11 +2579,11 @@ void playerTurnEnded() {
     }
 
     // "point of no return" check
-    if ((player.status[STATUS_LEVITATING] && cellHasTerrainFlag(player.loc.x, player.loc.y, T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT))
-        || (player.status[STATUS_IMMUNE_TO_FIRE] && cellHasTerrainFlag(player.loc.x, player.loc.y, T_LAVA_INSTA_DEATH))) {
+    if ((player.status[STATUS_LEVITATING] && cellHasTerrainFlag(player.loc, T_LAVA_INSTA_DEATH | T_IS_DEEP_WATER | T_AUTO_DESCENT))
+        || (player.status[STATUS_IMMUNE_TO_FIRE] && cellHasTerrainFlag(player.loc, T_LAVA_INSTA_DEATH))) {
         if (!rogue.receivedLevitationWarning) {
             turnsRequiredToShore = rogue.mapToShore[player.loc.x][player.loc.y] * player.movementSpeed / 100;
-            if (cellHasTerrainFlag(player.loc.x, player.loc.y, T_LAVA_INSTA_DEATH)) {
+            if (cellHasTerrainFlag(player.loc, T_LAVA_INSTA_DEATH)) {
                 turnsToShore = max(player.status[STATUS_LEVITATING], player.status[STATUS_IMMUNE_TO_FIRE]) * 100 / player.movementSpeed;
             } else {
                 turnsToShore = player.status[STATUS_LEVITATING] * 100 / player.movementSpeed;

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1532,7 +1532,7 @@ void updateAllySafetyMap() {
             playerCostMap[i][j] = monsterCostMap[i][j] = 1;
 
             if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
                 playerCostMap[i][j] = monsterCostMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag((pos){ i, j }, T_PATHING_BLOCKER & ~T_OBSTRUCTS_PASSABILITY)) {
@@ -1609,7 +1609,7 @@ void updateSafetyMap() {
             playerCostMap[i][j] = monsterCostMap[i][j] = 1; // prophylactic
 
             if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
                 playerCostMap[i][j] = monsterCostMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
             } else if (cellHasTerrainFlag((pos){ i, j }, T_SACRED)) {
@@ -1659,7 +1659,7 @@ void updateSafetyMap() {
                     }
                     monsterCostMap[i][j] = 5;
                 } else if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
-                           && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
+                           && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
                            && !(pmap[i][j].flags & IN_FIELD_OF_VIEW)) {
                     // Secret door that the player can't currently see
                     playerCostMap[i][j] = 100;
@@ -1685,7 +1685,7 @@ void updateSafetyMap() {
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<DROWS; j++) {
             if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
-                && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
+                && cellHasTMFlag(i, j, TM_IS_SECRET) && !(discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY)
                 && !(pmap[i][j].flags & IN_FIELD_OF_VIEW)) {
 
                 // Secret doors that the player can't see are not particularly safe themselves;
@@ -1738,7 +1738,7 @@ void updateSafeTerrainMap() {
         for (j=0; j<DROWS; j++) {
             monst = monsterAtLoc((pos){ i, j });
             if (cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_PASSABILITY)
-                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredterrainFlagsLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
+                && (!cellHasTMFlag(i, j, TM_IS_SECRET) || (discoveredTerrainFlagsAtLoc((pos){ i, j }) & T_OBSTRUCTS_PASSABILITY))) {
 
                 costMap[i][j] = cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_DIAGONAL_MOVEMENT) ? PDS_OBSTRUCTION : PDS_FORBIDDEN;
                 rogue.mapToSafeTerrain[i][j] = 30000; // OOS prophylactic

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -384,7 +384,7 @@ static void dialogCreateMonster() {
         if (theMonster->info.displayChar == G_TURRET && (!(pmapAt(selectedPosition)->layers[DUNGEON] == WALL))) {
             locationIsValid = false;
         }
-        if (!(theMonster->info.displayChar == G_TURRET) && cellHasTerrainFlag(selectedPosition.x, selectedPosition.y, T_OBSTRUCTS_PASSABILITY)) {
+        if (!(theMonster->info.displayChar == G_TURRET) && cellHasTerrainFlag(selectedPosition, T_OBSTRUCTS_PASSABILITY)) {
             locationIsValid = false;
         }
 


### PR DESCRIPTION
Almost all of the individual call-sites were refactored with a smart find+replace regex, so there shouldn't be any accidental typos.

Three functions have been refactored to take `pos` arguments instead of `short, short` coordinates:

- `terrainFlags`
- `terrainMechFlags`
- `cellHasTerrainFlag`