### PR TITLE
Adding out-of-range guard to plotChar+ functions

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -1774,6 +1774,9 @@ void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *
     foreRand, backRand;
 
     brogueAssert(locIsInWindow(loc));
+    if (!locIsInWindow(loc)) {
+        return;
+    }
 
     if (rogue.gameHasEnded || rogue.playbackFastForward) {
         return;
@@ -1828,6 +1831,9 @@ void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *f
     }
 
     brogueAssert(locIsInWindow(loc));
+    if (!locIsInWindow(loc)) {
+        return;
+    }
 
     oldRNG = rogue.RNG;
     rogue.RNG = RNG_COSMETIC;


### PR DESCRIPTION
Previously `getInputTextString` in debug builds would overwrite the edge of the `displayBuffer` due to the use of `plotCharWithColor`. This happened, for example, when printing the default save file name for debug builds (which have long version strings).
This change adds guarding to the `plotCharWithColor` and `plotCharToBuffer` (which was already there but only as an assert for debug builds). I haven't changed `plotChar` since it's a lower level function where the caller will have to take responsibility for not writing outside of bounds.