### PR TITLE
Fix staff/wand display on discovered items screen

### DIFF
--- a/changes/discovered-items-bug.md
+++ b/changes/discovered-items-bug.md
@@ -1,0 +1,1 @@
+Staves and wands that affect allies are now displayed correctly on the discovered items screen.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -7290,7 +7290,7 @@ short magicCharDiscoverySuffix(short category, short kind) {
             break;
         case WAND:
         case STAFF:
-            if (boltCatalog[tableForItemCategory(category)[kind].strengthRequired].flags & (BF_TARGET_ALLIES)) {
+            if (boltCatalog[tableForItemCategory(category)[kind].power].flags & (BF_TARGET_ALLIES)) {
                 result = -1;
             } else {
                 result = 1;


### PR DESCRIPTION
Fixes #623.

This issue was caused by #552 and the corresponding change for staves.