### PR TITLE
Fix unused function and missing prototype warnings

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2237,6 +2237,7 @@ static void displayWaypoints() {
         }
     }
     temporaryMessage("Waypoints:", REQUIRE_ACKNOWLEDGMENT);
+    displayLevel();
 }
 
 static void displayMachines() {
@@ -2270,14 +2271,14 @@ static void displayMachines() {
             }
         }
     }
-    displayMoreSign();
+    temporaryMessage("Machines:", REQUIRE_ACKNOWLEDGMENT);
     displayLevel();
 
     restoreRNG;
 }
 
 #define CHOKEMAP_DISPLAY_CUTOFF 160
-void displayChokeMap() {
+static void displayChokeMap() {
     short i, j;
     color foreColor, backColor;
     enum displayGlyph dchar;
@@ -2298,11 +2299,11 @@ void displayChokeMap() {
             }
         }
     }
-    displayMoreSign();
+    temporaryMessage("Choke map:", REQUIRE_ACKNOWLEDGMENT);
     displayLevel();
 }
 
-void displayLoops() {
+static void displayLoops() {
     short i, j;
     color foreColor, backColor;
     enum displayGlyph dchar;
@@ -2322,7 +2323,8 @@ void displayLoops() {
             }
         }
     }
-    waitForAcknowledgment();
+    temporaryMessage("Loops:", REQUIRE_ACKNOWLEDGMENT);
+    displayLevel();
 }
 
 static void exploreKey(const boolean controlKey) {
@@ -2686,10 +2688,14 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
                 copyDisplayBuffer(dbuf, displayBuffer);
                 funkyFade(dbuf, &white, 0, 100, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
             }*/
-            // DEBUG displayLoops();
-            // DEBUG displayChokeMap();
+            DEBUG displayLoops();
+            DEBUG displayChokeMap();
             DEBUG displayMachines();
-            //DEBUG displayWaypoints();
+            DEBUG displayWaypoints();
+            
+#ifdef LOG_LIGHTS
+            logLights();
+#endif
             // DEBUG {displayGrid(safetyMap); displayMoreSign(); displayLevel();}
             // parseFile();
             // DEBUG spawnDungeonFeature(player.loc.x, player.loc.y, &dungeonFeatureCatalog[DF_METHANE_GAS_ARMAGEDDON], true, false);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -6831,7 +6831,7 @@ static void magicMapCell(short x, short y) {
     }
 }
 
-boolean uncurse( item *theItem ) {
+static boolean uncurse( item *theItem ) {
     if (theItem->flags & ITEM_CURSED) {
         theItem->flags &= ~ITEM_CURSED;
         return true;

--- a/src/brogue/Light.c
+++ b/src/brogue/Light.c
@@ -25,8 +25,7 @@
 #include "GlobalsBase.h"
 #include "Globals.h"
 
-static void logLights() {
-
+void logLights() {
     short i, j;
 
     printf("    ");

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -69,6 +69,12 @@
 #define D_MESSAGE_ITEM_GENERATION       (rogue.wizard && 0)
 #define D_MESSAGE_MACHINE_GENERATION    (rogue.wizard && 0)
 
+// If enabled, runs a benchmark for the performance of repeatedly updating the screen at the start of the game.
+// #define SCREEN_UPDATE_BENCHMARK
+
+// If enabled, logs the light values when '~' is pressed.
+// #define LOG_LIGHTS
+
 // set to false to allow multiple loads from the same saved file:
 #define DELETE_SAVE_FILE_AFTER_LOADING  true
 
@@ -2870,7 +2876,7 @@ extern "C" {
                          boolean superpriority);
     boolean spawnDungeonFeature(short x, short y, dungeonFeature *feat, boolean refreshCell, boolean abortIfBlocking);
     void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit);
-    void restoreItems();
+    void restoreItems(void);
     void refreshWaypoint(short wpIndex);
     void setUpWaypoints(void);
     void zeroOutGrid(char grid[DCOLS][DROWS]);
@@ -2969,8 +2975,6 @@ extern "C" {
                                const char *promptSuffix,
                                short textEntryType,
                                boolean useDialogBox);
-    void displayChokeMap(void);
-    void displayLoops(void);
     boolean pauseBrogue(short milliseconds);
     boolean pauseAnimation(short milliseconds);
     void nextBrogueEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance, boolean realInputEvenInPlayback);
@@ -3337,6 +3341,7 @@ extern "C" {
     void displayCombatText(void);
     void flashMonster(creature *monst, const color *theColor, short strength);
 
+    void logLights(void);
     boolean paintLight(const lightSource *theLight, short x, short y, boolean isMinersLight, boolean maintainShadows);
     void backUpLighting(short lights[DCOLS][DROWS][3]);
     void restoreLighting(short lights[DCOLS][DROWS][3]);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -112,7 +112,8 @@ boolean openFile(const char *path) {
     return retval;
 }
 
-static void benchmark() {
+#ifdef SCREEN_UPDATE_BENCHMARK
+static void screen_update_benchmark() {
     short i, j, k;
     const color sparklesauce = {10, 0, 20,  60, 40, 100, 30, true};
     enum displayGlyph theChar;
@@ -127,8 +128,9 @@ static void benchmark() {
         }
         pauseBrogue(1);
     }
-    printf("\n\nBenchmark took a total of %lu seconds.", ((unsigned long) time(NULL)) - initialTime);
+    printf("\n\nBenchmark took a total of %lu seconds.\n", ((unsigned long) time(NULL)) - initialTime);
 }
+#endif
 
 static void welcome() {
     char buf[DCOLS*3], buf2[DCOLS*3];
@@ -206,7 +208,9 @@ void initializeRogue(uint64_t seed) {
         previousGameSeed = rogue.seed;
     }
 
-    //benchmark();
+#ifdef SCREEN_UPDATE_BENCHMARK
+    screen_update_benchmark();
+#endif
 
     initRecording();
 


### PR DESCRIPTION
Some of these warnings were directly introduced in #593; others are due to other PRs that were merged between when I made that PR and when it was merged.

Some of these are fixed with new `#define`s; this also makes `displayLoops` and `displayChokeMap` static and always runs them in wizard mode when '~' is pressed, along with `displayMachines` and `displayWaypoints`. This also improves those functions a bit, so it's easier to tell which output is from which function.