### PR TITLE
Adding guarding on --print-seed-catalog so it won't exceed the deepestLevel

### DIFF
--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -109,6 +109,7 @@ typedef long long fixpt;
 #define SCREENSHOT_SUFFIX       ".png"
 
 #define BROGUE_FILENAME_MAX     (min(1024*4, FILENAME_MAX))
+#define ERROR_MESSAGE_LENGTH    100
 
 // Date format used when listing recordings and high scores
 #define DATE_FORMAT             "%Y-%m-%d" // see strftime() documentation
@@ -2833,6 +2834,7 @@ extern "C" {
     boolean chooseFile(char *path, char *prompt, char *defaultName, char *suffix);
     boolean openFile(const char *path);
     void initializeGameVariant(void);
+    int deepestLevelForGameVariant(void);
     void initializeRogue(uint64_t seed);
     void gameOver(char *killedBy, boolean useCustomPhrasing);
     void victory(boolean superVictory);
@@ -3440,7 +3442,7 @@ extern "C" {
     int quitImmediately(void);
     void dialogAlert(char *message);
     void mainBrogueJunction(void);
-    void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat);
+    int printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat, char *errorMessage);
 
     void initializeButton(brogueButton *button);
     void drawButtonsInState(buttonState *state);

--- a/src/brogue/SeedCatalog.c
+++ b/src/brogue/SeedCatalog.c
@@ -251,13 +251,23 @@ static void printSeedCatalogAltars(boolean isCsvFormat) {
     }
 }
 
-void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth,
-                      boolean isCsvFormat) {
+int printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth,
+                     boolean isCsvFormat, char *errorMessage) {
     uint64_t theSeed;
     char message[1000] = "";
     rogue.nextGame = NG_NOTHING;
 
     initializeGameVariant();
+
+    if (startingSeed == 0) {
+        strncpy(errorMessage, "Starting seed must be 1+", ERROR_MESSAGE_LENGTH);
+        return 1;
+    }
+
+    if (scanThroughDepth == 0 || scanThroughDepth > gameConst->deepestLevel) {
+        snprintf(errorMessage, ERROR_MESSAGE_LENGTH, "Depth must be between 1 and %d", gameConst->deepestLevel);
+        return 1;
+    }
 
     sprintf(message, "Brogue seed catalog, seeds %llu to %llu, through depth %u.\n"
                      "Generated with %s. Dungeons unchanged since %s.\n\n"
@@ -303,5 +313,5 @@ void printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsig
 
         freeEverything();
     }
-
+    return 0;
 }

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -52,9 +52,13 @@ static void printCommandlineHelp() {
     return;
 }
 
-static void badArgument(const char *arg) {
-    printf("Bad argument: %s\n\n", arg);
+static void cliError(const char *prefix, const char *errorMsg) {
+    printf("%s%s\n\n", prefix, errorMsg);
     printCommandlineHelp();
+}
+
+static void badArgument(const char *arg) {
+    cliError("Bad argument: ", arg);
 }
 
 boolean tryParseUint64(char *str, uint64_t *num) {
@@ -195,20 +199,33 @@ int main(int argc, char *argv[])
         }
 
         if (strcmp(argv[i], "--print-seed-catalog") == 0) {
-            if (i + 3 < argc) {
-                uint64_t startingSeed, numberOfSeeds;
-                // Use converter for the type the next size up, because it returns signed
-                unsigned int numberOfLevels = atol(argv[i + 3]);
+            uint64_t startingSeed, numberOfSeeds;
+            int numberOfLevels;
 
-                if (tryParseUint64(argv[i+1], &startingSeed) && tryParseUint64(argv[i+2], &numberOfSeeds)
-                        && startingSeed > 0 && numberOfLevels <= 40) {
-                    printSeedCatalog(startingSeed, numberOfSeeds, numberOfLevels, isCsvFormat);
-                    return 0;
+            if (i + 3 < argc) {
+                numberOfLevels = atoi(argv[i + 3]);
+                if (!tryParseUint64(argv[i+1], &startingSeed)) {
+                    cliError("Bad params for seed catalog, starting seed: ", argv[i+1]);
+                    return 1;
+                }
+                if (!tryParseUint64(argv[i+2], &numberOfSeeds)) {
+                    cliError("Bad params for seed catalog, number of seeds: ", argv[i+2]);
+                    return 1;
                 }
             } else {
-                printSeedCatalog(1, 1000, 5, isCsvFormat);
-                return 0;
+                startingSeed = 1;
+                numberOfSeeds = 1000;
+                numberOfLevels = 5;
             }
+
+            int errorCode;
+            char errorMessage[ERROR_MESSAGE_LENGTH];
+
+            errorCode = printSeedCatalog(startingSeed, numberOfSeeds, numberOfLevels, isCsvFormat, errorMessage);
+            if (errorCode) {
+                cliError("Bad params for seed catalog, ", errorMessage);
+            }
+            return errorCode;
         }
 
         if (strcmp(argv[i], "-V") == 0 || strcmp(argv[i], "--version") == 0) {


### PR DESCRIPTION
Previously --print-seed-catalog could exceed the max depth of shorter variants. `printSeedCatalog` now returns an `errorCode` and writes to an `errorMessage`.
