### PR TITLE
Screen layers

### DIFF
--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -299,8 +299,8 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
                             drawButton(&(state->buttons[i]), BUTTON_PRESSED, &state->dbuf);
 
                             // Update the display.
-                            overlayDisplayBuffer(&state->rbuf, NULL);
-                            overlayDisplayBuffer(&state->dbuf, NULL);
+                            overlayDisplayBuffer(&state->rbuf);
+                            overlayDisplayBuffer(&state->dbuf);
 
                             if (!rogue.playbackMode || rogue.playbackPaused) {
                                 // Wait for a little; then we're done.
@@ -359,7 +359,7 @@ short buttonInputLoop(brogueButton *buttons,
 
     do {
         // Update the display.
-        overlayDisplayBuffer(&state.dbuf, NULL);
+        overlayDisplayBuffer(&state.dbuf);
 
         // Get input.
         nextBrogueEvent(&theEvent, true, false, false);
@@ -368,7 +368,7 @@ short buttonInputLoop(brogueButton *buttons,
         button = processButtonInput(&state, &canceled, &theEvent);
 
         // Revert the display.
-        overlayDisplayBuffer(&state.rbuf, NULL);
+        overlayDisplayBuffer(&state.rbuf);
 
     } while (button == -1 && !canceled);
 
@@ -376,7 +376,7 @@ short buttonInputLoop(brogueButton *buttons,
         *returnEvent = theEvent;
     }
 
-    //overlayDisplayBuffer(dbuf, NULL); // hangs around
+    //overlayDisplayBuffer(dbuf); // hangs around
 
     restoreRNG;
 

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -402,12 +402,13 @@ static void chooseGameVariant() {
     append(textBuf, "Die faster and more often in this quarter-length version of the classic game!\n\n", TEXT_MAX_LENGTH);
 
     brogueButton buttons[2];
-    screenDisplayBuffer rbuf;
-    copyDisplayBuffer(&rbuf, &displayBuffer);
+    ScreenLayerHandle menuButtonLayer = pushNewScreenLayer((ScreenLayerOptions) {
+        .name = "game variant",
+    });
     initializeMainMenuButton(&(buttons[0]), "  %sR%sapid Brogue     ", 'r', 'R', NG_NOTHING);
     initializeMainMenuButton(&(buttons[1]), "     %sB%srogue        ", 'b', 'B', NG_NOTHING);
-    gameVariantChoice = printTextBox(textBuf, 20, 7, 45, &white, &black, &rbuf, buttons, 2);
-    overlayDisplayBuffer(&rbuf, NULL);
+    gameVariantChoice = printTextBox(textBuf, 20, 7, 45, &white, &black, buttons, 2);
+    popScreenLayer(menuButtonLayer);
 
     if (gameVariantChoice == 1) {
         gameVariant = VARIANT_BROGUE;
@@ -442,13 +443,14 @@ static void chooseGameMode() {
                     "(Your score is not saved.)", TEXT_MAX_LENGTH);
 
     brogueButton buttons[3];
-    screenDisplayBuffer rbuf;
-    copyDisplayBuffer(&rbuf, &displayBuffer);
+    ScreenLayerHandle difficultyLayer = pushNewScreenLayer((ScreenLayerOptions) {
+        .name = "game difficulty",
+    });
     initializeMainMenuButton(&(buttons[0]), "      %sW%sizard       ", 'w', 'W', NG_NOTHING);
     initializeMainMenuButton(&(buttons[1]), "       %sE%sasy        ", 'e', 'E', NG_NOTHING);
     initializeMainMenuButton(&(buttons[2]), "      %sN%sormal       ", 'n', 'N', NG_NOTHING);
-    gameMode = printTextBox(textBuf, 10, 5, 66, &white, &black, &rbuf, buttons, 3);
-    overlayDisplayBuffer(&rbuf, NULL);
+    gameMode = printTextBox(textBuf, 10, 5, 66, &white, &black, buttons, 3);
+    popScreenLayer(difficultyLayer);
     if (gameMode == 0) {
         rogue.wizard = true;
         rogue.easyMode = false;
@@ -554,18 +556,18 @@ static void titleMenu() {
         do {
             if (isApplicationActive()) {
                 // Revert the display.
-                overlayDisplayBuffer(&mainMenu.rbuf, NULL);
+                overlayDisplayBuffer(&mainMenu.rbuf);
 
                 // Update the display.
                 updateMenuFlames(colors, colorSources, flames);
                 drawMenuFlames(flames, mask);
-                overlayDisplayBuffer(&mainShadowBuf, NULL);
-                overlayDisplayBuffer(&mainMenu.dbuf, NULL);
+                overlayDisplayBuffer(&mainShadowBuf);
+                overlayDisplayBuffer(&mainMenu.dbuf);
 
                 //Show flyout if selected
                 if (isFlyoutActive()) {
-                    overlayDisplayBuffer(&flyoutShadowBuf, NULL);
-                    overlayDisplayBuffer(&flyoutMenu.dbuf, NULL);
+                    overlayDisplayBuffer(&flyoutShadowBuf);
+                    overlayDisplayBuffer(&flyoutMenu.dbuf);
                 }
                 // Pause briefly.
                 if (pauseBrogue(MENU_FLAME_UPDATE_DELAY)) {
@@ -629,15 +631,17 @@ int quitImmediately() {
 }
 
 void dialogAlert(char *message) {
-    screenDisplayBuffer rbuf;
 
     brogueButton OKButton;
     initializeButton(&OKButton);
     strcpy(OKButton.text, "     OK     ");
     OKButton.hotkey[0] = RETURN_KEY;
     OKButton.hotkey[1] = ACKNOWLEDGE_KEY;
-    printTextBox(message, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, &rbuf, &OKButton, 1);
-    overlayDisplayBuffer(&rbuf, NULL);
+    ScreenLayerHandle dialogLayer = pushNewScreenLayer((ScreenLayerOptions) {
+        .name = "alert",
+    });
+    printTextBox(message, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, &OKButton, 1);
+    popScreenLayer(dialogLayer);
 }
 
 static boolean stringsExactlyMatch(const char *string1, const char *string2) {
@@ -801,7 +805,7 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
             clearDisplayBuffer(&dbuf);
             printString(prompt, x, y - 1, &itemMessageColor, dialogColor, &dbuf);
             rectangularShading(x - 1, y - 1, width + 1, height + 1, dialogColor, INTERFACE_OPACITY, &dbuf);
-            overlayDisplayBuffer(&dbuf, NULL);
+            overlayDisplayBuffer(&dbuf);
 
 //          for (j=0; j<min(count - currentPageStart, FILES_ON_PAGE_MAX); j++) {
 //              strftime(fileDate, sizeof(fileDate), DATE_FORMAT, &files[currentPageStart+j].date);
@@ -823,7 +827,7 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
 //              printf("\n   (button name)Sanity check AFTER: %s", buttons[j].text);
 //          }
 
-            overlayDisplayBuffer(&rbuf, NULL);
+            overlayDisplayBuffer(&rbuf);
 
             if (i < min(count - currentPageStart, FILES_ON_PAGE_MAX)) {
                 if (i >= 0) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1298,6 +1298,16 @@ typedef struct screenDisplayBuffer {
     cellDisplayBuffer cells[COLS][ROWS];
 } screenDisplayBuffer;
 
+typedef struct ScreenLayerHandle {
+    int index;
+    uint64_t uniqueId;
+} ScreenLayerHandle;
+
+typedef struct ScreenLayerOptions {
+    // The name of a layer is just intended to be used for debugging.
+    char name[32];
+} ScreenLayerOptions;
+
 typedef struct pcell {                              // permanent cell; have to remember this stuff to save levels
     enum tileType layers[NUMBER_TERRAIN_LAYERS];    // terrain
     unsigned long flags;                            // non-terrain cell flags
@@ -2921,15 +2931,13 @@ extern "C" {
                             const color *backColor, short opacity, screenDisplayBuffer *dbuf);
     short printTextBox(char *textBuf, short x, short y, short width,
                        const color *foreColor, const color *backColor,
-                       screenDisplayBuffer *rbuf,
                        brogueButton *buttons, short buttonCount);
     void setButtonText(brogueButton *button, const char *textWithHotkey, const char *textWithoutHotkey);
-    void printMonsterDetails(creature *monst, screenDisplayBuffer* rbuf);
-    void printFloorItemDetails(item *theItem, screenDisplayBuffer* rbuf);
+    void printMonsterDetails(creature *monst);
+    void printFloorItemDetails(item *theItem);
     unsigned long printCarriedItemDetails(item *theItem,
                                           short x, short y, short width,
-                                          boolean includeButtons,
-                                          screenDisplayBuffer* rbuf);
+                                          boolean includeButtons);
     void funkyFade(screenDisplayBuffer *displayBuf, const color *colorStart, const color *colorEnd, short stepCount, short x, short y, boolean invert);
     void displayCenteredAlert(char *message);
     void flashMessage(char *message, short x, short y, int time, const color *fColor, const color *bColor);
@@ -2966,7 +2974,10 @@ extern "C" {
     void copyDisplayBuffer(screenDisplayBuffer *toBuf, screenDisplayBuffer *fromBuf);
     void clearDisplayBuffer(screenDisplayBuffer *dbuf);
     color colorFromComponents(char rgb[3]);
-    void overlayDisplayBuffer(screenDisplayBuffer *overBuf, screenDisplayBuffer *previousBuf);
+
+    ScreenLayerHandle pushNewScreenLayer(ScreenLayerOptions options);
+    void popScreenLayer(ScreenLayerHandle layer);
+    void overlayDisplayBuffer(screenDisplayBuffer *overBuf);
     void flashForeground(short *x, short *y, const color **flashColor, short *flashStrength, short count, short frames);
     void flashCell(const color *theColor, short frames, short x, short y);
     void colorFlash(const color *theColor, unsigned long reqTerrainFlags, unsigned long reqTileFlags, short frames, short maxRadius, short x, short y);

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -44,7 +44,6 @@ static short dialogSelectEntryFromList(
 
     short x=0, y=0, width=0, height=0;
     screenDisplayBuffer dbuf;
-    screenDisplayBuffer rbuf;
     short i, selectedButton, len, maxLen;
     char buttonText[COLS];
 
@@ -78,11 +77,14 @@ static short dialogSelectEntryFromList(
     //Dialog background
     rectangularShading(x - 1, y - 1, width + 1, height + 1, &interfaceBoxColor, INTERFACE_OPACITY, &dbuf);
     //Display the title/background and save the prior display state
-    overlayDisplayBuffer(&dbuf, &rbuf);
+    ScreenLayerHandle buttonLayer = pushNewScreenLayer((ScreenLayerOptions) {
+        .name = "dialog select",
+    });
+    overlayDisplayBuffer(&dbuf);
     //Display the buttons and wait for user selection
     selectedButton = buttonInputLoop(buttons, buttonCount, x, y, width, height, NULL);
     //Revert the display state
-    overlayDisplayBuffer(&rbuf, NULL);
+    popScreenLayer(buttonLayer);
 
     return selectedButton;
 }


### PR DESCRIPTION
This is a refactoring of how the screen state is "restored" when you want to hide something that was previously drawn.

Before this PR, the `overlayDisplayBuffer` optionally provided an `rbuf` parameter, which would be filled with the "old" screen. Then, later, a caller could "revert" to this version of the screen by drawing it over the current screen.

Obviously, this pattern worked, but it hides the real structure of the game's interface from the platform. In order to make it possible to enrich the display of the world, it should be possible to _expose_ the structure of the layers of UI (e.g. confirmation window on top of inventory on top of dungeon).

This PR makes a partial step in this direction: `pushNewScreenLayer(...)` declares that you're about to draw a new layer of UI onto the screen. In a global variable, it stores the current `displayBuffer`, which can be reverted by calling `popScreenLayer(...)`:

```c
ScreenLayerHandle pushNewScreenLayer(ScreenLayerOptions options);
void popScreenLayer(ScreenLayerHandle layer);
```

In order to make debugging mismatched calls a little bit easier, these functions return a `ScreenLayerHandle`, which just tracks the index into the layers. In the future, we might want to include additional information in these. Likewise, each layer is given a name, and there's a (commented out right now - should probably guard with a `#define` instead) debug function that prints the current layer stack.

---

The `overlayDisplayBuffer` function has been rewritten to not support the `rbuf` parameter - all existing callers were rewritten to use the `pushNewScreenLayer` abstraction instead. A few of them are still quite messy (`displayInventory` in particular is quite complicated).

---

In follow-on PRs, I want to keep refactoring in this direction, of exposing the underlying state of the view to the platform (in addition to the backwards-compatible grid of symbols):

- `overlayDisplayBuffer` will also store (transparent) versions of each layer, so that they can be composited by the platform directly
- direct access to `screenDisplayBuffer` should be refactored out, so that layers can be composed "lazily" in the platform - this means you can't make a change to `displayBuffer` that's not also reflected in the transparent ui layer
- `ScreenLayerOptions` should provide additional details about the layer, so that different layers can be treated differently by the platform without lots of hard-coding logic
- More parts of the screen should be organized into layers, like making the status at the left separate from the dungeon



 