### PR TITLE
Redo the level if stairs cannot be placed

### DIFF
--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2982,7 +2982,8 @@ extern "C" {
     void nextBrogueEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance, boolean realInputEvenInPlayback);
     void executeMouseClick(rogueEvent *theEvent);
     void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKey);
-    void initializeLevel(void);
+    boolean placeStairs(pos *upStairsLoc);
+    void initializeLevel(pos upStairsLoc);
     void startLevel (short oldLevelNumber, short stairDirection);
     void updateMinersLightRadius(void);
     void freeCreature(creature *monst);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -684,8 +684,19 @@ void startLevel(short oldLevelNumber, short stairDirection) {
 
         levels[rogue.depthLevel-1].items = NULL;
 
-        digDungeon();
-        initializeLevel();
+        pos upStairLocation;
+        int failsafe;
+        for (failsafe = 50; failsafe; failsafe--) {
+            digDungeon();
+            if (placeStairs(&upStairLocation)) {
+                break;
+            }
+        }
+        if (!failsafe) {
+            printf("\nFailed to place stairs for level %d! Please report this error\n", rogue.depthLevel);
+            exit(1);
+        }
+        initializeLevel(upStairLocation);
         setUpWaypoints();
 
         shuffleTerrainColors(100, false);


### PR DESCRIPTION
Rapid Brogue seed 519 cannot place stairs in level 2 since there are no qualifying squares (basically every square is part of a machine). This patch rerolls the level when this (very rare) case occurs.