### PR TITLE
Ensuring recording buffer is always flushed even with no recording file

### DIFF
--- a/src/brogue/GlobalsBase.c
+++ b/src/brogue/GlobalsBase.c
@@ -64,7 +64,7 @@ char displayDetail[DCOLS][DROWS];       // used to make certain per-cell data ac
 FILE *RNGLogFile;
 #endif
 
-unsigned char inputRecordBuffer[INPUT_RECORD_BUFFER + 100];
+unsigned char inputRecordBuffer[INPUT_RECORD_BUFFER_MAX_SIZE];
 unsigned short locationInRecordingBuffer;
 unsigned long randomNumbersGenerated;
 unsigned long positionInPlaybackFile;

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -41,8 +41,12 @@ enum recordingSeekModes {
 };
 
 static void recordChar(unsigned char c) {
-    inputRecordBuffer[locationInRecordingBuffer++] = c;
-    recordingLocation++;
+    if (locationInRecordingBuffer < INPUT_RECORD_BUFFER_MAX_SIZE) {
+        inputRecordBuffer[locationInRecordingBuffer++] = c;
+        recordingLocation++;
+    } else {
+        printf("Recording buffer length exceeded at location %li! Turn number %li.\n", recordingLocation - 1, rogue.playerTurnNumber);
+    }
 }
 
 static void considerFlushingBufferToFile() {
@@ -217,34 +221,31 @@ static void writeHeaderInfo(char *path) {
 }
 
 void flushBufferToFile() {
-    if (currentFilePath[0] == '\0') {
-        return;
-    }
-
-    short i;
-    FILE *recordFile;
-
     if (rogue.playbackMode) {
         return;
     }
 
-    lengthOfPlaybackFile += locationInRecordingBuffer;
-    writeHeaderInfo(currentFilePath);
+    if (!currentFilePath[0] == '\0') {
+        short i;
+        FILE *recordFile;
 
-    if (locationInRecordingBuffer != 0) {
+        lengthOfPlaybackFile += locationInRecordingBuffer;
+        writeHeaderInfo(currentFilePath);
 
-        recordFile = fopen(currentFilePath, "ab");
+        if (locationInRecordingBuffer != 0) {
 
-        for (i=0; i<locationInRecordingBuffer; i++) {
-            putc(inputRecordBuffer[i], recordFile);
+            recordFile = fopen(currentFilePath, "ab");
+
+            for (i=0; i<locationInRecordingBuffer; i++) {
+                putc(inputRecordBuffer[i], recordFile);
+            }
+
+            if (recordFile) {
+                fclose(recordFile);
+            }
         }
-
-        if (recordFile) {
-            fclose(recordFile);
-        }
-
-        locationInRecordingBuffer = 0;
     }
+    locationInRecordingBuffer = 0;
 }
 
 void fillBufferFromFile() {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -188,7 +188,8 @@ typedef struct windowpos {
 
 #define MACHINES_BUFFER_LENGTH  200
 
-#define INPUT_RECORD_BUFFER     1000        // how many bytes of input data to keep in memory before saving it to disk
+#define INPUT_RECORD_BUFFER     1000        // the threshold size before flushing the record buffer to disk
+#define INPUT_RECORD_BUFFER_MAX_SIZE 1100   // the maximum size of the record buffer 
 #define DEFAULT_PLAYBACK_DELAY  50
 
 #define HIGH_SCORES_COUNT       30


### PR DESCRIPTION
This is a pretty hands-off fix for the issue where the recording buffer is never flushed when using `--print-seed-catalog`.
The real fix is to ensure that `flushBufferToFile` will always flush the buffer, regardless of if a recording file is present.
Guarding is also added to `recordChar` to avoid buffer overflows.
This change avoids creating a new game state of `isPrintingSeedCatalog`.
An addition we could do is to avoid writing to the recording buffer if there is no recording file.