### PR TITLE
create `struct screenDisplayBuffer` type (`cellDisplayBuffer[COLS][ROWS] ---> screenDisplayBuffer`)

### DIFF
--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -38,7 +38,7 @@ short smoothHiliteGradient(const short currentXValue, const short maxXValue) {
 // Text is white, but can use color escapes.
 //      Hovering highlight augments fore and back colors with buttonHoverColor by 20%.
 //      Pressed darkens the middle color (or turns it the hover color if the button is black).
-void drawButton(brogueButton *button, enum buttonDrawStates highlight, cellDisplayBuffer dbuf[COLS][ROWS]) {
+void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDisplayBuffer *dbuf) {
     if (!(button->flags & B_DRAW)) {
         return;
     }
@@ -114,7 +114,7 @@ void drawButton(brogueButton *button, enum buttonDrawStates highlight, cellDispl
             plotCharToBuffer(displayCharacter, (windowpos){ button->x + i, button->y }, &fColor, &bColor, dbuf);
             if (dbuf) {
                 // Only buffers can have opacity set.
-                dbuf[button->x + i][button->y].opacity = opacity;
+                dbuf->cells[button->x + i][button->y].opacity = opacity;
             }
         }
     }
@@ -160,7 +160,7 @@ void drawButtonsInState(buttonState *state) {
     // Draw the buttons to the dbuf:
     for (int i=0; i < state->buttonCount; i++) {
         if (state->buttons[i].flags & B_DRAW) {
-            drawButton(&(state->buttons[i]), BUTTON_NORMAL, state->dbuf);
+            drawButton(&(state->buttons[i]), BUTTON_NORMAL, &state->dbuf);
         }
     }
 }
@@ -182,15 +182,15 @@ void initializeButtonState(buttonState *state,
     for (int i=0; i < state->buttonCount; i++) {
         state->buttons[i] = buttons[i];
     }
-    copyDisplayBuffer(state->rbuf, displayBuffer);
-    clearDisplayBuffer(state->dbuf);
+    copyDisplayBuffer(&state->rbuf, &displayBuffer);
+    clearDisplayBuffer(&state->dbuf);
 
     drawButtonsInState(state);
 
     // Clear the rbuf so that it resets only those parts of the screen in which buttons are drawn in the first place:
     for (int i=0; i<COLS; i++) {
         for (int j=0; j<ROWS; j++) {
-            state->rbuf[i][j].opacity = (state->dbuf[i][j].opacity ? 100 : 0);
+            state->rbuf.cells[i][j].opacity = (state->dbuf.cells[i][j].opacity ? 100 : 0);
         }
     }
 }
@@ -216,7 +216,7 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
 
         // Revert the button with old focus, if any.
         if (state->buttonFocused >= 0) {
-            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_NORMAL, state->dbuf);
+            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_NORMAL, &state->dbuf);
             state->buttonFocused = -1;
         }
 
@@ -242,11 +242,11 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
 
         if (state->buttonDepressed >= 0) {
             if (state->buttonDepressed == state->buttonFocused) {
-                drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_PRESSED, state->dbuf);
+                drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_PRESSED, &state->dbuf);
             }
         } else if (state->buttonFocused >= 0) {
             // If no button is depressed, then update the appearance of the button with the new focus, if any.
-            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_HOVER, state->dbuf);
+            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_HOVER, &state->dbuf);
         }
 
         // Mouseup:
@@ -257,7 +257,7 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
             } else {
                 // Otherwise, no button is depressed. If one was previously depressed, redraw it.
                 if (state->buttonDepressed >= 0) {
-                    drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_NORMAL, state->dbuf);
+                    drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_NORMAL, &state->dbuf);
                 } else if (!(x >= state->winX && x < state->winX + state->winWidth
                              && y >= state->winY && y < state->winY + state->winHeight)) {
                     // Clicking outside of a button means canceling.
@@ -268,7 +268,7 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
 
                 if (state->buttonFocused >= 0) {
                     // Buttons don't hover-highlight when one is depressed, so we have to fix that when the mouse is up.
-                    drawButton(&(state->buttons[state->buttonFocused]), BUTTON_HOVER, state->dbuf);
+                    drawButton(&(state->buttons[state->buttonFocused]), BUTTON_HOVER, &state->dbuf);
                 }
                 state->buttonDepressed = -1;
             }
@@ -287,20 +287,20 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
                     if (state->buttons[i].flags & B_DRAW) {
                         // Restore the depressed and focused buttons.
                         if (state->buttonDepressed >= 0) {
-                            drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_NORMAL, state->dbuf);
+                            drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_NORMAL, &state->dbuf);
                         }
                         if (state->buttonFocused >= 0) {
-                            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_NORMAL, state->dbuf);
+                            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_NORMAL, &state->dbuf);
                         }
 
                         // If the button likes to flash when keypressed:
                         if (state->buttons[i].flags & B_KEYPRESS_HIGHLIGHT) {
                             // Depress the chosen button.
-                            drawButton(&(state->buttons[i]), BUTTON_PRESSED, state->dbuf);
+                            drawButton(&(state->buttons[i]), BUTTON_PRESSED, &state->dbuf);
 
                             // Update the display.
-                            overlayDisplayBuffer(state->rbuf, NULL);
-                            overlayDisplayBuffer(state->dbuf, NULL);
+                            overlayDisplayBuffer(&state->rbuf, NULL);
+                            overlayDisplayBuffer(&state->dbuf, NULL);
 
                             if (!rogue.playbackMode || rogue.playbackPaused) {
                                 // Wait for a little; then we're done.
@@ -359,7 +359,7 @@ short buttonInputLoop(brogueButton *buttons,
 
     do {
         // Update the display.
-        overlayDisplayBuffer(state.dbuf, NULL);
+        overlayDisplayBuffer(&state.dbuf, NULL);
 
         // Get input.
         nextBrogueEvent(&theEvent, true, false, false);
@@ -368,7 +368,7 @@ short buttonInputLoop(brogueButton *buttons,
         button = processButtonInput(&state, &canceled, &theEvent);
 
         // Revert the display.
-        overlayDisplayBuffer(state.rbuf, NULL);
+        overlayDisplayBuffer(&state.rbuf, NULL);
 
     } while (button == -1 && !canceled);
 

--- a/src/brogue/GlobalsBase.c
+++ b/src/brogue/GlobalsBase.c
@@ -30,7 +30,7 @@
 tcell tmap[DCOLS][DROWS];                       // grids with info about the map
 pcell pmap[DCOLS][DROWS];
 short **scentMap;
-cellDisplayBuffer displayBuffer[COLS][ROWS];    // used to optimize plotCharWithColor
+screenDisplayBuffer displayBuffer;    // used to optimize plotCharWithColor
 short terrainRandomValues[DCOLS][DROWS][8];
 short **safetyMap;                              // used to help monsters flee
 short **allySafetyMap;                          // used to help allies flee

--- a/src/brogue/GlobalsBase.h
+++ b/src/brogue/GlobalsBase.h
@@ -46,7 +46,7 @@ static inline pos posNeighborInDirection(pos p, enum directions direction_to_ste
 }
 
 extern short **scentMap;
-extern cellDisplayBuffer displayBuffer[COLS][ROWS];
+extern screenDisplayBuffer displayBuffer;
 extern short terrainRandomValues[DCOLS][DROWS][8];
 extern short **safetyMap;                                       // used to help monsters flee
 extern short **allySafetyMap;

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -88,12 +88,13 @@ void hiliteGrid(short **grid, const color *hiliteColor, short hiliteStrength) {
                 x = mapToWindowX(i);
                 y = mapToWindowY(j);
 
-                displayBuffer[x][y].backColorComponents[0] = clamp(displayBuffer[x][y].backColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].backColorComponents[1] = clamp(displayBuffer[x][y].backColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].backColorComponents[2] = clamp(displayBuffer[x][y].backColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].foreColorComponents[0] = clamp(displayBuffer[x][y].foreColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].foreColorComponents[1] = clamp(displayBuffer[x][y].foreColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].foreColorComponents[2] = clamp(displayBuffer[x][y].foreColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
+                cellDisplayBuffer *cell = &displayBuffer.cells[x][y];
+                cell->backColorComponents[0] = clamp(cell->backColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
+                cell->backColorComponents[1] = clamp(cell->backColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
+                cell->backColorComponents[2] = clamp(cell->backColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
+                cell->foreColorComponents[0] = clamp(cell->foreColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
+                cell->foreColorComponents[1] = clamp(cell->foreColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
+                cell->foreColorComponents[2] = clamp(cell->foreColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
             }
         }
     }

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -174,7 +174,7 @@ static short actionMenu(short x, boolean playingBack) {
     brogueButton buttons[ROWS] = {{{0}}};
     char yellowColorEscape[5] = "", whiteColorEscape[5] = "", darkGrayColorEscape[5] = "";
     short i, j, longestName = 0, buttonChosen;
-    cellDisplayBuffer dbuf[COLS][ROWS], rbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf, rbuf;
 
     encodeMessageColor(yellowColorEscape, 0, &itemMessageColor);
     encodeMessageColor(whiteColorEscape, 0, &white);
@@ -406,11 +406,11 @@ static short actionMenu(short x, boolean playingBack) {
             }
         }
 
-        clearDisplayBuffer(dbuf);
-        rectangularShading(x - 1, y, longestName + 2, buttonCount, &black, INTERFACE_OPACITY / 2, dbuf);
-        overlayDisplayBuffer(dbuf, rbuf);
+        clearDisplayBuffer(&dbuf);
+        rectangularShading(x - 1, y, longestName + 2, buttonCount, &black, INTERFACE_OPACITY / 2, &dbuf);
+        overlayDisplayBuffer(&dbuf, &rbuf);
         buttonChosen = buttonInputLoop(buttons, buttonCount, x - 1, y, longestName + 2, buttonCount, NULL);
-        overlayDisplayBuffer(rbuf, NULL);
+        overlayDisplayBuffer(&rbuf, NULL);
         if (buttonChosen == -1) {
             return -1;
         } else if (takeActionOurselves[buttonChosen]) {
@@ -523,17 +523,17 @@ static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
                           1);
 
     for (i=0; i < 5; i++) {
-        drawButton(&(state->buttons[i]), BUTTON_NORMAL, state->rbuf);
+        drawButton(&(state->buttons[i]), BUTTON_NORMAL, &state->rbuf);
     }
     for (i=0; i<COLS; i++) { // So the buttons stay (but are dimmed and desaturated) when inactive.
-        tempColor = colorFromComponents(state->rbuf[i][ROWS - 1].backColorComponents);
+        tempColor = colorFromComponents(state->rbuf.cells[i][ROWS - 1].backColorComponents);
         desaturate(&tempColor, 60);
         applyColorAverage(&tempColor, &black, 50);
-        storeColorComponents(state->rbuf[i][ROWS - 1].backColorComponents, &tempColor);
-        tempColor = colorFromComponents(state->rbuf[i][ROWS - 1].foreColorComponents);
+        storeColorComponents(state->rbuf.cells[i][ROWS - 1].backColorComponents, &tempColor);
+        tempColor = colorFromComponents(state->rbuf.cells[i][ROWS - 1].foreColorComponents);
         desaturate(&tempColor, 60);
         applyColorAverage(&tempColor, &black, 50);
-        storeColorComponents(state->rbuf[i][ROWS - 1].foreColorComponents, &tempColor);
+        storeColorComponents(state->rbuf.cells[i][ROWS - 1].foreColorComponents, &tempColor);
     }
 }
 
@@ -545,7 +545,7 @@ void mainInputLoop() {
     pos path[1000];
     creature *monst;
     item *theItem;
-    cellDisplayBuffer rbuf[COLS][ROWS];
+    screenDisplayBuffer rbuf;
 
     boolean canceled, targetConfirmed, tabKey, focusedOnMonster, focusedOnItem, focusedOnTerrain,
     playingBack, doEvent, textDisplayed;
@@ -673,7 +673,7 @@ void mainInputLoop() {
 
                     focusedOnMonster = true;
                     if (monst != &player && (!player.status[STATUS_HALLUCINATING] || rogue.playbackOmniscience || player.status[STATUS_TELEPATHIC])) {
-                        printMonsterDetails(monst, rbuf);
+                        printMonsterDetails(monst, &rbuf);
                         textDisplayed = true;
                     }
                 } else if (theItem != NULL && playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y)) {
@@ -683,7 +683,7 @@ void mainInputLoop() {
 
                     focusedOnItem = true;
                     if (!player.status[STATUS_HALLUCINATING] || rogue.playbackOmniscience) {
-                        printFloorItemDetails(theItem, rbuf);
+                        printFloorItemDetails(theItem, &rbuf);
                         textDisplayed = true;
                     }
                 } else if (cellHasTMFlag(rogue.cursorLoc.x, rogue.cursorLoc.y, TM_LIST_IN_SIDEBAR) && playerCanSeeOrSense(rogue.cursorLoc.x, rogue.cursorLoc.y)) {
@@ -738,7 +738,7 @@ void mainInputLoop() {
                 focusedOnItem = false;
                 focusedOnTerrain = false;
                 if (textDisplayed) {
-                    overlayDisplayBuffer(rbuf, 0); // Erase the monster info window.
+                    overlayDisplayBuffer(&rbuf, NULL); // Erase the monster info window.
                 }
                 rogue.playbackMode = playingBack;
                 refreshSideBar(-1, -1, false);
@@ -853,15 +853,15 @@ void considerCautiousMode() {
 
 // previouslyPlottedCells is only accessed by commitDraws and refreshScreen,
 // as below.
-static cellDisplayBuffer previouslyPlottedCells[COLS][ROWS];
+static screenDisplayBuffer previouslyPlottedCells;
 
 // Only cells which have changed since the previous commitDraws are actually
 // drawn.
 void commitDraws() {
     for (int j = 0; j < ROWS; j++) {
         for (int i = 0; i < COLS; i++) {
-            cellDisplayBuffer *lastPlotted = &previouslyPlottedCells[i][j];
-            cellDisplayBuffer *curr = &displayBuffer[i][j];
+            cellDisplayBuffer *lastPlotted = &previouslyPlottedCells.cells[i][j];
+            cellDisplayBuffer *curr = &displayBuffer.cells[i][j];
             boolean needsUpdate =
                 lastPlotted->character != curr->character
                 || lastPlotted->foreColorComponents[0] != curr->foreColorComponents[0]
@@ -893,7 +893,7 @@ void commitDraws() {
 void refreshScreen() {
     for (int i = 0; i < COLS; i++) {
         for (int j = 0; j < ROWS; j++) {
-            cellDisplayBuffer *curr = &displayBuffer[i][j];
+            cellDisplayBuffer *curr = &displayBuffer.cells[i][j];
             plotChar(curr->character, i, j,
                      curr->foreColorComponents[0],
                      curr->foreColorComponents[1],
@@ -904,7 +904,7 @@ void refreshScreen() {
             );
             // Remember that it was previously plotted, so that
             // commitDraws still knows when it needs updates.
-            previouslyPlottedCells[i][j] = *curr;
+            previouslyPlottedCells.cells[i][j] = *curr;
         }
     }
 }
@@ -1365,7 +1365,7 @@ void getCellAppearance(short x, short y, enum displayGlyph *returnChar, color *r
 
     // Smooth out walls: if there's a "wall-ish" tile drawn below us, just draw the wall top
     if ((cellChar == G_WALL || cellChar == G_GRANITE) && coordinatesAreInMap(x, y+1)
-        && glyphIsWallish(displayBuffer[mapToWindowX(x)][mapToWindowY(y+1)].character)) {
+        && glyphIsWallish(displayBuffer.cells[mapToWindowX(x)][mapToWindowY(y+1)].character)) {
         cellChar = G_WALL_TOP;
     }
 
@@ -1647,8 +1647,8 @@ static void blendAppearances(const color *fromForeColor, const color *fromBackCo
     }
 }
 
-void irisFadeBetweenBuffers(cellDisplayBuffer fromBuf[COLS][ROWS],
-                            cellDisplayBuffer toBuf[COLS][ROWS],
+void irisFadeBetweenBuffers(screenDisplayBuffer* fromBuf,
+                            screenDisplayBuffer* toBuf,
                             short x, short y,
                             short frameCount,
                             boolean outsideIn) {
@@ -1694,13 +1694,13 @@ void irisFadeBetweenBuffers(cellDisplayBuffer fromBuf[COLS][ROWS],
             for (j=0; j<ROWS; j++) {
                 thisCellPercent = percentBasis * 3 / 100 + completionMap[i][j];
 
-                fromBackColor = colorFromComponents(fromBuf[i][j].backColorComponents);
-                fromForeColor = colorFromComponents(fromBuf[i][j].foreColorComponents);
-                fromChar = fromBuf[i][j].character;
+                fromBackColor = colorFromComponents(fromBuf->cells[i][j].backColorComponents);
+                fromForeColor = colorFromComponents(fromBuf->cells[i][j].foreColorComponents);
+                fromChar = fromBuf->cells[i][j].character;
 
-                toBackColor = colorFromComponents(toBuf[i][j].backColorComponents);
-                toForeColor = colorFromComponents(toBuf[i][j].foreColorComponents);
-                toChar = toBuf[i][j].character;
+                toBackColor = colorFromComponents(toBuf->cells[i][j].backColorComponents);
+                toForeColor = colorFromComponents(toBuf->cells[i][j].foreColorComponents);
+                toChar = toBuf->cells[i][j].character;
 
                 blendAppearances(&fromForeColor, &fromBackColor, fromChar, &toForeColor, &toBackColor, toChar, &currentForeColor, &currentBackColor, &currentChar, clamp(thisCellPercent, 0, 100));
                 plotCharWithColor(currentChar, (windowpos){ i, j }, &currentForeColor, &currentBackColor);
@@ -1807,7 +1807,7 @@ void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *
         inputChar = ' ';
     }
 
-    cellDisplayBuffer *target = &displayBuffer[loc.window_x][loc.window_y];
+    cellDisplayBuffer *target = &displayBuffer.cells[loc.window_x][loc.window_y];
     target->character = inputChar;
     target->foreColorComponents[0] = foreRed;
     target->foreColorComponents[1] = foreGreen;
@@ -1819,7 +1819,7 @@ void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *
     restoreRNG;
 }
 
-void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *foreColor, const color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]) {
+void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *foreColor, const color *backColor, screenDisplayBuffer *dbuf) {
     short oldRNG;
 
     if (!dbuf) {
@@ -1833,7 +1833,7 @@ void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *f
     rogue.RNG = RNG_COSMETIC;
     //assureCosmeticRNG;
 
-    cellDisplayBuffer* cell = &dbuf[loc.window_x][loc.window_y];
+    cellDisplayBuffer* cell = &dbuf->cells[loc.window_x][loc.window_y];
     cell->foreColorComponents[0] = foreColor->red + rand_range(0, foreColor->redRand) + rand_range(0, foreColor->rand);
     cell->foreColorComponents[1] = foreColor->green + rand_range(0, foreColor->greenRand) + rand_range(0, foreColor->rand);
     cell->foreColorComponents[2] = foreColor->blue + rand_range(0, foreColor->blueRand) + rand_range(0, foreColor->rand);
@@ -1910,12 +1910,13 @@ void hiliteCharGrid(char hiliteCharGrid[DCOLS][DROWS], const color *hiliteColor,
                 x = mapToWindowX(i);
                 y = mapToWindowY(j);
 
-                displayBuffer[x][y].backColorComponents[0] = clamp(displayBuffer[x][y].backColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].backColorComponents[1] = clamp(displayBuffer[x][y].backColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].backColorComponents[2] = clamp(displayBuffer[x][y].backColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].foreColorComponents[0] = clamp(displayBuffer[x][y].foreColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].foreColorComponents[1] = clamp(displayBuffer[x][y].foreColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
-                displayBuffer[x][y].foreColorComponents[2] = clamp(displayBuffer[x][y].foreColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
+                cellDisplayBuffer *cell = &displayBuffer.cells[x][y];
+                cell->backColorComponents[0] = clamp(cell->backColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
+                cell->backColorComponents[1] = clamp(cell->backColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
+                cell->backColorComponents[2] = clamp(cell->backColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
+                cell->foreColorComponents[0] = clamp(cell->foreColorComponents[0] + hCol.red * hiliteStrength / 100, 0, 100);
+                cell->foreColorComponents[1] = clamp(cell->foreColorComponents[1] + hCol.green * hiliteStrength / 100, 0, 100);
+                cell->foreColorComponents[2] = clamp(cell->foreColorComponents[2] + hCol.blue * hiliteStrength / 100, 0, 100);
             }
         }
     }
@@ -1942,27 +1943,21 @@ void colorOverDungeon(const color *color) {
     }
 }
 
-void copyDisplayBuffer(cellDisplayBuffer toBuf[COLS][ROWS], cellDisplayBuffer fromBuf[COLS][ROWS]) {
-    short i, j;
-
-    for (i=0; i<COLS; i++) {
-        for (j=0; j<ROWS; j++) {
-            toBuf[i][j] = fromBuf[i][j];
-        }
-    }
+void copyDisplayBuffer(screenDisplayBuffer *toBuf, screenDisplayBuffer *fromBuf) {
+    *toBuf = *fromBuf;
 }
 
-void clearDisplayBuffer(cellDisplayBuffer dbuf[COLS][ROWS]) {
+void clearDisplayBuffer(screenDisplayBuffer *dbuf) {
     short i, j, k;
 
     for (i=0; i<COLS; i++) {
         for (j=0; j<ROWS; j++) {
-            dbuf[i][j].character = ' ';
+            dbuf->cells[i][j].character = ' ';
             for (k=0; k<3; k++) {
-                dbuf[i][j].foreColorComponents[k] = 0;
-                dbuf[i][j].backColorComponents[k] = 0;
+                dbuf->cells[i][j].foreColorComponents[k] = 0;
+                dbuf->cells[i][j].backColorComponents[k] = 0;
             }
-            dbuf[i][j].opacity = 0;
+            dbuf->cells[i][j].opacity = 0;
         }
     }
 }
@@ -1977,34 +1972,34 @@ color colorFromComponents(char rgb[3]) {
 
 // draws overBuf over the current display with per-cell pseudotransparency as specified in overBuf.
 // If previousBuf is not null, it gets filled with the preexisting display for reversion purposes.
-void overlayDisplayBuffer(cellDisplayBuffer overBuf[COLS][ROWS], cellDisplayBuffer previousBuf[COLS][ROWS]) {
+void overlayDisplayBuffer(screenDisplayBuffer *overBuf, screenDisplayBuffer *previousBuf) {
     short i, j;
     color foreColor, backColor, tempColor;
     enum displayGlyph character;
 
     if (previousBuf) {
-        copyDisplayBuffer(previousBuf, displayBuffer);
+        copyDisplayBuffer(previousBuf, &displayBuffer);
     }
 
     for (i=0; i<COLS; i++) {
         for (j=0; j<ROWS; j++) {
 
-            if (overBuf[i][j].opacity != 0) {
-                backColor = colorFromComponents(overBuf[i][j].backColorComponents);
+            if (overBuf->cells[i][j].opacity != 0) {
+                backColor = colorFromComponents(overBuf->cells[i][j].backColorComponents);
 
                 // character and fore color:
-                if (overBuf[i][j].character == ' ') { // Blank cells in the overbuf take the character from the screen.
-                    character = displayBuffer[i][j].character;
-                    foreColor = colorFromComponents(displayBuffer[i][j].foreColorComponents);
-                    applyColorAverage(&foreColor, &backColor, overBuf[i][j].opacity);
+                if (overBuf->cells[i][j].character == ' ') { // Blank cells in the overbuf take the character from the screen.
+                    character = displayBuffer.cells[i][j].character;
+                    foreColor = colorFromComponents(displayBuffer.cells[i][j].foreColorComponents);
+                    applyColorAverage(&foreColor, &backColor, overBuf->cells[i][j].opacity);
                 } else {
-                    character = overBuf[i][j].character;
-                    foreColor = colorFromComponents(overBuf[i][j].foreColorComponents);
+                    character = overBuf->cells[i][j].character;
+                    foreColor = colorFromComponents(overBuf->cells[i][j].foreColorComponents);
                 }
 
                 // back color:
-                tempColor = colorFromComponents(displayBuffer[i][j].backColorComponents);
-                applyColorAverage(&backColor, &tempColor, 100 - overBuf[i][j].opacity);
+                tempColor = colorFromComponents(displayBuffer.cells[i][j].backColorComponents);
+                applyColorAverage(&backColor, &tempColor, 100 - overBuf->cells[i][j].opacity);
 
                 plotCharWithColor(character, (windowpos){ i, j }, &foreColor, &backColor);
             }
@@ -2124,7 +2119,7 @@ void colorFlash(const color *theColor, unsigned long reqTerrainFlags,
 #define bCurve(x)   (((x) * (x) + 11) / (10 * ((x) * (x) + 1)) - 0.1)
 
 // x and y are global coordinates, not within the playing square
-void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart,
+void funkyFade(screenDisplayBuffer *displayBuf, const color *colorStart,
                const color *colorEnd, short stepCount, short x, short y, boolean invert) {
     short i, j, n, weight;
     double x2, y2, weightGrid[COLS][ROWS][3], percentComplete;
@@ -2183,9 +2178,9 @@ void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart
 
                 backColor = black;
 
-                backColor.red = displayBuf[i][j].backColorComponents[0];
-                backColor.green = displayBuf[i][j].backColorComponents[1];
-                backColor.blue = displayBuf[i][j].backColorComponents[2];
+                backColor.red = displayBuf->cells[i][j].backColorComponents[0];
+                backColor.green = displayBuf->cells[i][j].backColorComponents[1];
+                backColor.blue = displayBuf->cells[i][j].backColorComponents[2];
 
                 foreColor = (invert ? white : black);
 
@@ -2194,11 +2189,11 @@ void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart
                     && i < mapToWindowX(strLenWithoutEscapes(displayedMessage[MESSAGE_LINES - j - 1]))) {
                     tempChar = displayedMessage[MESSAGE_LINES - j - 1][windowToMapX(i)];
                 } else {
-                    tempChar = displayBuf[i][j].character;
+                    tempChar = displayBuf->cells[i][j].character;
 
-                    foreColor.red = displayBuf[i][j].foreColorComponents[0];
-                    foreColor.green = displayBuf[i][j].foreColorComponents[1];
-                    foreColor.blue = displayBuf[i][j].foreColorComponents[2];
+                    foreColor.red = displayBuf->cells[i][j].foreColorComponents[0];
+                    foreColor.green = displayBuf->cells[i][j].foreColorComponents[1];
+                    foreColor.blue = displayBuf->cells[i][j].foreColorComponents[2];
 
                     applyColorAverage(&foreColor, &tempColor, weight);
                 }
@@ -2682,8 +2677,8 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             break;
         case SEED_KEY:
             /*DEBUG {
-                cellDisplayBuffer dbuf[COLS][ROWS];
-                copyDisplayBuffer(dbuf, displayBuffer);
+                screenDisplayBuffer dbuf;
+                copyDisplayBuffer(&dbuf, &displayBuffer);
                 funkyFade(dbuf, &white, 0, 100, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
             }*/
             // DEBUG displayLoops();
@@ -2739,16 +2734,17 @@ boolean getInputTextString(char *inputText,
     short charNum, i, x, y;
     char keystroke, suffix[100];
     const short textEntryBounds[TEXT_INPUT_TYPES][2] = {{' ', '~'}, {' ', '~'}, {'0', '9'}};
-    cellDisplayBuffer dbuf[COLS][ROWS], rbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
+    screenDisplayBuffer rbuf;
 
     // x and y mark the origin for text entry.
     if (useDialogBox) {
         x = (COLS - max(maxLength, strLenWithoutEscapes(prompt))) / 2;
         y = ROWS / 2 - 1;
-        clearDisplayBuffer(dbuf);
+        clearDisplayBuffer(&dbuf);
         rectangularShading(x - 1, y - 2, max(maxLength, strLenWithoutEscapes(prompt)) + 2,
-                           4, &interfaceBoxColor, INTERFACE_OPACITY, dbuf);
-        overlayDisplayBuffer(dbuf, rbuf);
+                           4, &interfaceBoxColor, INTERFACE_OPACITY, &dbuf);
+        overlayDisplayBuffer(&dbuf, &rbuf);
         printString(prompt, x, y - 1, &white, &interfaceBoxColor, NULL);
         for (i=0; i<maxLength; i++) {
             plotCharWithColor(' ', (windowpos){ x + i, y }, &black, &black);
@@ -2828,7 +2824,7 @@ boolean getInputTextString(char *inputText,
     } while (keystroke != RETURN_KEY && keystroke != ESCAPE_KEY);
 
     if (useDialogBox) {
-        overlayDisplayBuffer(rbuf, NULL);
+        overlayDisplayBuffer(&rbuf, NULL);
     }
 
     inputText[charNum] = '\0';
@@ -2867,8 +2863,8 @@ void flashMessage(char *message, short x, short y, int time, const color *fColor
     fastForward = false;
 
     for (j=0; j<messageLength; j++) {
-        backColors[j] = colorFromComponents(displayBuffer[j + x][y].backColorComponents);
-        dbufs[j] = displayBuffer[j + x][y];
+        backColors[j] = colorFromComponents(displayBuffer.cells[j + x][y].backColorComponents);
+        dbufs[j] = displayBuffer.cells[j + x][y];
     }
 
     previousPercentComplete = -1;
@@ -2878,8 +2874,8 @@ void flashMessage(char *message, short x, short y, int time, const color *fColor
         if (previousPercentComplete != percentComplete) {
             for (j=0; j<messageLength; j++) {
                 if (i==0) {
-                    backColors[j] = colorFromComponents(displayBuffer[j + x][y].backColorComponents);
-                    dbufs[j] = displayBuffer[j + x][y];
+                    backColors[j] = colorFromComponents(displayBuffer.cells[j + x][y].backColorComponents);
+                    dbufs[j] = displayBuffer.cells[j + x][y];
                 }
                 backColor = backColors[j];
                 applyColorAverage(&backColor, bColor, 100 - percentComplete);
@@ -2936,7 +2932,7 @@ void waitForKeystrokeOrMouseClick() {
 boolean confirm(char *prompt, boolean alsoDuringPlayback) {
     short retVal;
     brogueButton buttons[2] = {{{0}}};
-    cellDisplayBuffer rbuf[COLS][ROWS];
+    screenDisplayBuffer rbuf;
     char whiteColorEscape[20] = "";
     char yellowColorEscape[20] = "";
 
@@ -2962,8 +2958,8 @@ boolean confirm(char *prompt, boolean alsoDuringPlayback) {
     buttons[1].hotkey[3] = ESCAPE_KEY;
     buttons[1].flags |= (B_WIDE_CLICK_AREA | B_KEYPRESS_HIGHLIGHT);
 
-    retVal = printTextBox(prompt, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, rbuf, buttons, 2);
-    overlayDisplayBuffer(rbuf, NULL);
+    retVal = printTextBox(prompt, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, &rbuf, buttons, 2);
+    overlayDisplayBuffer(&rbuf, NULL);
 
     if (retVal == -1 || retVal == 1) { // If they canceled or pressed no.
         return false;
@@ -3224,29 +3220,29 @@ void displayRecentMessages() {
 // offset: index of oldest (visually highest) message to draw
 // height: height in rows of the message archive display area
 // rbuf: background display buffer to draw against
-static void drawMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
+static void drawMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, screenDisplayBuffer *rbuf) {
     int i, j, k, fadePercent;
-    cellDisplayBuffer dbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
 
-    clearDisplayBuffer(dbuf);
+    clearDisplayBuffer(&dbuf);
 
     for (i = 0; (MESSAGE_ARCHIVE_LINES - offset + i) < MESSAGE_ARCHIVE_LINES && i < ROWS && i < height; i++) {
-        printString(messages[MESSAGE_ARCHIVE_LINES - offset + i], mapToWindowX(0), i, &white, &black, dbuf);
+        printString(messages[MESSAGE_ARCHIVE_LINES - offset + i], mapToWindowX(0), i, &white, &black, &dbuf);
 
         // Set the dbuf opacity, and do a fade from bottom to top to make it clear that the bottom messages are the most recent.
         fadePercent = 50 * (length - offset + i) / length + 50;
         for (j = 0; j < DCOLS; j++) {
-            dbuf[mapToWindowX(j)][i].opacity = INTERFACE_OPACITY;
-            if (dbuf[mapToWindowX(j)][i].character != ' ') {
+            dbuf.cells[mapToWindowX(j)][i].opacity = INTERFACE_OPACITY;
+            if (dbuf.cells[mapToWindowX(j)][i].character != ' ') {
                 for (k=0; k<3; k++) {
-                    dbuf[mapToWindowX(j)][i].foreColorComponents[k] = dbuf[mapToWindowX(j)][i].foreColorComponents[k] * fadePercent / 100;
+                    dbuf.cells[mapToWindowX(j)][i].foreColorComponents[k] = dbuf.cells[mapToWindowX(j)][i].foreColorComponents[k] * fadePercent / 100;
                 }
             }
         }
     }
 
-    overlayDisplayBuffer(rbuf, 0);
-    overlayDisplayBuffer(dbuf, 0);
+    overlayDisplayBuffer(rbuf, NULL);
+    overlayDisplayBuffer(&dbuf, NULL);
 }
 
 // Pull-down/pull-up animation.
@@ -3256,7 +3252,7 @@ static void drawMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], sho
 // offset: index of oldest (visually highest) message to draw in the fully expanded state
 // height: height in rows of the message archive display area in the fully expanded state
 // rbuf: background display buffer to draw against
-static void animateMessageArchive(boolean opening, char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
+static void animateMessageArchive(boolean opening, char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, screenDisplayBuffer *rbuf) {
     short i;
     boolean fastForward;
 
@@ -3284,7 +3280,7 @@ static void animateMessageArchive(boolean opening, char messages[MESSAGE_ARCHIVE
 // rbuf: background display buffer to draw against
 //
 // returns the new offset, which can change if the player scrolled around before closing
-static short scrollMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, cellDisplayBuffer rbuf[COLS][ROWS]) {
+static short scrollMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], short length, short offset, short height, screenDisplayBuffer *rbuf) {
     short lastOffset;
     boolean exit;
     rogueEvent theEvent;
@@ -3350,7 +3346,7 @@ static short scrollMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], 
 
 void displayMessageArchive() {
     short length, offset, height;
-    cellDisplayBuffer rbuf[COLS][ROWS];
+    screenDisplayBuffer rbuf;
     char messageBuffer[MESSAGE_ARCHIVE_LINES][COLS*2];
 
     formatRecentMessages(messageBuffer, MESSAGE_ARCHIVE_LINES, &length, 0);
@@ -3362,13 +3358,13 @@ void displayMessageArchive() {
     height = min(length, MESSAGE_ARCHIVE_VIEW_LINES);
     offset = height;
 
-    copyDisplayBuffer(rbuf, displayBuffer);
+    copyDisplayBuffer(&rbuf, &displayBuffer);
 
-    animateMessageArchive(true, messageBuffer, length, offset, height, rbuf);
-    offset = scrollMessageArchive(messageBuffer, length, offset, height, rbuf);
-    animateMessageArchive(false, messageBuffer, length, offset, height, rbuf);
+    animateMessageArchive(true, messageBuffer, length, offset, height, &rbuf);
+    offset = scrollMessageArchive(messageBuffer, length, offset, height, &rbuf);
+    animateMessageArchive(false, messageBuffer, length, offset, height, &rbuf);
 
-    overlayDisplayBuffer(rbuf, 0);
+    overlayDisplayBuffer(&rbuf, NULL);
     updateFlavorText();
     confirmMessages();
     updateMessageDisplay();
@@ -3902,7 +3898,7 @@ void refreshSideBar(short focusX, short focusY, boolean focusedEntityMustGoFirst
     restoreRNG;
 }
 
-void printString(const char *theString, short x, short y, const color *foreColor, const color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]) {
+void printString(const char *theString, short x, short y, const color *foreColor, const color *backColor, screenDisplayBuffer *dbuf) {
     short i;
 
     color fColor = *foreColor;
@@ -4009,7 +4005,7 @@ short wrapText(char *to, const char *sourceText, short width) {
 
 // returns the y-coordinate of the last line
 short printStringWithWrapping(const char *theString, short x, short y, short width, const color *foreColor,
-                              const color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]) {
+                              const color *backColor, screenDisplayBuffer *dbuf) {
     color fColor;
     char printString[TEXT_MAX_LENGTH];
     short i, px, py;
@@ -4056,7 +4052,8 @@ char nextKeyPress(boolean textInput) {
 
 void printHelpScreen() {
     short i, j;
-    cellDisplayBuffer dbuf[COLS][ROWS], rbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
+    screenDisplayBuffer rbuf;
     char helpText[BROGUE_HELP_LINE_COUNT][DCOLS*3] = {
         "",
         "",
@@ -4102,30 +4099,30 @@ void printHelpScreen() {
         }
     }
 
-    clearDisplayBuffer(dbuf);
+    clearDisplayBuffer(&dbuf);
 
     // Print the text to the dbuf.
     for (i=0; i<BROGUE_HELP_LINE_COUNT && i < ROWS; i++) {
-        printString(helpText[i], mapToWindowX(1), i, &itemMessageColor, &black, dbuf);
+        printString(helpText[i], mapToWindowX(1), i, &itemMessageColor, &black, &dbuf);
     }
 
     // Set the dbuf opacity.
     for (i=0; i<DCOLS; i++) {
         for (j=0; j<ROWS; j++) {
             //plotCharWithColor(' ', (windowpos) { mapToWindowX(i), j }, &black, &black);
-            dbuf[mapToWindowX(i)][j].opacity = INTERFACE_OPACITY;
+            dbuf.cells[mapToWindowX(i)][j].opacity = INTERFACE_OPACITY;
         }
     }
 
     // Display.
-    overlayDisplayBuffer(dbuf, rbuf);
+    overlayDisplayBuffer(&dbuf, &rbuf);
     waitForAcknowledgment();
-    overlayDisplayBuffer(rbuf, 0);
+    overlayDisplayBuffer(&rbuf, NULL);
     updateFlavorText();
     updateMessageDisplay();
 }
 
-static void printDiscoveries(short category, short count, unsigned short itemCharacter, short x, short y, cellDisplayBuffer dbuf[COLS][ROWS]) {
+static void printDiscoveries(short category, short count, unsigned short itemCharacter, short x, short y, screenDisplayBuffer *dbuf) {
     color goodColor, badColor;
     const color *theColor;
     char buf[COLS], buf2[COLS];
@@ -4175,38 +4172,39 @@ static void printDiscoveries(short category, short count, unsigned short itemCha
 
 void printDiscoveriesScreen() {
     short i, j, y;
-    cellDisplayBuffer dbuf[COLS][ROWS], rbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
+    screenDisplayBuffer rbuf;
 
-    clearDisplayBuffer(dbuf);
+    clearDisplayBuffer(&dbuf);
 
-    printString("-- SCROLLS --", mapToWindowX(2), y = mapToWindowY(1), &flavorTextColor, &black, dbuf);
-    printDiscoveries(SCROLL, gameConst->numberScrollKinds, G_SCROLL, mapToWindowX(3), ++y, dbuf);
+    printString("-- SCROLLS --", mapToWindowX(2), y = mapToWindowY(1), &flavorTextColor, &black, &dbuf);
+    printDiscoveries(SCROLL, gameConst->numberScrollKinds, G_SCROLL, mapToWindowX(3), ++y, &dbuf);
 
-    printString("-- RINGS --", mapToWindowX(2), y += gameConst->numberScrollKinds + 1, &flavorTextColor, &black, dbuf);
-    printDiscoveries(RING, NUMBER_RING_KINDS, G_RING, mapToWindowX(3), ++y, dbuf);
+    printString("-- RINGS --", mapToWindowX(2), y += gameConst->numberScrollKinds + 1, &flavorTextColor, &black, &dbuf);
+    printDiscoveries(RING, NUMBER_RING_KINDS, G_RING, mapToWindowX(3), ++y, &dbuf);
 
-    printString("-- POTIONS --", mapToWindowX(29), y = mapToWindowY(1), &flavorTextColor, &black, dbuf);
-    printDiscoveries(POTION, gameConst->numberPotionKinds, G_POTION, mapToWindowX(30), ++y, dbuf);
+    printString("-- POTIONS --", mapToWindowX(29), y = mapToWindowY(1), &flavorTextColor, &black, &dbuf);
+    printDiscoveries(POTION, gameConst->numberPotionKinds, G_POTION, mapToWindowX(30), ++y, &dbuf);
 
-    printString("-- STAFFS --", mapToWindowX(53), y = mapToWindowY(1), &flavorTextColor, &black, dbuf);
-    printDiscoveries(STAFF, NUMBER_STAFF_KINDS, G_STAFF, mapToWindowX(54), ++y, dbuf);
+    printString("-- STAFFS --", mapToWindowX(53), y = mapToWindowY(1), &flavorTextColor, &black, &dbuf);
+    printDiscoveries(STAFF, NUMBER_STAFF_KINDS, G_STAFF, mapToWindowX(54), ++y, &dbuf);
 
-    printString("-- WANDS --", mapToWindowX(53), y += NUMBER_STAFF_KINDS + 1, &flavorTextColor, &black, dbuf);
-    printDiscoveries(WAND, gameConst->numberWandKinds, G_WAND, mapToWindowX(54), ++y, dbuf);
+    printString("-- WANDS --", mapToWindowX(53), y += NUMBER_STAFF_KINDS + 1, &flavorTextColor, &black, &dbuf);
+    printDiscoveries(WAND, gameConst->numberWandKinds, G_WAND, mapToWindowX(54), ++y, &dbuf);
 
     printString(KEYBOARD_LABELS ? "-- press any key to continue --" : "-- touch anywhere to continue --",
-                mapToWindowX(20), mapToWindowY(DROWS-2), &itemMessageColor, &black, dbuf);
+                mapToWindowX(20), mapToWindowY(DROWS-2), &itemMessageColor, &black, &dbuf);
 
     for (i=0; i<COLS; i++) {
         for (j=0; j<ROWS; j++) {
-            dbuf[i][j].opacity = (i < STAT_BAR_WIDTH ? 0 : INTERFACE_OPACITY);
+            dbuf.cells[i][j].opacity = (i < STAT_BAR_WIDTH ? 0 : INTERFACE_OPACITY);
         }
     }
-    overlayDisplayBuffer(dbuf, rbuf);
+    overlayDisplayBuffer(&dbuf, &rbuf);
 
     waitForKeystrokeOrMouseClick();
 
-    overlayDisplayBuffer(rbuf, NULL);
+    overlayDisplayBuffer(&rbuf, NULL);
 }
 
 void printHighScores(boolean hiliteMostRecent) {
@@ -4390,13 +4388,13 @@ void printProgressBar(short x, short y, const char barLabel[COLS], long amtFille
 void highlightScreenCell(short x, short y, const color *highlightColor, short strength) {
     color tempColor;
 
-    tempColor = colorFromComponents(displayBuffer[x][y].foreColorComponents);
+    tempColor = colorFromComponents(displayBuffer.cells[x][y].foreColorComponents);
     applyColorAugment(&tempColor, highlightColor, strength);
-    storeColorComponents(displayBuffer[x][y].foreColorComponents, &tempColor);
+    storeColorComponents(displayBuffer.cells[x][y].foreColorComponents, &tempColor);
 
-    tempColor = colorFromComponents(displayBuffer[x][y].backColorComponents);
+    tempColor = colorFromComponents(displayBuffer.cells[x][y].backColorComponents);
     applyColorAugment(&tempColor, highlightColor, strength);
-    storeColorComponents(displayBuffer[x][y].backColorComponents, &tempColor);
+    storeColorComponents(displayBuffer.cells[x][y].backColorComponents, &tempColor);
 }
 
 // Like `armorValueIfUnenchanted` for the currently-equipped armor, but takes the penalty from
@@ -4874,24 +4872,24 @@ short printTerrainInfo(short x, short y, short py, const char *description, bool
 }
 
 void rectangularShading(short x, short y, short width, short height,
-                        const color *backColor, short opacity, cellDisplayBuffer dbuf[COLS][ROWS]) {
+                        const color *backColor, short opacity, screenDisplayBuffer* dbuf) {
     short i, j, dist;
 
     assureCosmeticRNG;
     for (i=0; i<COLS; i++) {
         for (j=0; j<ROWS; j++) {
-            storeColorComponents(dbuf[i][j].backColorComponents, backColor);
+            storeColorComponents(dbuf->cells[i][j].backColorComponents, backColor);
 
             if (i >= x && i < x + width
                 && j >= y && j < y + height) {
-                dbuf[i][j].opacity = min(100, opacity);
+                dbuf->cells[i][j].opacity = min(100, opacity);
             } else {
                 dist = 0;
                 dist += max(0, max(x - i, i - x - width + 1));
                 dist += max(0, max(y - j, j - y - height + 1));
-                dbuf[i][j].opacity = (int) ((opacity - 10) / max(1, dist));
-                if (dbuf[i][j].opacity < 3) {
-                    dbuf[i][j].opacity = 0;
+                dbuf->cells[i][j].opacity = (int) ((opacity - 10) / max(1, dist));
+                if (dbuf->cells[i][j].opacity < 3) {
+                    dbuf->cells[i][j].opacity = 0;
                 }
             }
         }
@@ -4920,9 +4918,9 @@ void rectangularShading(short x, short y, short width, short height,
 // (Returns -1 for canceled; otherwise the button index number.)
 short printTextBox(char *textBuf, short x, short y, short width,
                    const color *foreColor, const color *backColor,
-                   cellDisplayBuffer rbuf[COLS][ROWS],
+                   screenDisplayBuffer *rbuf,
                    brogueButton *buttons, short buttonCount) {
-    cellDisplayBuffer dbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
 
     short x2, y2, lineCount, i, bx, by, padLines;
 
@@ -4979,10 +4977,10 @@ short printTextBox(char *textBuf, short x, short y, short width,
         padLines = 0;
     }
 
-    clearDisplayBuffer(dbuf);
-    printStringWithWrapping(textBuf, x2, y2, width, foreColor, backColor, dbuf);
-    rectangularShading(x2, y2, width, lineCount + padLines, backColor, INTERFACE_OPACITY, dbuf);
-    overlayDisplayBuffer(dbuf, rbuf);
+    clearDisplayBuffer(&dbuf);
+    printStringWithWrapping(textBuf, x2, y2, width, foreColor, backColor, &dbuf);
+    rectangularShading(x2, y2, width, lineCount + padLines, backColor, INTERFACE_OPACITY, &dbuf);
+    overlayDisplayBuffer(&dbuf, rbuf);
 
     if (buttonCount > 0) {
         return buttonInputLoop(buttons, buttonCount, x2, y2, width, by - y2 + 1 + padLines, NULL);
@@ -4991,7 +4989,7 @@ short printTextBox(char *textBuf, short x, short y, short width,
     }
 }
 
-void printMonsterDetails(creature *monst, cellDisplayBuffer rbuf[COLS][ROWS]) {
+void printMonsterDetails(creature *monst, screenDisplayBuffer *rbuf) {
     char textBuf[COLS * 100];
 
     monsterDetails(textBuf, monst);
@@ -5004,7 +5002,7 @@ void printMonsterDetails(creature *monst, cellDisplayBuffer rbuf[COLS][ROWS]) {
 unsigned long printCarriedItemDetails(item *theItem,
                                       short x, short y, short width,
                                       boolean includeButtons,
-                                      cellDisplayBuffer rbuf[COLS][ROWS]) {
+                                      screenDisplayBuffer *rbuf) {
     char textBuf[COLS * 100], goldColorEscape[5] = "", whiteColorEscape[5] = "";
     brogueButton buttons[20] = {{{0}}};
     short b;
@@ -5086,7 +5084,7 @@ unsigned long printCarriedItemDetails(item *theItem,
 }
 
 // Returns true if an action was taken.
-void printFloorItemDetails(item *theItem, cellDisplayBuffer rbuf[COLS][ROWS]) {
+void printFloorItemDetails(item *theItem, screenDisplayBuffer *rbuf) {
     char textBuf[COLS * 100];
 
     itemDetails(textBuf, theItem);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2702,8 +2702,8 @@ char displayInventory(unsigned short categoryMask,
     rogueEvent theEvent;
     boolean magicDetected, repeatDisplay;
     short highlightItemLine, itemSpaceRemaining;
-    cellDisplayBuffer dbuf[COLS][ROWS];
-    cellDisplayBuffer rbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
+    screenDisplayBuffer rbuf;
     brogueButton buttons[50] = {{{0}}};
     short actionKey = -1;
     color darkItemColor;
@@ -2719,7 +2719,7 @@ char displayInventory(unsigned short categoryMask,
     assureCosmeticRNG;
 
     clearCursorPath();
-    clearDisplayBuffer(dbuf);
+    clearDisplayBuffer(&dbuf);
 
     whiteColorEscapeSequence[0] = '\0';
     encodeMessageColor(whiteColorEscapeSequence, 0, &white);
@@ -2917,7 +2917,7 @@ char displayInventory(unsigned short categoryMask,
 
         // Display the button. This would be redundant with the button loop,
         // except that we want the display to stick around until we get rid of it.
-        drawButton(&(buttons[i]), BUTTON_NORMAL, dbuf);
+        drawButton(&(buttons[i]), BUTTON_NORMAL, &dbuf);
     }
 
     // Add invisible previous and next buttons, so up and down arrows can select items.
@@ -2930,14 +2930,14 @@ char displayInventory(unsigned short categoryMask,
     buttons[itemNumber + extraLineCount + 1].hotkey[0] = NUMPAD_2;
     buttons[itemNumber + extraLineCount + 1].hotkey[1] = DOWN_ARROW;
 
-    overlayDisplayBuffer(dbuf, rbuf);
+    overlayDisplayBuffer(&dbuf, &rbuf);
 
     do {
         repeatDisplay = false;
 
         // Do the button loop.
         highlightItemLine = -1;
-        overlayDisplayBuffer(rbuf, NULL);   // Remove the inventory display while the buttons are active,
+        overlayDisplayBuffer(&rbuf, NULL);   // Remove the inventory display while the buttons are active,
                                             // since they look the same and we don't want their opacities to stack.
 
         highlightItemLine = buttonInputLoop(buttons,
@@ -2970,7 +2970,7 @@ char displayInventory(unsigned short categoryMask,
             do {
                 // Yes. Highlight the selected item. Do this by changing the button color and re-displaying it.
 
-                overlayDisplayBuffer(dbuf, NULL);
+                overlayDisplayBuffer(&dbuf, NULL);
 
                 //buttons[highlightItemLine].buttonColor = interfaceBoxColor;
                 drawButton(&(buttons[highlightItemLine]), BUTTON_PRESSED, NULL);
@@ -2980,15 +2980,15 @@ char displayInventory(unsigned short categoryMask,
                     // Display an information window about the item.
                     actionKey = printCarriedItemDetails(theItem, max(2, mapToWindowX(DCOLS - maxLength - 42)), mapToWindowY(2), 40, includeButtons, NULL);
 
-                    overlayDisplayBuffer(rbuf, NULL); // remove the item info window
+                    overlayDisplayBuffer(&rbuf, NULL); // remove the item info window
 
                     if (actionKey == -1) {
                         repeatDisplay = true;
-                        overlayDisplayBuffer(dbuf, NULL); // redisplay the inventory
+                        overlayDisplayBuffer(&dbuf, NULL); // redisplay the inventory
                     } else {
                         restoreRNG;
                         repeatDisplay = false;
-                        overlayDisplayBuffer(rbuf, NULL); // restore the original screen
+                        overlayDisplayBuffer(&rbuf, NULL); // restore the original screen
                     }
 
                     switch (actionKey) {
@@ -3042,7 +3042,7 @@ char displayInventory(unsigned short categoryMask,
         }
     } while (repeatDisplay); // so you can get info on multiple items sequentially
 
-    overlayDisplayBuffer(rbuf, NULL); // restore the original screen
+    overlayDisplayBuffer(&rbuf, NULL); // restore the original screen
 
     restoreRNG;
     return theKey;
@@ -5260,7 +5260,7 @@ boolean moveCursor(boolean *targetConfirmed,
         if (state) { // Also running a button loop.
 
             // Update the display.
-            overlayDisplayBuffer(state->dbuf, NULL);
+            overlayDisplayBuffer(&state->dbuf, NULL);
 
             // Get input.
             nextBrogueEvent(&theEvent, false, colorsDance, true);
@@ -5274,7 +5274,7 @@ boolean moveCursor(boolean *targetConfirmed,
             }
 
             // Revert the display.
-            overlayDisplayBuffer(state->rbuf, NULL);
+            overlayDisplayBuffer(&state->rbuf, NULL);
 
         } else { // No buttons to worry about.
             nextBrogueEvent(&theEvent, false, colorsDance, true);

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -2094,7 +2094,7 @@ boolean proposeOrConfirmLocation(short x, short y, char *failureMessage) {
 
 boolean useStairs(short stairDirection) {
     boolean succeeded = false;
-    //cellDisplayBuffer fromBuf[COLS][ROWS], toBuf[COLS][ROWS];
+    //screenDisplayBuffer fromBuf, toBuf;
 
     if (stairDirection == 1) {
         if (rogue.depthLevel < gameConst->deepestLevel) {

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -302,7 +302,7 @@ If this is a different computer from the one on which the recording was saved, t
 might succeed on the original computer."
 
 static void playbackPanic() {
-    cellDisplayBuffer rbuf[COLS][ROWS];
+    screenDisplayBuffer rbuf;
 
     if (!rogue.playbackOOS) {
         rogue.playbackFastForward = false;
@@ -316,13 +316,13 @@ static void playbackPanic() {
         confirmMessages();
         message("Playback is out of sync.", 0);
 
-        printTextBox(OOS_APOLOGY, 0, 0, 0, &white, &black, rbuf, NULL, 0);
+        printTextBox(OOS_APOLOGY, 0, 0, 0, &white, &black, &rbuf, NULL, 0);
 
         rogue.playbackMode = false;
         displayMoreSign();
         rogue.playbackMode = true;
 
-        overlayDisplayBuffer(rbuf, 0);
+        overlayDisplayBuffer(&rbuf, NULL);
 
         if (nonInteractivePlayback) {
             rogue.gameHasEnded = true;
@@ -330,7 +330,7 @@ static void playbackPanic() {
         rogue.gameExitStatusCode = EXIT_STATUS_FAILURE_RECORDING_OOS;
 
         printf("Playback panic at location %li! Turn number %li.\n", recordingLocation - 1, rogue.playerTurnNumber);
-        overlayDisplayBuffer(rbuf, 0);
+        overlayDisplayBuffer(&rbuf, NULL);
 
         mainInputLoop();
     }
@@ -432,7 +432,7 @@ static void loadNextAnnotation() {
 }
 
 void displayAnnotation() {
-    cellDisplayBuffer rbuf[COLS][ROWS];
+    screenDisplayBuffer rbuf;
 
     if (rogue.playbackMode
         && rogue.playerTurnNumber == rogue.nextAnnotationTurn) {
@@ -440,13 +440,13 @@ void displayAnnotation() {
         if (!rogue.playbackFastForward) {
             refreshSideBar(-1, -1, false);
 
-            printTextBox(rogue.nextAnnotation, player.loc.x, 0, 0, &black, &white, rbuf, NULL, 0);
+            printTextBox(rogue.nextAnnotation, player.loc.x, 0, 0, &black, &white, &rbuf, NULL, 0);
 
             rogue.playbackMode = false;
             displayMoreSign();
             rogue.playbackMode = true;
 
-            overlayDisplayBuffer(rbuf, 0);
+            overlayDisplayBuffer(&rbuf, NULL);
         }
 
         loadNextAnnotation();
@@ -638,7 +638,8 @@ static boolean unpause() {
 
 static void printPlaybackHelpScreen() {
     short i, j;
-    cellDisplayBuffer dbuf[COLS][ROWS], rbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
+    screenDisplayBuffer rbuf;
     char helpText[PLAYBACK_HELP_LINE_COUNT][80] = {
         "Commands:",
         "",
@@ -671,23 +672,23 @@ static void printPlaybackHelpScreen() {
         }
     }
 
-    clearDisplayBuffer(dbuf);
+    clearDisplayBuffer(&dbuf);
 
     for (i=0; i<PLAYBACK_HELP_LINE_COUNT; i++) {
-        printString(helpText[i], mapToWindowX(5), mapToWindowY(i), &itemMessageColor, &black, dbuf);
+        printString(helpText[i], mapToWindowX(5), mapToWindowY(i), &itemMessageColor, &black, &dbuf);
     }
 
     for (i=0; i<COLS; i++) {
         for (j=0; j<ROWS; j++) {
-            dbuf[i][j].opacity = (i < STAT_BAR_WIDTH ? 0 : INTERFACE_OPACITY);
+            dbuf.cells[i][j].opacity = (i < STAT_BAR_WIDTH ? 0 : INTERFACE_OPACITY);
         }
     }
-    overlayDisplayBuffer(dbuf, rbuf);
+    overlayDisplayBuffer(&dbuf, &rbuf);
 
     rogue.playbackMode = false;
     waitForAcknowledgment();
     rogue.playbackMode = true;
-    overlayDisplayBuffer(rbuf, NULL);
+    overlayDisplayBuffer(&rbuf, NULL);
 }
 
 static void resetPlayback() {
@@ -716,7 +717,7 @@ static void seek(unsigned long seekTarget, enum recordingSeekModes seekMode) {
     unsigned long progressBarRefreshInterval = 1, startTurnNumber = 0, targetTurnNumber = 0, avgTurnsPerLevel = 1;
     rogueEvent theEvent;
     boolean pauseState, useProgressBar = false, arrivedAtDestination = false;
-    cellDisplayBuffer dbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
 
     pauseState = rogue.playbackPaused;
 
@@ -762,9 +763,9 @@ static void seek(unsigned long seekTarget, enum recordingSeekModes seekMode) {
     }
 
     if (useProgressBar) {
-        clearDisplayBuffer(dbuf);
-        rectangularShading((COLS - 20) / 2, ROWS / 2, 20, 1, &black, INTERFACE_OPACITY, dbuf);
-        overlayDisplayBuffer(dbuf, 0);
+        clearDisplayBuffer(&dbuf);
+        rectangularShading((COLS - 20) / 2, ROWS / 2, 20, 1, &black, INTERFACE_OPACITY, &dbuf);
+        overlayDisplayBuffer(&dbuf, NULL);
         commitDraws();
     }
     rogue.playbackFastForward = true;
@@ -1337,7 +1338,7 @@ boolean loadSavedGame() {
     unsigned long previousRecordingLocation;
     rogueEvent theEvent;
 
-    cellDisplayBuffer dbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
 
     randomNumbersGenerated = 0;
     rogue.playbackMode = true;
@@ -1352,10 +1353,10 @@ boolean loadSavedGame() {
 
         progressBarInterval = max(1, lengthOfPlaybackFile / 100);
         previousRecordingLocation = -1; // unsigned
-        clearDisplayBuffer(dbuf);
-        rectangularShading((COLS - 20) / 2, ROWS / 2, 20, 1, &black, INTERFACE_OPACITY, dbuf);
+        clearDisplayBuffer(&dbuf);
+        rectangularShading((COLS - 20) / 2, ROWS / 2, 20, 1, &black, INTERFACE_OPACITY, &dbuf);
         rogue.playbackFastForward = false;
-        overlayDisplayBuffer(dbuf, 0);
+        overlayDisplayBuffer(&dbuf, NULL);
         rogue.playbackFastForward = true;
 
         while (recordingLocation < lengthOfPlaybackFile

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1287,6 +1287,10 @@ typedef struct cellDisplayBuffer {
     char opacity;
 } cellDisplayBuffer;
 
+typedef struct screenDisplayBuffer {
+    cellDisplayBuffer cells[COLS][ROWS];
+} screenDisplayBuffer;
+
 typedef struct pcell {                              // permanent cell; have to remember this stuff to save levels
     enum tileType layers[NUMBER_TERRAIN_LAYERS];    // terrain
     unsigned long flags;                            // non-terrain cell flags
@@ -2779,8 +2783,8 @@ typedef struct buttonState {
     short winHeight;
 
     // Graphical buffers:
-    cellDisplayBuffer dbuf[COLS][ROWS]; // Where buttons are drawn.
-    cellDisplayBuffer rbuf[COLS][ROWS]; // Reversion screen state.
+    screenDisplayBuffer dbuf; // Where buttons are drawn.
+    screenDisplayBuffer rbuf; // Reversion screen state.
 } buttonState;
 
 enum messageFlags {
@@ -2906,19 +2910,19 @@ extern "C" {
     short printItemInfo(item *theItem, short y, boolean dim, boolean highlight);
     short printTerrainInfo(short x, short y, short py, const char *description, boolean dim, boolean highlight);
     void rectangularShading(short x, short y, short width, short height,
-                            const color *backColor, short opacity, cellDisplayBuffer dbuf[COLS][ROWS]);
+                            const color *backColor, short opacity, screenDisplayBuffer *dbuf);
     short printTextBox(char *textBuf, short x, short y, short width,
                        const color *foreColor, const color *backColor,
-                       cellDisplayBuffer rbuf[COLS][ROWS],
+                       screenDisplayBuffer *rbuf,
                        brogueButton *buttons, short buttonCount);
     void setButtonText(brogueButton *button, const char *textWithHotkey, const char *textWithoutHotkey);
-    void printMonsterDetails(creature *monst, cellDisplayBuffer rbuf[COLS][ROWS]);
-    void printFloorItemDetails(item *theItem, cellDisplayBuffer rbuf[COLS][ROWS]);
+    void printMonsterDetails(creature *monst, screenDisplayBuffer* rbuf);
+    void printFloorItemDetails(item *theItem, screenDisplayBuffer* rbuf);
     unsigned long printCarriedItemDetails(item *theItem,
                                           short x, short y, short width,
                                           boolean includeButtons,
-                                          cellDisplayBuffer rbuf[COLS][ROWS]);
-    void funkyFade(cellDisplayBuffer displayBuf[COLS][ROWS], const color *colorStart, const color *colorEnd, short stepCount, short x, short y, boolean invert);
+                                          screenDisplayBuffer* rbuf);
+    void funkyFade(screenDisplayBuffer *displayBuf, const color *colorStart, const color *colorEnd, short stepCount, short x, short y, boolean invert);
     void displayCenteredAlert(char *message);
     void flashMessage(char *message, short x, short y, int time, const color *fColor, const color *bColor);
     void flashTemporaryAlert(char *message, int time);
@@ -2935,8 +2939,8 @@ extern "C" {
     void desaturate(color *baseColor, short weight);
     void randomizeColor(color *baseColor, short randomizePercent);
     void swapColors(color *color1, color *color2);
-    void irisFadeBetweenBuffers(cellDisplayBuffer fromBuf[COLS][ROWS],
-                                cellDisplayBuffer toBuf[COLS][ROWS],
+    void irisFadeBetweenBuffers(screenDisplayBuffer *fromBuf,
+                                screenDisplayBuffer *toBuf,
                                 short x, short y,
                                 short frameCount,
                                 boolean outsideIn);
@@ -2944,24 +2948,24 @@ extern "C" {
     void hiliteCell(short x, short y, const color *hiliteColor, short hiliteStrength, boolean distinctColors);
     void colorMultiplierFromDungeonLight(short x, short y, color *editColor);
     void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *cellForeColor, const color *cellBackColor);
-    void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *foreColor, const color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]);
+    void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *foreColor, const color *backColor, screenDisplayBuffer *dbuf);
     void plotForegroundChar(enum displayGlyph inputChar, short x, short y, const color *foreColor, boolean affectedByLighting);
     void commitDraws(void);
     void dumpLevelToScreen(void);
     void hiliteCharGrid(char hiliteCharGrid[DCOLS][DROWS], const color *hiliteColor, short hiliteStrength);
     void blackOutScreen(void);
     void colorOverDungeon(const color *color);
-    void copyDisplayBuffer(cellDisplayBuffer toBuf[COLS][ROWS], cellDisplayBuffer fromBuf[COLS][ROWS]);
-    void clearDisplayBuffer(cellDisplayBuffer dbuf[COLS][ROWS]);
+    void copyDisplayBuffer(screenDisplayBuffer *toBuf, screenDisplayBuffer *fromBuf);
+    void clearDisplayBuffer(screenDisplayBuffer *dbuf);
     color colorFromComponents(char rgb[3]);
-    void overlayDisplayBuffer(cellDisplayBuffer overBuf[COLS][ROWS], cellDisplayBuffer previousBuf[COLS][ROWS]);
+    void overlayDisplayBuffer(screenDisplayBuffer *overBuf, screenDisplayBuffer *previousBuf);
     void flashForeground(short *x, short *y, const color **flashColor, short *flashStrength, short count, short frames);
     void flashCell(const color *theColor, short frames, short x, short y);
     void colorFlash(const color *theColor, unsigned long reqTerrainFlags, unsigned long reqTileFlags, short frames, short maxRadius, short x, short y);
-    void printString(const char *theString, short x, short y, const color *foreColor, const color* backColor, cellDisplayBuffer dbuf[COLS][ROWS]);
+    void printString(const char *theString, short x, short y, const color *foreColor, const color* backColor, screenDisplayBuffer *dbuf);
     short wrapText(char *to, const char *sourceText, short width);
     short printStringWithWrapping(const char *theString, short x, short y, short width, const color *foreColor,
-                                  const color *backColor, cellDisplayBuffer dbuf[COLS][ROWS]);
+                                  const color *backColor, screenDisplayBuffer *dbuf);
     boolean getInputTextString(char *inputText,
                                const char *prompt,
                                short maxLength,
@@ -3436,7 +3440,7 @@ extern "C" {
                                short winHeight);
     short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event);
     short smoothHiliteGradient(const short currentXValue, const short maxXValue);
-    void drawButton(brogueButton *button, enum buttonDrawStates highlight, cellDisplayBuffer dbuf[COLS][ROWS]);
+    void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDisplayBuffer* dbuf);
     short buttonInputLoop(brogueButton *buttons,
                           short buttonCount,
                           short winX,

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -990,7 +990,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     short i, y;
     char buf[200], highScoreText[200], buf2[200];
     rogueHighScoresEntry theEntry;
-    cellDisplayBuffer dbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
     boolean playback;
     rogueEvent theEvent;
     item *theItem;
@@ -1077,8 +1077,8 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     if (rogue.quit) {
         blackOutScreen();
     } else {
-        copyDisplayBuffer(dbuf, displayBuffer);
-        funkyFade(dbuf, &black, 0, 120, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
+        copyDisplayBuffer(&dbuf, &displayBuffer);
+        funkyFade(&dbuf, &black, 0, 120, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
     }
 
     if (useCustomPhrasing) {
@@ -1163,7 +1163,7 @@ void victory(boolean superVictory) {
     unsigned long totalValue = 0;
     rogueHighScoresEntry theEntry;
     boolean qualified, isPlayback;
-    cellDisplayBuffer dbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
     char recordingFilename[BROGUE_FILENAME_MAX] = {0};
 
     rogue.gameInProgress = false;
@@ -1179,22 +1179,22 @@ void victory(boolean superVictory) {
     //
     if (superVictory) {
         message(    "Light streams through the portal, and you are teleported out of the dungeon.", 0);
-        copyDisplayBuffer(dbuf, displayBuffer);
-        funkyFade(dbuf, &superVictoryColor, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
+        copyDisplayBuffer(&dbuf, &displayBuffer);
+        funkyFade(&dbuf, &superVictoryColor, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
         displayMoreSign();
         printString("Congratulations; you have transcended the Dungeons of Doom!                 ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
         displayMoreSign();
-        clearDisplayBuffer(dbuf);
+        clearDisplayBuffer(&dbuf);
         deleteMessages();
         strcpy(displayedMessage[0], "You retire in splendor, forever renowned for your remarkable triumph.     ");
     } else {
         message(    "You are bathed in sunlight as you throw open the heavy doors.", 0);
-        copyDisplayBuffer(dbuf, displayBuffer);
-        funkyFade(dbuf, &white, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
+        copyDisplayBuffer(&dbuf, &displayBuffer);
+        funkyFade(&dbuf, &white, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
         displayMoreSign();
         printString("Congratulations; you have escaped from the Dungeons of Doom!     ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
         displayMoreSign();
-        clearDisplayBuffer(dbuf);
+        clearDisplayBuffer(&dbuf);
         deleteMessages();
         strcpy(displayedMessage[0], "You sell your treasures and live out your days in fame and glory.");
     }
@@ -1202,12 +1202,12 @@ void victory(boolean superVictory) {
     //
     // Second screen - Show inventory and item's value
     //
-    printString(displayedMessage[0], mapToWindowX(0), mapToWindowY(-1), &white, &black, dbuf);
+    printString(displayedMessage[0], mapToWindowX(0), mapToWindowY(-1), &white, &black, &dbuf);
 
-    plotCharToBuffer(G_GOLD, mapToWindow((pos){ 2, 1 }), &yellow, &black, dbuf);
-    printString("Gold", mapToWindowX(4), mapToWindowY(1), &white, &black, dbuf);
+    plotCharToBuffer(G_GOLD, mapToWindow((pos){ 2, 1 }), &yellow, &black, &dbuf);
+    printString("Gold", mapToWindowX(4), mapToWindowY(1), &white, &black, &dbuf);
     sprintf(buf, "%li", rogue.gold);
-    printString(buf, mapToWindowX(60), mapToWindowY(1), &itemMessageColor, &black, dbuf);
+    printString(buf, mapToWindowX(60), mapToWindowY(1), &itemMessageColor, &black, &dbuf);
     totalValue += rogue.gold;
 
     for (i = 4, theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
@@ -1215,10 +1215,10 @@ void victory(boolean superVictory) {
             gemCount += theItem->quantity;
         }
         if (theItem->category == AMULET && superVictory) {
-            plotCharToBuffer(G_AMULET, (windowpos){ mapToWindowX(2), min(ROWS-1, i + 1) }, &yellow, &black, dbuf);
-            printString("The Birthright of Yendor", mapToWindowX(4), min(ROWS-1, i + 1), &itemMessageColor, &black, dbuf);
+            plotCharToBuffer(G_AMULET, (windowpos){ mapToWindowX(2), min(ROWS-1, i + 1) }, &yellow, &black, &dbuf);
+            printString("The Birthright of Yendor", mapToWindowX(4), min(ROWS-1, i + 1), &itemMessageColor, &black, &dbuf);
             sprintf(buf, "%li", max(0, itemValue(theItem) * 2));
-            printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &itemMessageColor, &black, dbuf);
+            printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &itemMessageColor, &black, &dbuf);
             totalValue += max(0, itemValue(theItem) * 2);
             i++;
         } else {
@@ -1226,12 +1226,12 @@ void victory(boolean superVictory) {
             itemName(theItem, buf, true, true, &white);
             upperCase(buf);
 
-            plotCharToBuffer(theItem->displayChar, (windowpos){ mapToWindowX(2), min(ROWS-1, i + 1) }, &yellow, &black, dbuf);
-            printString(buf, mapToWindowX(4), min(ROWS-1, i + 1), &white, &black, dbuf);
+            plotCharToBuffer(theItem->displayChar, (windowpos){ mapToWindowX(2), min(ROWS-1, i + 1) }, &yellow, &black, &dbuf);
+            printString(buf, mapToWindowX(4), min(ROWS-1, i + 1), &white, &black, &dbuf);
 
             if (itemValue(theItem) > 0) {
                 sprintf(buf, "%li", max(0, itemValue(theItem)));
-                printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &itemMessageColor, &black, dbuf);
+                printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &itemMessageColor, &black, &dbuf);
             }
 
             totalValue += max(0, itemValue(theItem));
@@ -1239,11 +1239,11 @@ void victory(boolean superVictory) {
         }
     }
     i++;
-    printString("TOTAL:", mapToWindowX(2), min(ROWS-1, i + 1), &lightBlue, &black, dbuf);
+    printString("TOTAL:", mapToWindowX(2), min(ROWS-1, i + 1), &lightBlue, &black, &dbuf);
     sprintf(buf, "%li", totalValue);
-    printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &lightBlue, &black, dbuf);
+    printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &lightBlue, &black, &dbuf);
 
-    funkyFade(dbuf, &white, 0, 120, COLS/2, ROWS/2, true);
+    funkyFade(&dbuf, &white, 0, 120, COLS/2, ROWS/2, true);
     displayMoreSign();
 
     //

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -43,7 +43,8 @@ static short dialogSelectEntryFromList(
 ) {
 
     short x=0, y=0, width=0, height=0;
-    cellDisplayBuffer dbuf[COLS][ROWS], rbuf[COLS][ROWS];
+    screenDisplayBuffer dbuf;
+    screenDisplayBuffer rbuf;
     short i, selectedButton, len, maxLen;
     char buttonText[COLS];
 
@@ -70,18 +71,18 @@ static short dialogSelectEntryFromList(
     height = buttonCount + 2;
     x = WINDOW_POSITION_DUNGEON_TOP_LEFT.window_x;
     y = WINDOW_POSITION_DUNGEON_TOP_LEFT.window_y;
-    clearDisplayBuffer(dbuf);
+    clearDisplayBuffer(&dbuf);
 
     //Dialog Title
-    printString(windowTitle, x , y - 1, &itemMessageColor, &interfaceBoxColor, dbuf);
+    printString(windowTitle, x , y - 1, &itemMessageColor, &interfaceBoxColor, &dbuf);
     //Dialog background
-    rectangularShading(x - 1, y - 1, width + 1, height + 1, &interfaceBoxColor, INTERFACE_OPACITY, dbuf);
+    rectangularShading(x - 1, y - 1, width + 1, height + 1, &interfaceBoxColor, INTERFACE_OPACITY, &dbuf);
     //Display the title/background and save the prior display state
-    overlayDisplayBuffer(dbuf, rbuf);
+    overlayDisplayBuffer(&dbuf, &rbuf);
     //Display the buttons and wait for user selection
     selectedButton = buttonInputLoop(buttons, buttonCount, x, y, width, height, NULL);
     //Revert the display state
-    overlayDisplayBuffer(rbuf, NULL);
+    overlayDisplayBuffer(&rbuf, NULL);
 
     return selectedButton;
 }


### PR DESCRIPTION
Before this change, most of the time, a `cellDisplayBuffer buf[COLS][ROWS]` was created wherever needed. Now, you can spell this as `screenDisplayBuffer buf;`

There are a few ways that this is nicer:
- The new type remembers the correct size for the buffer, so it doesn't have to be written down `[COLS][ROWS]` every time
- The new type is a _struct_ instead of an _array_, so it has more-consistent semantics: no pointer decay; taking references is explicit instead of implicit, etc.

This PR just swaps out all of the existing `cellDisplayBuffer` arrays to references to this new type. There's no other changes.

---

Eventually, I'd like to refactor a bit more, so that the screen is more "encapsulated" - references to `.cells` should be restricted to a handful of functions, so that the screen buffer can become a higher-level data structure (e.g. we could eventually store info about "layers" or "effects" to make the view prettier on platforms that support it). Having a consistent "screen" type is an important basic step to make that happen.