### PR TITLE
Adding github action to monitor for dungeon gen changes

### DIFF
--- a/.github/workflows/test-seed-catalog.yml
+++ b/.github/workflows/test-seed-catalog.yml
@@ -1,0 +1,27 @@
+name: "Compare Seed Catalogs"
+on:
+  pull_request:
+    branches:
+    - 'release'
+
+jobs:
+
+  linux-test:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: "Install dependencies"
+      run: |
+        sudo apt update -y
+        sudo apt install -y libsdl2-dev libsdl2-image-dev
+
+    - name: "Checkout sources"
+      uses: actions/checkout@v3
+
+    - name: "Compile"
+      run: |
+        make bin/brogue
+
+    - name: "Run seed catalog regression tests"
+      run: |
+        python3 test/compare_seed_catalog.py test/seed_catalogs/seed_catalog_brogue.txt 40
+        python3 test/compare_seed_catalog.py --extra_args "--variant rapid_brogue" test/seed_catalogs/seed_catalog_rapid_brogue.txt 10

--- a/test/compare_seed_catalog.py
+++ b/test/compare_seed_catalog.py
@@ -1,0 +1,54 @@
+import subprocess
+import argparse
+import sys
+import os
+
+def run_brogue_tests(seed_catalog_file, extra_args, max_level):
+
+    output_seed_catalog_file = f'output_seed_catalog_{max_level}.txt'
+    seed_catalog_cmd_args = f'--print-seed-catalog 1 25 {max_level}'
+
+    # Generate the first 25 seeds
+    if extra_args:
+        brogue_command = f'./brogue {extra_args} {seed_catalog_cmd_args} > {output_seed_catalog_file}'
+    else:
+        brogue_command = f'./brogue {seed_catalog_cmd_args} > {output_seed_catalog_file}'
+    print(f"Running {brogue_command}...")
+    brogue_result = subprocess.run(brogue_command, shell=True, capture_output=True, text=True)
+
+    # Run diff to compare the seed catalog files
+    print (f"Comparing {seed_catalog_file} and {output_seed_catalog_file}...")
+
+    diff_command = f"bash -c 'diff <(sed \"1,4d\" {seed_catalog_file}) <(sed \"1,4d\" {output_seed_catalog_file})'"
+    diff_result = subprocess.run(diff_command, shell=True, capture_output=True, text=True)
+
+    # Delete the output seed catalog file
+    os.remove(output_seed_catalog_file)
+
+    if brogue_result.returncode:
+        print("Test run failure, seed catalog generation failed. Output:")
+        print(brogue_result.stdout)
+        sys.exit(1)
+
+    if diff_result.returncode:
+        print("Test run failure, seed catalog has changed. Output:")
+        print(diff_result.stdout)
+        sys.exit(1)
+
+    print("Seed catalog identical - test run successful")
+
+def main():
+    # Create the argument parser
+    parser = argparse.ArgumentParser(description='Brogue Seed Compare Test Runner')
+    parser.add_argument('seed_catalog', help='Seed catalog file to compare')
+    parser.add_argument('max_level', help='Maximum level to generate seeds for')
+    parser.add_argument('--extra_args', help='Extra command-line arguments to be passed to brogue (e.g. to select variant)')
+
+    # Parse the command line arguments
+    args = parser.parse_args()
+
+    # Call the function to run the brogue tests
+    run_brogue_tests(args.seed_catalog, args.extra_args, args.max_level)
+
+if __name__ == '__main__':
+    main()

--- a/test/compare_seed_catalog.py
+++ b/test/compare_seed_catalog.py
@@ -31,7 +31,7 @@ def run_brogue_tests(seed_catalog_file, extra_args, max_level):
         sys.exit(1)
 
     if diff_result.returncode:
-        print("Test run failure, seed catalog has changed. Output:")
+        print("Test run failure, seed catalog has changed.\nIf this was intentional, update the seed catalogs by running update_seed_catalogs.py.\nOutput:")
         print(diff_result.stdout)
         sys.exit(1)
 

--- a/test/seed_catalogs/seed_catalog_brogue.txt
+++ b/test/seed_catalogs/seed_catalog_brogue.txt
@@ -1,0 +1,6777 @@
+Brogue seed catalog, seeds 1 to 25, through depth 40.
+Generated with CE 1.13.0-dev.8736c7c.feature/fix_rb_seed519. Dungeons unchanged since CE 1.11.
+
+To play one of these seeds, select Play>New Seeded Game from the title screen.
+Seed 1:
+    Depth 1:
+        A potion of confusion
+        A scroll of enchanting
+        A +3 sword <14>
+        A potion of life
+        A scroll of enchanting
+        A +1 invisibility charm (ready) (vault 1)
+        A +1 ring of reaping (vault 1)
+        A +1 ring of clairvoyance (vault 1)
+        +2 splint mail [11]<17> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A wand of slowness [5] (vault 1)
+        149 gold pieces (2 piles)
+    Depth 2:
+        A +2 haste charm (ready)
+        A potion of confusion
+        A +3 ring of clairvoyance
+        A potion of confusion
+        +1 chain mail [6]<13>
+        A potion of strength
+        A shackled monkey
+    Depth 3:
+        A potion of levitation
+        A scroll of identify
+        A potion of creeping death
+        +3 banded mail [10]<15>
+        A potion of telepathy
+        Some food
+        Some food
+        Some food
+        219 gold pieces (2 piles)
+        A shackled monkey
+    Depth 4:
+        A potion of fire immunity
+        +2 scale mail of mutuality [6]<12>
+        A potion of speed
+        A potion of strength
+        200 gold pieces (2 piles)
+    Depth 5:
+        +0 chain mail [5]<13>
+        A potion of speed
+        A potion of speed
+        171 gold pieces
+    Depth 6:
+        A scroll of teleportation
+        A scroll of negation
+        A potion of invisibility
+        A potion of life
+        A scroll of magic mapping
+        A potion of caustic gas
+        A scroll of summon monsters
+        659 gold pieces (4 piles)
+    Depth 7:
+        A scroll of teleportation
+        A potion of incineration
+        A potion of paralysis
+        A potion of strength
+        A +0 war axe <19>
+        A +1 ring of transference
+        A scroll of enchanting
+        456 gold pieces (3 piles)
+        A shackled ogre
+        A shackled goblin mystic
+    Depth 8:
+        A scroll of aggravate monsters
+        Some food
+        A potion of telepathy
+        A scroll of identify
+        A scroll of enchanting
+        A potion of confusion
+        712 gold pieces (4 piles)
+        A staff of obstruction [3/3] (goblin mystic)
+    Depth 9:
+        A potion of invisibility
+        A scroll of enchanting
+        A potion of telepathy
+        1249 gold pieces (6 piles)
+    Depth 10:
+        A +0 sword <14>
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        627 gold pieces (3 piles)
+        A potion of detect magic (goblin conjurer)
+        A potion of paralysis (goblin conjurer)
+    Depth 11:
+        A +1 ring of reaping
+        A staff of firebolt [2/2]
+        A potion of descent
+        A +0 war axe <19>
+        A +3 spear of speed <13>
+        706 gold pieces (3 piles)
+    Depth 12:
+        A potion of invisibility
+        A potion of paralysis
+        A potion of descent
+        A potion of telepathy
+        759 gold pieces (3 piles)
+        A potion of invisibility (goblin conjurer)
+    Depth 13:
+        A scroll of enchanting
+        A scroll of protect armor
+        A scroll of enchanting
+        A potion of life
+        790 gold pieces (3 piles)
+        A +0 war pike <18> (goblin mystic)
+    Depth 14:
+        A scroll of identify
+        A potion of strength
+        A potion of invisibility
+        A potion of descent
+        A potion of detect magic
+        +0 splint mail [9]<17>
+        A potion of strength
+        -1 chain mail [4]<13>
+        A scroll of enchanting
+        A door key (opens vault 1)
+        1362 gold pieces (6 piles)
+        A commutation altar (vault 1)
+    Depth 15:
+        A potion of detect magic
+        A potion of speed
+        +1 scale mail of reprisal [5]<12>
+        Some food
+        1244 gold pieces (5 piles)
+    Depth 16:
+        A potion of strength
+        A potion of telepathy
+        A wand of invisibility [4]
+        A potion of caustic gas
+        A scroll of summon monsters
+        A scroll of summon monsters
+        A potion of hallucination
+        A scroll of protect weapon
+        +1 splint mail [10]<17>
+        A scroll of enchanting
+        A scroll of shattering
+        A potion of life
+        1157 gold pieces (4 piles)
+    Depth 17:
+        +2 plate armor [13]<19>
+        A scroll of enchanting
+        A scroll of sanctuary
+        1317 gold pieces (4 piles)
+    Depth 18:
+        A scroll of negation
+        A scroll of magic mapping
+        A mango
+        1383 gold pieces (5 piles)
+        A shackled dar blademaster
+    Depth 19:
+        A wand of polymorphism [5]
+        A potion of strength
+        A +1 ring of wisdom
+        A scroll of teleportation
+        A potion of life
+        A door key (opens vault 1)
+        1292 gold pieces (4 piles)
+        A staff of blinking [2/2] (dar priestess)
+        A scroll of shattering (dar priestess [infested])
+        A cage key (vampire)
+        A caged naga
+        A caged dar priestess [infested]
+        A caged troll
+        A caged dar blademaster
+        A shackled troll
+        A shackled wraith
+        A commutation altar (vault 1)
+    Depth 20:
+        A potion of telepathy
+        A potion of strength
+        A potion of fire immunity
+        Some food
+        2111 gold pieces (6 piles)
+        A scroll of shattering (dar blademaster)
+    Depth 21:
+        A +0 whip <14>
+        A potion of paralysis
+        A potion of invisibility
+        1670 gold pieces (5 piles)
+        A potion of confusion (dar blademaster)
+        A scroll of protect armor (dar priestess)
+    Depth 22:
+        A scroll of enchanting
+        A scroll of enchanting
+        A scroll of protect armor
+        A potion of life
+        Some food
+        2078 gold pieces (6 piles)
+    Depth 23:
+        A scroll of enchanting
+        A potion of speed
+        A potion of invisibility
+        A scroll of discord (vault 1)
+        A scroll of protect armor (vault 1)
+        A scroll of teleportation (vault 1)
+        A scroll of identify (vault 1)
+        A scroll of recharging (vault 1)
+        A scroll of negation (vault 1)
+        2918 gold pieces (8 piles)
+        A potion of invisibility (dar priestess)
+        A shackled golem
+    Depth 24:
+        A scroll of identify
+        A scroll of recharging
+        A potion of telepathy
+        A mango
+        2099 gold pieces (5 piles)
+        A scroll of magic mapping (dar priestess)
+    Depth 25:
+        Some food
+        A -3 ring of awareness
+        A potion of descent
+        A scroll of enchanting
+        2058 gold pieces (5 piles)
+        A +1 ring of transference (dar battlemage)
+        A +1 ring of reaping (dar priestess)
+        A potion of incineration (dragon)
+        A scroll of identify (dar priestess)
+        A scroll of protect armor (dar blademaster)
+        A +0 axe <15> (dar blademaster)
+        A shackled dar battlemage
+        A shackled golem
+    Depth 26:
+        +0 plate armor [11]<19>
+        +0 splint mail [9]<17>
+        A potion of caustic gas
+        2333 gold pieces (6 piles)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        Some food
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 2:
+    Depth 1:
+        A potion of strength
+        A scroll of identify
+        A scroll of enchanting
+        A +0 rapier <15>
+        A potion of life
+        Some food
+        70 gold pieces
+        A shackled monkey
+    Depth 2:
+        A scroll of teleportation
+        A scroll of enchanting
+        A potion of caustic gas
+        A potion of caustic gas
+        A potion of caustic gas
+    Depth 3:
+        A scroll of remove curse
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        A +0 war axe <19>
+        A scroll of identify
+        A staff of protection [3/3] (vault 1)
+        A staff of entrancement [3/3] (vault 1)
+        A staff of healing [2/2] (vault 1)
+        A staff of obstruction [3/3] (vault 1)
+        A door key (opens vault 1)
+    Depth 4:
+        A potion of descent
+        A potion of descent
+        A wand of polymorphism [3]
+        A +2 protection charm (ready)
+        353 gold pieces (3 piles)
+    Depth 5:
+        A potion of strength
+        A scroll of discord
+        A +2 haste charm (ready)
+        A +1 dagger of confusion <12> (vault 3)
+        A +1 guardian charm (ready) (vault 1)
+        A +1 ring of clairvoyance (vault 1)
+        A +1 sword <14> (vault 1)
+        A wand of invisibility [5] (vault 1)
+        A +0 axe <15> (vault 1)
+        A wand of polymorphism [3] (vault 1)
+        278 gold pieces (2 piles)
+        +0 chain mail [5]<13> (goblin conjurer)
+    Depth 6:
+        A scroll of protect weapon
+        A potion of detect magic
+        Some food
+        5 +0 incendiary darts <12> (vault 1)
+        A +0 whip <14> (vault 1)
+        +0 splint mail [9]<17> (vault 1)
+        A potion of life (vault 1)
+        793 gold pieces (5 piles)
+        A scroll of remove curse (goblin warlord)
+    Depth 7:
+        4 +0 incendiary darts <12>
+        A potion of fire immunity
+        A potion of life
+        495 gold pieces (3 piles)
+    Depth 8:
+        A scroll of sanctuary
+        A potion of creeping death
+        A potion of strength
+        995 gold pieces (6 piles)
+        +0 scale mail [4]<12> (goblin conjurer)
+        A shackled goblin mystic
+        A shackled ogre
+    Depth 9:
+        +0 chain mail [5]<13>
+        A scroll of identify
+        A scroll of remove curse
+        A +3 mace <16>
+        745 gold pieces (4 piles)
+    Depth 10:
+        A scroll of enchanting
+        A scroll of remove curse
+        Some food
+        839 gold pieces (4 piles)
+    Depth 11:
+        A scroll of recharging
+        A potion of life
+        A +0 sword <14>
+        437 gold pieces (2 piles)
+        A scroll of teleportation (goblin mystic)
+        A potion of hallucination (goblin conjurer)
+    Depth 12:
+        A +1 ring of reaping
+        +0 splint mail [9]<17>
+        A potion of caustic gas
+        A potion of paralysis
+        A potion of invisibility
+        A potion of caustic gas
+        A scroll of enchanting
+        A +3 flail <17>
+        A wand of domination [1]
+        1557 gold pieces (7 piles)
+        A potion of incineration (goblin mystic)
+    Depth 13:
+        A scroll of shattering
+        A scroll of protect weapon
+        +0 splint mail [9]<17>
+        +2 leather armor [5]<10>
+        Some food
+        678 gold pieces (3 piles)
+    Depth 14:
+        A +0 dagger <12>
+        A potion of strength
+        A scroll of enchanting
+        A scroll of enchanting
+        A staff of entrancement [3/3]
+        A potion of telepathy
+        A scroll of sanctuary
+        940 gold pieces (4 piles)
+    Depth 15:
+        A +0 broadsword <19>
+        A scroll of identify
+        A scroll of enchanting
+        A potion of strength
+        +3 plate armor [14]<19>
+        1333 gold pieces (5 piles)
+        A scroll of sanctuary (dar blademaster)
+        A resurrection altar (vault 1)
+    Depth 16:
+        A potion of life
+        A scroll of recharging
+        A scroll of enchanting
+        +0 plate armor [11]<19>
+        Some food
+        973 gold pieces (4 piles)
+        A shackled naga
+    Depth 17:
+        A +0 sword <14>
+        A scroll of shattering
+        A scroll of enchanting
+        A +2 teleportation charm (ready)
+        A potion of strength
+        1233 gold pieces (4 piles)
+        A scroll of remove curse (dar blademaster)
+    Depth 18:
+        A potion of incineration
+        A potion of caustic gas
+        Some food
+        1172 gold pieces (4 piles)
+    Depth 19:
+        A +2 ring of light
+        A potion of strength
+        A potion of telepathy
+        A +0 war pike <18>
+        1529 gold pieces (5 piles)
+        A potion of paralysis (dar blademaster)
+        A shackled troll
+        A shackled golem
+    Depth 20:
+        A potion of invisibility
+        A potion of telepathy
+        A potion of life
+        A mango
+        1790 gold pieces (5 piles)
+    Depth 21:
+        A potion of paralysis
+        A potion of detect magic
+        A potion of fire immunity
+        A scroll of enchanting
+        A scroll of summon monsters
+        A potion of hallucination
+        1650 gold pieces (5 piles)
+        A shackled dar blademaster
+    Depth 22:
+        A scroll of enchanting
+        A scroll of identify
+        A potion of darkness
+        A scroll of enchanting
+        A potion of detect magic
+        Some food
+        1536 gold pieces (5 piles)
+        A shackled tentacle horror
+    Depth 23:
+        A potion of caustic gas
+        A potion of hallucination
+        A potion of fire immunity
+        A potion of life
+        A potion of levitation (vault 1)
+        A potion of caustic gas (vault 1)
+        A potion of descent (vault 1)
+        A potion of detect magic (vault 1)
+        A potion of incineration (vault 1)
+        2600 gold pieces (7 piles)
+        A scroll of shattering (dar blademaster)
+        A shackled dar blademaster
+        A shackled dar blademaster
+        A shackled golem [infested]
+        A shackled dar priestess
+    Depth 24:
+        A +3 war pike <18>
+        A scroll of sanctuary
+        A potion of detect magic
+        A scroll of enchanting
+        A potion of strength
+        Some food
+        2518 gold pieces (7 piles)
+        A +1 teleportation charm (ready) (dar battlemage)
+        A shackled dar blademaster
+    Depth 25:
+        A potion of strength
+        +0 splint mail [9]<17>
+        A potion of levitation
+        2554 gold pieces (7 piles)
+        A shackled imp
+    Depth 26:
+        A potion of strength
+        A scroll of teleportation
+        A potion of caustic gas
+        1873 gold pieces (5 piles)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A mango
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 3:
+    Depth 1:
+        A potion of detect magic
+        A scroll of enchanting
+        A potion of strength
+        A +0 war axe <19>
+        A scroll of teleportation
+        A potion of telepathy
+        A +3 dagger of jelly slaying <12>
+        A potion of detect magic
+        A +1 ring of reaping (vault 4)
+        A +1 ring of awareness (vault 4)
+        A +3 ring of regeneration (vault 4)
+        6 +0 incendiary darts <12>
+        A staff of blinking [2/2] (vault 1)
+        A staff of protection [3/3] (vault 1)
+        A wand of teleportation [3] (vault 1)
+        A wand of beckoning [3] (vault 1)
+        +3 plate armor [14]<19> (vault 1)
+        A wand of negation [5] (vault 1)
+        A door key (opens vault 1)
+        210 gold pieces (2 piles)
+    Depth 2:
+        A staff of discord [3/3]
+        A scroll of remove curse
+        A potion of confusion
+        A scroll of sanctuary
+        A potion of levitation
+        A potion of life
+        203 gold pieces (2 piles)
+    Depth 3:
+        A potion of caustic gas
+        A potion of descent
+        A scroll of shattering
+        Some food
+        A scroll of magic mapping (goblin conjurer)
+        A shackled monkey
+    Depth 4:
+        -3 splint mail [6]<17>
+        +1 splint mail [10]<17>
+        A potion of detect magic
+        A scroll of protect armor
+        A scroll of enchanting
+        A +1 protection charm (ready) (vault 1)
+        A +2 health charm (ready) (vault 1)
+        A +2 fire immunity charm (ready) (vault 1)
+        +2 scale mail of absorption [6]<12> (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        A wand of teleportation [3] (vault 1)
+        102 gold pieces
+        A shackled ogre
+    Depth 5:
+        A potion of life
+        A potion of strength
+        A potion of invisibility
+        A potion of telepathy
+        A scroll of discord
+        A door key (opens vault 1)
+        +2 leather armor of mutuality [5]<10> (vault 1)
+        318 gold pieces (2 piles)
+    Depth 6:
+        A wand of domination [2]
+        A scroll of enchanting
+        +3 leather armor of multiplicity [6]<10>
+        437 gold pieces (3 piles)
+        3 +0 incendiary darts <12> (goblin conjurer)
+    Depth 7:
+        +0 banded mail [7]<15>
+        A +3 spear of jelly slaying <13>
+        -2 scale mail [2]<12>
+        +0 plate armor [11]<19>
+        633 gold pieces (4 piles)
+    Depth 8:
+        A scroll of teleportation
+        A potion of fire immunity
+        Some food
+        A +0 sword <14>
+        Some food
+        710 gold pieces (4 piles)
+    Depth 9:
+        A scroll of negation
+        A scroll of magic mapping
+        A potion of life
+        666 gold pieces (4 piles)
+    Depth 10:
+        A potion of telepathy
+        A scroll of identify
+        A potion of strength
+        A potion of hallucination
+        A scroll of identify
+        760 gold pieces (4 piles)
+    Depth 11:
+        A potion of strength
+        +0 banded mail [7]<15>
+        A potion of strength
+        A potion of detect magic
+        A potion of detect magic
+        Some food
+        A potion of descent
+        A scroll of magic mapping
+        1434 gold pieces (7 piles)
+    Depth 12:
+        +3 banded mail [10]<15>
+        A potion of invisibility
+        A scroll of enchanting
+        681 gold pieces (3 piles)
+    Depth 13:
+        A scroll of enchanting
+        A potion of telepathy
+        A +0 axe <15>
+        A potion of confusion
+        A potion of detect magic
+        A potion of levitation
+        A door key (opens vault 1)
+        A scroll of enchanting (vault 1)
+        978 gold pieces (4 piles)
+    Depth 14:
+        18 +0 javelins <15>
+        A potion of detect magic
+        A potion of caustic gas
+        A potion of confusion
+        935 gold pieces (4 piles)
+        A shackled pixie
+    Depth 15:
+        A potion of speed
+        A potion of strength
+        Some food
+        844 gold pieces (3 piles)
+        A shackled pixie
+    Depth 16:
+        A scroll of enchanting
+        A potion of incineration
+        A potion of strength
+        A potion of detect magic
+        A scroll of recharging
+        A potion of life
+        1096 gold pieces (4 piles)
+    Depth 17:
+        A scroll of enchanting
+        A potion of invisibility
+        A scroll of shattering
+        A +1 spear of speed <13>
+        1326 gold pieces (5 piles)
+    Depth 18:
+        A potion of fire immunity
+        A potion of caustic gas
+        A -1 sword <14>
+        Some food
+        A potion of speed
+        1151 gold pieces (4 piles)
+        A potion of hallucination (dar blademaster)
+    Depth 19:
+        A potion of life
+        A scroll of negation
+        A scroll of enchanting
+        1851 gold pieces (6 piles)
+    Depth 20:
+        A +2 haste charm (ready)
+        A potion of detect magic
+        Some food
+        A scroll of enchanting (vault 1)
+        2181 gold pieces (7 piles)
+        A shackled dar blademaster
+        A shackled imp
+    Depth 21:
+        A scroll of enchanting
+        A scroll of enchanting
+        A scroll of enchanting
+        A scroll of enchanting
+        2570 gold pieces (8 piles)
+        A shackled imp [toxic]
+    Depth 22:
+        A mango
+        A scroll of protect armor
+        A potion of strength
+        A scroll of enchanting
+        A potion of levitation
+        A +0 rapier <15>
+        2579 gold pieces (7 piles)
+    Depth 23:
+        A scroll of aggravate monsters
+        A +3 ring of light
+        A potion of darkness
+        A door key (opens vault 1)
+        2167 gold pieces (6 piles)
+        A scroll of protect armor (dar battlemage)
+        A shackled golem
+        A shackled tentacle horror
+        A commutation altar (vault 1)
+    Depth 24:
+        A potion of detect magic
+        A scroll of magic mapping
+        A potion of life
+        Some food
+        2273 gold pieces (6 piles)
+    Depth 25:
+        A potion of telepathy
+        A potion of hallucination
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of darkness
+        A +0 axe <15>
+        2122 gold pieces (5 piles)
+        A door key (stone guardian) (opens vault 1)
+        A commutation altar (vault 1)
+    Depth 26:
+        A +0 mace <16>
+        A scroll of enchanting
+        Some food
+        2331 gold pieces (6 piles)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A mango
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+    Depth 35:
+        A lumenstone from depth 35
+        A mango
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 4:
+    Depth 1:
+        A scroll of protect weapon
+        A potion of strength
+        A scroll of identify
+        A scroll of enchanting
+        +0 plate armor [11]<19>
+        A +2 ring of regeneration (vault 1)
+        A +2 ring of wisdom (vault 1)
+        A +1 ring of reaping (vault 1)
+        A +3 ring of awareness (vault 1)
+        A door key (opens vault 1)
+        104 gold pieces
+    Depth 2:
+        A potion of descent
+        A potion of life
+        A potion of confusion
+        A potion of descent
+        A potion of incineration
+        246 gold pieces (2 piles)
+    Depth 3:
+        A scroll of remove curse
+        A scroll of enchanting
+        A scroll of discord
+        A scroll of magic mapping
+        A potion of descent
+        -1 plate armor [10]<19>
+        Some food
+        A scroll of negation (goblin conjurer)
+    Depth 4:
+        A potion of creeping death
+        A potion of invisibility
+        A potion of detect magic
+        +0 banded mail [7]<15>
+        149 gold pieces
+        A potion of telepathy (goblin conjurer)
+    Depth 5:
+        A potion of detect magic
+        A scroll of enchanting
+        A potion of telepathy
+        259 gold pieces (2 piles)
+    Depth 6:
+        A +2 negation charm (ready)
+        A scroll of aggravate monsters
+        +0 chain mail [5]<13>
+        Some food
+        565 gold pieces (4 piles)
+    Depth 7:
+        A potion of strength
+        A potion of caustic gas
+        A scroll of enchanting
+        452 gold pieces (3 piles)
+        A shackled ogre
+        A shackled goblin mystic
+    Depth 8:
+        A wand of negation [6]
+        A staff of firebolt [3/3]
+        A potion of life
+        614 gold pieces (4 piles)
+    Depth 9:
+        A scroll of enchanting
+        A +2 ring of clairvoyance
+        A scroll of recharging
+        A scroll of magic mapping
+        A potion of telepathy
+        A potion of confusion
+        A potion of detect magic
+        A scroll of enchanting
+        A scroll of summon monsters
+        1074 gold pieces (6 piles)
+    Depth 10:
+        A potion of strength
+        A potion of levitation
+        A potion of creeping death
+        A scroll of recharging
+        A potion of creeping death
+        Some food
+        994 gold pieces (5 piles)
+    Depth 11:
+        A +0 war hammer <20>
+        A scroll of negation
+        A wand of beckoning [3]
+        A staff of lightning [2/2] (vault 1)
+        A staff of protection [3/3] (vault 1)
+        A +1 negation charm (ready) (vault 1)
+        A +3 spear of fireborne slaying <13> (vault 1)
+        A +0 war pike <18> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        A wand of slowness [5] (vault 1)
+        595 gold pieces (3 piles)
+        A door key (monkey) (opens vault 1)
+    Depth 12:
+        A scroll of identify
+        A potion of invisibility
+        A potion of descent
+        A potion of darkness
+        A potion of telepathy
+        A potion of invisibility
+        1095 gold pieces (5 piles)
+    Depth 13:
+        A potion of invisibility
+        A potion of life
+        Some food
+        1043 gold pieces (4 piles)
+    Depth 14:
+        A +2 ring of clairvoyance
+        A +0 mace <16>
+        -3 splint mail of burden [6]<17>
+        1015 gold pieces (4 piles)
+    Depth 15:
+        A potion of detect magic
+        A +2 protection charm (ready)
+        Some food
+        986 gold pieces (4 piles)
+        A shackled troll
+        A shackled dar blademaster
+    Depth 16:
+        A potion of speed
+        A +0 sword <14>
+        +2 plate armor [13]<19>
+        A potion of life
+        1619 gold pieces (6 piles)
+    Depth 17:
+        +0 splint mail [9]<17>
+        A staff of poison [2/2]
+        A scroll of enchanting
+        A potion of darkness
+        A potion of confusion
+        A +1 teleportation charm (ready)
+        A scroll of negation
+        A potion of strength
+        A scroll of protect weapon
+        A scroll of recharging
+        1359 gold pieces (5 piles)
+    Depth 18:
+        A scroll of enchanting
+        A potion of strength
+        Some food
+        1898 gold pieces (6 piles)
+        A potion of paralysis (dar blademaster)
+        A potion of levitation (dar priestess)
+        A shackled dar blademaster
+    Depth 19:
+        A potion of levitation
+        A potion of strength
+        A scroll of magic mapping
+        A potion of life
+        A door key (vault 3) (opens vault 1)
+        A staff of discord [4/4] (vault 3)
+        A wand of domination [1] (vault 3)
+        1233 gold pieces (4 piles)
+        A door key (imp) (opens vault 3)
+        A shackled golem
+        A commutation altar (vault 1)
+    Depth 20:
+        A scroll of enchanting
+        A +0 axe <15>
+        Some food
+        2148 gold pieces (6 piles)
+        A shackled imp
+    Depth 21:
+        A potion of detect magic
+        A potion of incineration
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of fire immunity
+        1810 gold pieces (5 piles)
+    Depth 22:
+        A scroll of protect armor
+        A potion of fire immunity
+        +0 splint mail [9]<17>
+        2091 gold pieces (6 piles)
+    Depth 23:
+        A potion of levitation
+        A scroll of enchanting
+        A potion of telepathy
+        A potion of life
+        A mango
+        A cage key
+        A cage key
+        1764 gold pieces (5 piles)
+        A scroll of identify (dar blademaster)
+        A shackled dar blademaster
+        A shackled golem
+        A shackled tentacle horror
+        A caged dar battlemage
+        A caged dar battlemage
+        A caged naga
+        A caged naga [reflective]
+    Depth 24:
+        A scroll of enchanting
+        A +1 negation charm (ready)
+        3 +0 incendiary darts <12>
+        A potion of strength
+        +0 plate armor [11]<19>
+        A potion of strength
+        A potion of telepathy
+        A mango
+        2708 gold pieces (7 piles)
+        A potion of telepathy (dragon)
+        A shackled dar blademaster
+    Depth 25:
+        A potion of strength
+        A +3 broadsword <19>
+        A scroll of enchanting
+        A potion of hallucination
+        1873 gold pieces (5 piles)
+        A potion of invisibility (dar blademaster)
+        A potion of caustic gas (dar battlemage)
+        A scroll of discord (dar priestess)
+        A shackled dar blademaster [agile]
+    Depth 26:
+        A potion of descent
+        A +3 ring of light
+        A mango
+        A scroll of enchanting
+        2048 gold pieces (5 piles)
+        A shackled dar blademaster
+        A commutation altar (vault 2)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A mango
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        A mango
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+        A mango
+    Depth 38:
+        A lumenstone from depth 38
+    Depth 39:
+        A lumenstone from depth 39
+        Some food
+    Depth 40:
+        A lumenstone from depth 40
+Seed 5:
+    Depth 1:
+        A +0 rapier <15>
+        A potion of strength
+        Some food
+        A potion of paralysis
+        A potion of detect magic
+        75 gold pieces
+    Depth 2:
+        A potion of strength
+        A potion of descent
+        A staff of lightning [2/2]
+        A scroll of discord
+        A potion of life
+        A scroll of enchanting
+        A +3 ring of light (vault 1)
+        A +1 ring of reaping (vault 1)
+        A +0 war axe <19> (vault 1)
+        A +1 whip of multiplicity <14> (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        A wand of teleportation [5] (vault 1)
+        A potion of levitation
+        A door key (opens vault 1)
+        115 gold pieces
+    Depth 3:
+        A potion of confusion
+        A scroll of protect armor
+        A -1 whip of plenty <14>
+        A potion of telepathy
+        A +1 shattering charm (ready) (vault 1)
+        A +3 ring of stealth (vault 1)
+        A +1 teleportation charm (ready) (vault 1)
+        A +0 dagger <12> (vault 1)
+        A +0 war hammer <20> (vault 1)
+        A +0 whip <14> (vault 1)
+        A wand of invisibility [3] (vault 1)
+        4 +0 incendiary darts <12>
+        140 gold pieces
+    Depth 4:
+        A potion of descent
+        A potion of incineration
+        +1 chain mail [6]<13>
+        A wand of slowness [4]
+        242 gold pieces (2 piles)
+    Depth 5:
+        A +2 war hammer <20>
+        A potion of fire immunity
+        A scroll of teleportation
+        +0 plate armor [11]<19>
+        161 gold pieces
+    Depth 6:
+        A potion of strength
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of life
+        609 gold pieces (4 piles)
+    Depth 7:
+        A scroll of enchanting
+        A +0 flail <17>
+        A scroll of identify
+        Some food
+        1203 gold pieces (7 piles)
+    Depth 8:
+        A potion of telepathy
+        A scroll of aggravate monsters
+        A potion of strength
+        A +2 flail <17>
+        987 gold pieces (6 piles)
+    Depth 9:
+        A scroll of identify
+        A wand of negation [4]
+        A potion of levitation
+        948 gold pieces (5 piles)
+    Depth 10:
+        A staff of discord [3/3]
+        A -2 war axe <19>
+        Some food
+        729 gold pieces (4 piles)
+        A shackled ogre
+    Depth 11:
+        A +2 guardian charm (ready)
+        +0 banded mail [7]<15>
+        A +0 broadsword <19>
+        A potion of speed
+        A scroll of enchanting
+        A scroll of identify
+        A potion of strength
+        A scroll of enchanting
+        A staff of lightning [2/2]
+        A potion of life
+        A door key (opens vault 1)
+        A potion of speed (vault 1)
+        A potion of levitation (vault 1)
+        A potion of invisibility (vault 1)
+        A potion of fire immunity (vault 1)
+        A potion of confusion (vault 1)
+        A potion of darkness (vault 1)
+        A potion of caustic gas (vault 1)
+        856 gold pieces (4 piles)
+    Depth 12:
+        A scroll of negation
+        +2 plate armor [13]<19>
+        A potion of telepathy
+        A staff of poison [2/2]
+        699 gold pieces (3 piles)
+        A potion of paralysis (goblin conjurer)
+        A shackled ogre
+    Depth 13:
+        A +3 war hammer <20>
+        A potion of fire immunity
+        A potion of levitation
+        +3 chain mail of respiration [8]<13>
+        A scroll of enchanting
+        A potion of speed
+        A +3 mace <16>
+        Some food
+        958 gold pieces (4 piles)
+    Depth 14:
+        A potion of hallucination
+        Some food
+        A scroll of identify
+        A potion of incineration
+        1202 gold pieces (5 piles)
+    Depth 15:
+        A potion of creeping death
+        A potion of strength
+        A potion of life
+        A door key (vault 4) (opens vault 1)
+        A +2 ring of regeneration (vault 4)
+        A +2 dagger of speed <12> (vault 4)
+        A door key (opens vault 4)
+        1059 gold pieces (4 piles)
+        A resurrection altar (vault 1)
+    Depth 16:
+        A scroll of remove curse
+        A +1 guardian charm (ready)
+        A staff of firebolt [2/2]
+        A potion of strength
+        1178 gold pieces (4 piles)
+        A shackled salamander
+    Depth 17:
+        A potion of confusion
+        A staff of protection [2/2]
+        A scroll of enchanting
+        1187 gold pieces (4 piles)
+    Depth 18:
+        A scroll of teleportation
+        A scroll of enchanting
+        A scroll of enchanting
+        Some food
+        1323 gold pieces (4 piles)
+        A potion of speed (dar priestess)
+    Depth 19:
+        +0 plate armor [11]<19>
+        A potion of detect magic
+        A +0 rapier <15>
+        13 +0 javelins <15>
+        A door key (opens vault 1)
+        A potion of descent (vault 1)
+        A potion of hallucination (vault 1)
+        A potion of detect magic (vault 1)
+        A potion of incineration (vault 1)
+        A potion of telepathy (vault 1)
+        A potion of fire immunity (vault 1)
+        1648 gold pieces (5 piles)
+        A shackled troll
+    Depth 20:
+        A scroll of identify
+        A potion of descent
+        A scroll of summon monsters
+        1789 gold pieces (6 piles)
+        A scroll of aggravate monsters (dar priestess)
+    Depth 21:
+        +0 scale mail [4]<12>
+        A potion of strength
+        A potion of life
+        Some food
+        2349 gold pieces (7 piles)
+    Depth 22:
+        A +2 teleportation charm (ready)
+        A potion of descent
+        A potion of strength
+        A scroll of enchanting
+        Some food
+        2236 gold pieces (6 piles)
+        A scroll of magic mapping (dar battlemage)
+        A scroll of summon monsters (dar priestess)
+        A -3 mace of plenty <16> (dar blademaster)
+    Depth 23:
+        A scroll of enchanting
+        A potion of detect magic
+        A scroll of protect weapon
+        A scroll of enchanting
+        1371 gold pieces (4 piles)
+        A resurrection altar (vault 1)
+    Depth 24:
+        A potion of incineration
+        A scroll of discord
+        A scroll of teleportation
+        A scroll of enchanting
+        A potion of life
+        2015 gold pieces (5 piles)
+        A scroll of sanctuary (dar priestess)
+        A shackled dar priestess
+    Depth 25:
+        A potion of levitation
+        A potion of creeping death
+        A scroll of discord
+        A +0 broadsword <19>
+        A potion of paralysis
+        Some food
+        1895 gold pieces (5 piles)
+        A shackled dar priestess
+        A shackled dar blademaster
+        A shackled golem [juggernaut]
+    Depth 26:
+        A potion of telepathy
+        +0 leather armor [3]<10>
+        A potion of fire immunity
+        1909 gold pieces (5 piles)
+        A shackled dar priestess
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A mango
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+    Depth 35:
+        A lumenstone from depth 35
+        A mango
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        A mango
+Seed 6:
+    Depth 1:
+        A scroll of remove curse
+        A potion of caustic gas
+        -1 leather armor of burden [2]<10>
+        A potion of descent
+        A potion of life
+        A +4 ring of stealth (vault 1)
+        A +1 ring of light (vault 1)
+        A +2 ring of wisdom (vault 1)
+        A +3 ring of transference (vault 1)
+        82 gold pieces
+    Depth 2:
+        A scroll of enchanting
+        A +0 dagger <12>
+        A potion of caustic gas
+        A scroll of shattering
+        A potion of telepathy
+        A scroll of sanctuary
+        A scroll of identify
+        A potion of caustic gas
+        A wand of invisibility [5]
+        A potion of detect magic
+        A potion of caustic gas
+        A scroll of recharging
+    Depth 3:
+        A scroll of protect weapon
+        A potion of strength
+        A staff of lightning [3/3]
+        A mango
+        231 gold pieces (2 piles)
+    Depth 4:
+        A potion of detect magic
+        A +0 whip <14>
+        A +2 negation charm (ready)
+        A potion of confusion
+        131 gold pieces
+    Depth 5:
+        A +0 mace <16>
+        A potion of life
+        A +0 spear <13>
+        345 gold pieces (2 piles)
+    Depth 6:
+        A potion of strength
+        A wand of negation [5]
+        A mango
+        A cage key
+        671 gold pieces (4 piles)
+        A caged goblin mystic
+        A caged goblin
+        A caged goblin mystic
+        A caged goblin mystic
+        A caged goblin mystic
+    Depth 7:
+        A +1 invisibility charm (ready)
+        A potion of strength
+        -1 plate armor [10]<19>
+        A scroll of remove curse
+        A potion of levitation
+        A scroll of enchanting
+        650 gold pieces (4 piles)
+    Depth 8:
+        A potion of hallucination
+        A potion of paralysis
+        -1 splint mail of vulnerability [8]<17>
+        866 gold pieces (5 piles)
+    Depth 9:
+        A potion of creeping death
+        A +1 health charm (ready)
+        Some food
+        943 gold pieces (5 piles)
+    Depth 10:
+        A scroll of remove curse
+        A wand of invisibility [4]
+        A scroll of remove curse
+        A scroll of enchanting
+        418 gold pieces (2 piles)
+        A potion of hallucination (goblin conjurer)
+    Depth 11:
+        A potion of invisibility
+        A potion of confusion
+        A potion of life
+        A scroll of enchanting
+        525 gold pieces (2 piles)
+        A shackled wraith
+        A shackled dar priestess
+    Depth 12:
+        A potion of confusion
+        A +0 rapier <15>
+        A scroll of enchanting
+        Some food
+        1556 gold pieces (7 piles)
+    Depth 13:
+        A staff of firebolt [2/2]
+        A scroll of sanctuary
+        A potion of fire immunity
+        A potion of strength
+        A door key (opens vault 1)
+        847 gold pieces (4 piles)
+        A shackled ogre
+        A commutation altar (vault 1)
+    Depth 14:
+        A potion of telepathy
+        A +0 war pike <18>
+        A potion of incineration
+        A door key (opens vault 1)
+        +2 chain mail of absorption [7]<13> (vault 1)
+        610 gold pieces (3 piles)
+    Depth 15:
+        A potion of detect magic
+        A potion of life
+        Some food
+        908 gold pieces (3 piles)
+        A shackled naga
+    Depth 16:
+        A +0 axe <15>
+        +0 plate armor [11]<19>
+        A scroll of enchanting
+        A potion of strength
+        A potion of caustic gas
+        A potion of strength
+        1191 gold pieces (4 piles)
+        A scroll of remove curse (dar priestess)
+    Depth 17:
+        A +0 axe <15>
+        A potion of fire immunity
+        Some food
+        1157 gold pieces (4 piles)
+        A scroll of magic mapping (dar priestess)
+    Depth 18:
+        A scroll of enchanting
+        -1 splint mail [8]<17>
+        A wand of invisibility [5]
+        A potion of invisibility
+        A potion of caustic gas
+        A scroll of summon monsters
+        A potion of telepathy
+        2235 gold pieces (7 piles)
+        A potion of detect magic (dar priestess)
+        A shackled dar blademaster
+    Depth 19:
+        A scroll of enchanting
+        A potion of darkness
+        +0 banded mail [7]<15>
+        1416 gold pieces (4 piles)
+        -2 scale mail [2]<12> (dar blademaster)
+    Depth 20:
+        A potion of detect magic
+        A potion of confusion
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of life
+        Some food
+        2788 gold pieces (8 piles)
+        A commutation altar (vault 1)
+    Depth 21:
+        A potion of strength
+        A scroll of enchanting
+        +0 leather armor [3]<10>
+        A potion of detect magic
+        A -1 war pike <18>
+        A potion of telepathy
+        +0 scale mail [4]<12>
+        A +3 ring of clairvoyance
+        2055 gold pieces (6 piles)
+    Depth 22:
+        A potion of telepathy
+        A wand of beckoning [3]
+        Some food
+        1307 gold pieces (4 piles)
+        A shackled golem
+        A shackled tentacle horror
+    Depth 23:
+        A potion of strength
+        A potion of caustic gas
+        6 +0 incendiary darts <12>
+        A scroll of enchanting
+        A +2 dagger of infernal slaying <12>
+        A potion of life
+        2196 gold pieces (6 piles)
+        A potion of levitation (dar blademaster)
+        A shackled dar blademaster
+    Depth 24:
+        A scroll of recharging
+        A potion of incineration
+        A scroll of enchanting
+        Some food
+        2006 gold pieces (5 piles)
+        A potion of descent (dar blademaster)
+        A potion of creeping death (dragon)
+        A shackled tentacle horror
+        A shackled dragon
+        A shackled dragon
+    Depth 25:
+        6 +0 incendiary darts <12>
+        A potion of strength
+        +0 splint mail [9]<17>
+        A +3 ring of light
+        A potion of invisibility
+        3290 gold pieces (8 piles)
+        A scroll of identify (dragon)
+        A scroll of discord (dar battlemage)
+        A potion of fire immunity (dar battlemage)
+        A shackled golem
+        A commutation altar (vault 1)
+    Depth 26:
+        A scroll of shattering
+        A +1 protection charm (ready)
+        A wand of slowness [4]
+        A potion of detect magic
+        +0 leather armor [3]<10>
+        A potion of fire immunity
+        A +4 ring of reaping
+        A +2 sword of confusion <14>
+        A potion of speed
+        Some food
+        A scroll of aggravate monsters
+        2408 gold pieces (6 piles)
+        A scroll of recharging (dragon [infested])
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        Some food
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        A mango
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 7:
+    Depth 1:
+        A potion of life
+        A scroll of enchanting
+        A potion of descent
+        A scroll of protect weapon
+        A potion of fire immunity
+        +0 chain mail [5]<13>
+        71 gold pieces
+    Depth 2:
+        +0 banded mail [7]<15>
+        A scroll of sanctuary
+        +0 banded mail [7]<15>
+        A scroll of recharging
+        A potion of detect magic
+        A potion of hallucination
+        A potion of detect magic
+        A potion of invisibility
+        A potion of strength
+    Depth 3:
+        A scroll of remove curse
+        A potion of levitation
+        A potion of strength
+        A scroll of enchanting
+        Some food
+        A +2 ring of regeneration (vault 1)
+        A staff of obstruction [2/2] (vault 1)
+        A staff of blinking [2/2] (vault 1)
+        +1 banded mail [8]<15> (vault 1)
+        +1 scale mail of dampening [5]<12> (vault 1)
+        A wand of negation [6] (vault 1)
+        A wand of beckoning [4] (vault 1)
+        A door key (opens vault 1)
+        81 gold pieces
+        A scroll of sanctuary (goblin conjurer)
+    Depth 4:
+        A scroll of remove curse
+        A scroll of enchanting
+        A scroll of shattering
+        A +0 mace <16>
+        A -3 ring of clairvoyance
+        266 gold pieces (2 piles)
+        A potion of confusion (goblin conjurer)
+    Depth 5:
+        A wand of slowness [5]
+        A potion of descent
+        A scroll of enchanting
+        A scroll of identify
+        A staff of tunneling [3/3]
+        A potion of telepathy
+        556 gold pieces (4 piles)
+        A shackled goblin mystic
+    Depth 6:
+        A potion of strength
+        A scroll of protect armor
+        +0 scale mail [4]<12>
+        A scroll of enchanting
+        A potion of detect magic
+        A wand of slowness [2]
+        463 gold pieces (3 piles)
+    Depth 7:
+        A potion of life
+        A potion of caustic gas
+        A scroll of sanctuary
+        Some food
+        A staff of poison [2/2] (vault 1)
+        A staff of haste [3/3] (vault 1)
+        462 gold pieces (3 piles)
+        A scroll of aggravate monsters (goblin conjurer)
+    Depth 8:
+        A potion of detect magic
+        A potion of detect magic
+        A scroll of identify
+        761 gold pieces (5 piles)
+        A shackled goblin mystic
+    Depth 9:
+        A potion of fire immunity
+        A potion of hallucination
+        A potion of invisibility
+        A scroll of enchanting
+        A scroll of discord
+        A potion of strength
+        1037 gold pieces (6 piles)
+    Depth 10:
+        A potion of caustic gas
+        A scroll of enchanting
+        Some food
+        363 gold pieces (2 piles)
+    Depth 11:
+        A potion of speed
+        A scroll of protect weapon
+        A +0 sword <14>
+        A +1 recharging charm (ready)
+        816 gold pieces (4 piles)
+    Depth 12:
+        A potion of life
+        A potion of darkness
+        A staff of obstruction [3/3]
+        +0 plate armor [11]<19>
+        A potion of levitation
+        A cage key
+        A cage key
+        A cage key
+        1069 gold pieces (5 piles)
+        A potion of caustic gas (dar blademaster)
+        A potion of detect magic (dar priestess)
+        A potion of levitation (dar blademaster)
+        A caged dar priestess
+        A caged pixie
+        A caged troll
+        A caged pixie
+        A caged dar blademaster
+        A caged pixie
+        A caged dar priestess
+        A caged dar blademaster
+        A caged dar priestess
+    Depth 13:
+        A potion of hallucination
+        A +3 ring of stealth
+        A potion of confusion
+        A potion of strength
+        A -2 spear of mercy <13>
+        Some food
+        1742 gold pieces (7 piles)
+        A shackled centaur
+    Depth 14:
+        A potion of speed
+        A scroll of identify
+        A potion of strength
+        A +2 telepathy charm (ready)
+        A potion of levitation
+        1220 gold pieces (5 piles)
+        A scroll of discord (goblin mystic)
+    Depth 15:
+        A potion of incineration
+        A potion of darkness
+        A +0 dagger <12>
+        A potion of confusion
+        A potion of invisibility
+        A wand of negation [6]
+        Some food
+        1050 gold pieces (4 piles)
+    Depth 16:
+        A scroll of enchanting
+        A potion of hallucination
+        A scroll of protect armor
+        A scroll of enchanting
+        A potion of life
+        1134 gold pieces (5 piles)
+        A shackled troll
+    Depth 17:
+        +0 chain mail [5]<13>
+        -3 plate armor of burden [8]<19>
+        A potion of caustic gas
+        1143 gold pieces (4 piles)
+    Depth 18:
+        A potion of incineration
+        A scroll of enchanting
+        A scroll of shattering
+        A potion of strength
+        A potion of caustic gas
+        Some food
+        1226 gold pieces (4 piles)
+        A shackled pixie
+    Depth 19:
+        A +1 protection charm (ready)
+        A potion of levitation
+        A potion of detect magic
+        A scroll of teleportation
+        A potion of life
+        1315 gold pieces (4 piles)
+        A scroll of recharging (dar battlemage)
+        A scroll of discord (dar battlemage)
+        A potion of caustic gas (dar priestess)
+        A potion of creeping death (dar blademaster)
+        A shackled dar battlemage
+        A shackled dar battlemage
+    Depth 20:
+        A potion of paralysis
+        A potion of paralysis
+        A potion of confusion
+        Some food
+        A door key (vault 4) (opens vault 1)
+        A +1 ring of wisdom (vault 4)
+        +0 plate armor [11]<19> (vault 4)
+        +0 scale mail [4]<12> (vault 4)
+        A potion of life (vault 1)
+        2057 gold pieces (6 piles)
+        A staff of blinking [3/3] (dar priestess)
+        A +1 rapier <15> (dar blademaster)
+    Depth 21:
+        A scroll of protect weapon
+        A scroll of enchanting
+        A potion of caustic gas
+        A scroll of enchanting
+        2362 gold pieces (7 piles)
+    Depth 22:
+        A scroll of identify
+        A potion of paralysis
+        A potion of confusion
+        2319 gold pieces (7 piles)
+    Depth 23:
+        A scroll of enchanting
+        A potion of telepathy
+        A potion of life
+        Some food
+        2225 gold pieces (6 piles)
+    Depth 24:
+        A potion of detect magic
+        A potion of hallucination
+        A potion of strength
+        A scroll of protect armor
+        A scroll of enchanting
+        2504 gold pieces (7 piles)
+        A potion of descent (dragon)
+        A potion of speed (dar blademaster)
+    Depth 25:
+        +0 splint mail [9]<17>
+        A scroll of identify
+        Some food
+        2059 gold pieces (5 piles)
+        A potion of speed (dar battlemage)
+        A scroll of negation (dar priestess)
+        A shackled tentacle horror
+    Depth 26:
+        A scroll of enchanting
+        A potion of detect magic
+        A potion of strength
+        A scroll of aggravate monsters
+        2322 gold pieces (6 piles)
+        A scroll of summon monsters (dragon)
+        A shackled dar blademaster
+        A shackled tentacle horror
+        A shackled dragon
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        Some food
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        Some food
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+    Depth 35:
+        A lumenstone from depth 35
+        A mango
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        A mango
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 8:
+    Depth 1:
+        A +1 health charm (ready)
+        A potion of telepathy
+        +0 splint mail [9]<17>
+        A potion of levitation
+        A -2 mace <16>
+        A potion of detect magic
+    Depth 2:
+        A staff of firebolt [3/3]
+        A -2 war hammer <20>
+        +0 splint mail [9]<17>
+        A potion of life
+        A potion of detect magic
+        A staff of firebolt [2/2] (vault 1)
+        A staff of conjuration [2/2] (vault 1)
+        A staff of poison [2/2] (vault 1)
+        A staff of discord [3/3] (vault 1)
+        A staff of blinking [2/2] (vault 1)
+        A door key (opens vault 1)
+    Depth 3:
+        +0 leather armor [3]<10>
+        -3 leather armor [0]<10>
+        A potion of strength
+        A potion of invisibility
+        A potion of detect magic
+        Some food
+        219 gold pieces (2 piles)
+        A shackled goblin
+    Depth 4:
+        A scroll of sanctuary
+        A scroll of identify
+        A scroll of enchanting
+        A +1 ring of awareness
+        A potion of caustic gas
+        A potion of confusion
+        450 gold pieces (4 piles)
+        A shackled monkey
+    Depth 5:
+        A scroll of enchanting
+        A scroll of remove curse
+        A potion of hallucination
+        134 gold pieces
+    Depth 6:
+        A potion of life
+        A potion of telepathy
+        A scroll of protect weapon
+        Some food
+        414 gold pieces (3 piles)
+    Depth 7:
+        A wand of teleportation [5]
+        A potion of strength
+        A scroll of enchanting
+        A scroll of enchanting
+        A +1 negation charm (ready)
+        743 gold pieces (4 piles)
+        A scroll of recharging (goblin conjurer)
+        A +1 health charm (ready) (goblin warlord)
+        A shackled ogre
+    Depth 8:
+        A scroll of teleportation
+        A potion of strength
+        A potion of invisibility
+        A staff of blinking [4/4] (vault 3)
+        A +1 ring of awareness (vault 3)
+        A +1 health charm (ready) (vault 3)
+        A wand of invisibility [5] (vault 3)
+        A door key (opens vault 3)
+        691 gold pieces (4 piles)
+        A staff of poison [2/2] (black jelly)
+    Depth 9:
+        A potion of fire immunity
+        A potion of hallucination
+        A potion of strength
+        1070 gold pieces (5 piles)
+    Depth 10:
+        A -2 ring of wisdom
+        A potion of descent
+        Some food
+        667 gold pieces (3 piles)
+    Depth 11:
+        A +1 guardian charm (ready)
+        A +2 protection charm (ready)
+        A potion of life
+        438 gold pieces (2 piles)
+    Depth 12:
+        A potion of strength
+        A +0 war axe <19>
+        Some food
+        A scroll of summon monsters
+        1100 gold pieces (5 piles)
+    Depth 13:
+        A potion of caustic gas
+        A scroll of sanctuary
+        A +0 spear <13>
+        A potion of confusion
+        A scroll of enchanting
+        A potion of invisibility
+        A scroll of enchanting
+        A potion of descent
+        732 gold pieces (3 piles)
+        A staff of conjuration [3/3] (dar blademaster)
+    Depth 14:
+        Some food
+        A potion of invisibility
+        A scroll of aggravate monsters
+        733 gold pieces (3 piles)
+    Depth 15:
+        A potion of detect magic
+        A potion of caustic gas
+        A scroll of enchanting
+        A potion of hallucination
+        A potion of life
+        1379 gold pieces (6 piles)
+        A door key (black jelly) (opens vault 1)
+        A resurrection altar (vault 1)
+    Depth 16:
+        A potion of levitation
+        +3 banded mail of reflection [10]<15>
+        A potion of invisibility
+        A potion of invisibility
+        A scroll of protect armor
+        A potion of strength
+        +2 scale mail [6]<12>
+        A scroll of enchanting
+        A scroll of magic mapping
+        1781 gold pieces (7 piles)
+        A shackled pixie
+    Depth 17:
+        A potion of hallucination
+        A potion of strength
+        A potion of descent
+        A potion of hallucination
+        A potion of incineration
+        1091 gold pieces (4 piles)
+    Depth 18:
+        A -3 war hammer <20>
+        A scroll of protect weapon
+        A potion of caustic gas
+        Some food
+        2157 gold pieces (7 piles)
+        A shackled imp
+    Depth 19:
+        A scroll of enchanting
+        A potion of telepathy
+        A potion of levitation
+        A scroll of enchanting
+        A scroll of discord
+        A potion of hallucination
+        A scroll of enchanting
+        A door key (opens vault 1)
+        1301 gold pieces (4 piles)
+        A potion of descent (dar battlemage)
+        A potion of creeping death (dar blademaster)
+        A shackled imp
+        A resurrection altar (vault 1)
+    Depth 20:
+        A scroll of shattering
+        A potion of darkness
+        A potion of life
+        Some food
+        2128 gold pieces (6 piles)
+        A potion of telepathy (dar battlemage)
+        A potion of detect magic (dar blademaster)
+        A shackled dar blademaster
+    Depth 21:
+        +0 banded mail [7]<15>
+        A scroll of recharging
+        A potion of strength
+        A scroll of negation
+        1941 gold pieces (6 piles)
+        A scroll of recharging (dar priestess)
+    Depth 22:
+        A potion of fire immunity
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        2513 gold pieces (7 piles)
+        A shackled dar battlemage
+    Depth 23:
+        A potion of darkness
+        A potion of life
+        A potion of detect magic
+        A +0 rapier <15>
+        A potion of strength
+        A scroll of protect armor
+        A potion of detect magic
+        A potion of creeping death
+        A potion of descent
+        A +0 whip <14>
+        Some food
+        A door key (opens vault 1)
+        1241 gold pieces (3 piles)
+        A shackled dar priestess
+        A commutation altar (vault 1)
+    Depth 24:
+        A potion of caustic gas
+        A -3 axe <15>
+        A potion of telepathy
+        A potion of caustic gas
+        A +0 whip <14>
+        A potion of telepathy
+        A scroll of enchanting
+        A potion of incineration
+        A potion of telepathy
+        1686 gold pieces (5 piles)
+        A scroll of shattering (dar battlemage)
+        A shackled tentacle horror
+    Depth 25:
+        -3 plate armor of vulnerability [8]<19>
+        Some food
+        +0 splint mail [9]<17>
+        A potion of telepathy
+        A mango
+        2425 gold pieces (7 piles)
+        A scroll of remove curse (dar battlemage)
+    Depth 26:
+        A scroll of negation
+        A scroll of summon monsters
+        A wand of slowness [4]
+        2088 gold pieces (5 piles)
+        A scroll of magic mapping (dar blademaster)
+        A shackled dar battlemage
+        A shackled tentacle horror [explosive]
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        A mango
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 9:
+    Depth 1:
+        A scroll of enchanting
+        A scroll of enchanting
+        A -3 sword of mercy <14>
+        A scroll of protect armor
+        A scroll of shattering
+        A potion of life
+        A potion of fire immunity
+        A scroll of identify
+        A +2 ring of light (vault 4)
+        A +3 ring of regeneration (vault 4)
+        A wand of domination [1] (vault 4)
+        +2 plate armor [13]<19> (vault 4)
+        A wand of slowness [5] (vault 4)
+        A wand of teleportation [3] (vault 4)
+        A door key (opens vault 4)
+        A +3 ring of awareness (vault 1)
+        A staff of protection [3/3] (vault 1)
+        A +4 broadsword <19> (vault 1)
+        +3 leather armor of respiration [6]<10> (vault 1)
+        +3 scale mail [7]<12> (vault 1)
+        A wand of beckoning [2] (vault 1)
+        A potion of levitation
+        A door key (opens vault 1)
+    Depth 2:
+        A potion of invisibility
+        A scroll of enchanting
+        A potion of strength
+        A +0 whip <14>
+        -1 chain mail [4]<13>
+        A +0 war axe <19>
+        A scroll of sanctuary
+        A potion of darkness
+        A +2 ring of reaping (vault 1)
+        A +2 invisibility charm (ready) (vault 1)
+        A +3 sword of confusion <14> (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A +0 whip <14> (vault 1)
+        A wand of negation [5] (vault 1)
+        A door key (opens vault 1)
+    Depth 3:
+        A scroll of summon monsters
+        A staff of firebolt [3/3]
+        A potion of strength
+        A potion of detect magic
+        A mango
+        126 gold pieces
+    Depth 4:
+        A potion of telepathy
+        A potion of descent
+        A potion of invisibility
+        A scroll of discord
+        272 gold pieces (2 piles)
+    Depth 5:
+        A potion of strength
+        A staff of tunneling [2/2]
+        A potion of caustic gas
+        A potion of hallucination
+        A scroll of enchanting
+        A staff of lightning [3/3]
+        504 gold pieces (4 piles)
+    Depth 6:
+        A potion of telepathy
+        Some food
+        A potion of paralysis
+        Some food
+        A +1 ring of light
+        A +1 fire immunity charm (ready)
+        642 gold pieces (4 piles)
+    Depth 7:
+        A scroll of remove curse
+        A scroll of enchanting
+        A scroll of aggravate monsters
+        A scroll of identify
+        642 gold pieces (4 piles)
+    Depth 8:
+        A potion of invisibility
+        A scroll of aggravate monsters
+        A potion of life
+        790 gold pieces (4 piles)
+        A shackled goblin mystic
+        A shackled dar priestess
+    Depth 9:
+        A scroll of shattering
+        A -1 ring of transference
+        A potion of telepathy
+        A scroll of enchanting
+        A scroll of sanctuary
+        A scroll of summon monsters
+        766 gold pieces (4 piles)
+    Depth 10:
+        A scroll of teleportation
+        A scroll of discord
+        A potion of strength
+        340 gold pieces (2 piles)
+    Depth 11:
+        A +2 recharging charm (ready)
+        A potion of descent
+        A potion of fire immunity
+        A potion of life
+        1104 gold pieces (5 piles)
+        A scroll of recharging (goblin conjurer)
+    Depth 12:
+        A scroll of identify
+        A scroll of shattering
+        A scroll of identify
+        A scroll of teleportation
+        913 gold pieces (4 piles)
+        A shackled dar blademaster
+    Depth 13:
+        A scroll of enchanting
+        A scroll of discord
+        A +0 broadsword <19>
+        Some food
+        705 gold pieces (3 piles)
+        A scroll of identify (dar blademaster)
+    Depth 14:
+        A -3 broadsword <19>
+        -2 chain mail of burden [3]<13>
+        A potion of incineration
+        A staff of firebolt [3/3]
+        1241 gold pieces (6 piles)
+    Depth 15:
+        A potion of telepathy
+        A scroll of protect armor
+        A potion of strength
+        A scroll of shattering
+        935 gold pieces (4 piles)
+    Depth 16:
+        A scroll of magic mapping
+        A potion of life
+        Some food
+        1076 gold pieces (4 piles)
+    Depth 17:
+        A scroll of enchanting
+        A potion of strength
+        A potion of fire immunity
+        A potion of telepathy
+        1478 gold pieces (5 piles)
+        A shackled centaur
+    Depth 18:
+        A scroll of enchanting
+        A potion of hallucination
+        A scroll of magic mapping
+        Some food
+        1507 gold pieces (5 piles)
+        A scroll of magic mapping (dar battlemage)
+        A scroll of recharging (dar blademaster)
+        A shackled golem
+    Depth 19:
+        A +0 war axe <19>
+        A scroll of remove curse
+        A potion of caustic gas
+        A scroll of enchanting
+        1527 gold pieces (5 piles)
+        A shackled wraith
+        A shackled naga
+    Depth 20:
+        A potion of invisibility
+        A scroll of enchanting
+        A scroll of enchanting
+        A scroll of summon monsters
+        A potion of strength
+        A potion of life
+        A mango
+        1462 gold pieces (5 piles)
+    Depth 21:
+        A scroll of teleportation
+        A potion of fire immunity
+        A scroll of enchanting
+        2467 gold pieces (7 piles)
+    Depth 22:
+        A scroll of negation
+        A potion of caustic gas
+        A potion of creeping death
+        Some food
+        3070 gold pieces (9 piles)
+    Depth 23:
+        A potion of strength
+        A scroll of remove curse
+        A scroll of enchanting
+        A scroll of identify
+        A potion of speed
+        A scroll of negation (vault 1)
+        A scroll of aggravate monsters (vault 1)
+        A scroll of sanctuary (vault 1)
+        A potion of life (vault 1)
+        2114 gold pieces (6 piles)
+        +0 scale mail [4]<12> (dar priestess)
+        A staff of lightning [3/3] (dar battlemage)
+        A scroll of summon monsters (dar priestess)
+    Depth 24:
+        Some food
+        A potion of life
+        Some food
+        2628 gold pieces (7 piles)
+        A potion of telepathy (dragon)
+    Depth 25:
+        A scroll of identify
+        A +2 war hammer <20>
+        A potion of incineration
+        A +2 negation charm (ready)
+        A potion of fire immunity
+        A scroll of summon monsters
+        A staff of lightning [3/3]
+        1729 gold pieces (4 piles)
+        A potion of invisibility (dragon)
+        A shackled golem
+    Depth 26:
+        A potion of fire immunity
+        A potion of detect magic
+        A +0 mace <16>
+        A potion of descent
+        A scroll of enchanting
+        2208 gold pieces (5 piles)
+        A +0 war hammer <20> (dar battlemage)
+        A potion of speed (dragon)
+        A shackled tentacle horror
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 10:
+    Depth 1:
+        A potion of paralysis
+        A potion of caustic gas
+        A potion of caustic gas
+        A potion of life
+        A scroll of remove curse
+        A potion of strength
+        A scroll of enchanting
+        13 +0 javelins <15>
+        77 gold pieces
+    Depth 2:
+        A potion of hallucination
+        A potion of strength
+        A scroll of summon monsters
+        A staff of entrancement [2/2]
+        A scroll of sanctuary
+        A potion of invisibility
+        A potion of telepathy
+        A staff of poison [3/3] (vault 1)
+        A staff of tunneling [4/4] (vault 1)
+        A +3 ring of transference (vault 1)
+        A wand of empowerment [1] (vault 1)
+        A +3 axe of force <15> (vault 1)
+        A +0 spear <13> (vault 1)
+        A wand of invisibility [4] (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A staff of firebolt [3/3] (vault 3)
+        A staff of entrancement [4/4] (vault 3)
+        +3 splint mail [12]<17> (vault 3)
+        A +0 dagger <12> (vault 3)
+        A door key (opens vault 3)
+        118 gold pieces
+    Depth 3:
+        A potion of confusion
+        A potion of confusion
+        A potion of telepathy
+        A mango
+    Depth 4:
+        A scroll of identify
+        A potion of confusion
+        A +2 teleportation charm (ready)
+        A scroll of enchanting
+        A potion of detect magic
+        +2 plate armor [13]<19>
+        A staff of conjuration [2/2]
+        A potion of detect magic
+        A potion of hallucination
+        135 gold pieces
+        +2 plate armor [13]<19> (goblin conjurer)
+    Depth 5:
+        A scroll of enchanting
+        A potion of levitation
+        A scroll of teleportation
+        632 gold pieces (5 piles)
+    Depth 6:
+        A scroll of protect armor
+        +0 chain mail [5]<13>
+        A staff of discord [3/3]
+        A potion of invisibility
+        A scroll of identify
+        618 gold pieces (4 piles)
+    Depth 7:
+        A potion of confusion
+        A scroll of magic mapping
+        Some food
+        A +2 invisibility charm (ready) (vault 2)
+        A +2 haste charm (ready) (vault 2)
+        A +1 ring of awareness (vault 2)
+        A +0 sword <14> (vault 2)
+        A +0 spear <13> (vault 2)
+        466 gold pieces (3 piles)
+        A +2 health charm (ready) (goblin warlord)
+        A shackled goblin
+    Depth 8:
+        A scroll of aggravate monsters
+        A +0 war pike <18>
+        A potion of life
+        901 gold pieces (5 piles)
+    Depth 9:
+        A +0 war axe <19>
+        A +1 ring of stealth
+        A potion of speed
+        1181 gold pieces (6 piles)
+        A crystal orb (black jelly)
+        An allied mangrove dryad
+    Depth 10:
+        A scroll of aggravate monsters
+        +0 leather armor [3]<10>
+        A potion of detect magic
+        A scroll of sanctuary
+        A mango
+        367 gold pieces (2 piles)
+    Depth 11:
+        A scroll of enchanting
+        -3 chain mail [2]<13>
+        A potion of life
+        Some food
+        829 gold pieces (4 piles)
+        A scroll of identify (goblin conjurer)
+    Depth 12:
+        A potion of strength
+        A potion of speed
+        A potion of hallucination
+        A potion of caustic gas
+        +0 banded mail [7]<15>
+        A potion of hallucination
+        A +0 war pike <18>
+        A scroll of negation
+        1445 gold pieces (6 piles)
+    Depth 13:
+        A scroll of remove curse
+        A potion of strength
+        A scroll of enchanting
+        +1 leather armor [4]<10>
+        A potion of strength
+        1604 gold pieces (7 piles)
+        A scroll of identify (goblin mystic)
+        A scroll of magic mapping (goblin mystic)
+    Depth 14:
+        A scroll of identify
+        +0 scale mail [4]<12>
+        +0 chain mail [5]<13>
+        A potion of life
+        Some food
+        215 gold pieces
+    Depth 15:
+        A scroll of remove curse
+        A +0 dagger <12>
+        A potion of darkness
+        A potion of detect magic
+        A door key (opens vault 1)
+        A staff of discord [3/3] (vault 1)
+        A staff of lightning [3/3] (vault 1)
+        1489 gold pieces (6 piles)
+    Depth 16:
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of strength
+        A scroll of sanctuary
+        1508 gold pieces (5 piles)
+    Depth 17:
+        A +1 ring of clairvoyance
+        A scroll of enchanting
+        A potion of descent
+        916 gold pieces (3 piles)
+        A shackled salamander
+        A shackled wraith
+        A shackled naga
+    Depth 18:
+        A +2 ring of light
+        A scroll of enchanting
+        A potion of life
+        Some food
+        1207 gold pieces (4 piles)
+        A shackled pixie
+        A shackled dar priestess
+    Depth 19:
+        A scroll of enchanting
+        A scroll of enchanting
+        A scroll of enchanting
+        Some food
+        A scroll of enchanting
+        A scroll of sanctuary
+        A potion of confusion
+        A potion of strength
+        A potion of telepathy
+        1677 gold pieces (5 piles)
+        A scroll of summon monsters (dar battlemage)
+        A scroll of protect armor (dar blademaster)
+        A shackled golem
+    Depth 20:
+        A -2 axe <15>
+        A potion of confusion
+        +0 leather armor [3]<10>
+        A scroll of enchanting
+        A potion of speed
+        1730 gold pieces (5 piles)
+        A potion of confusion (dragon)
+    Depth 21:
+        A potion of hallucination
+        A +1 ring of awareness
+        A potion of strength
+        A +0 flail <17>
+        +0 banded mail [7]<15>
+        A mango
+        A door key (vault 8) (opens vault 6)
+        A staff of poison [3/3] (vault 8)
+        A wand of negation [4] (vault 8)
+        A door key (vault 10) (opens vault 8)
+        A scroll of teleportation
+        A door key (opens vault 3)
+        A crystal orb
+        1804 gold pieces (6 piles)
+        A shackled golem
+        An allied unicorn
+        A commutation altar (vault 3)
+        A commutation altar (vault 6)
+    Depth 22:
+        A wand of invisibility [4]
+        A +3 broadsword <19>
+        Some food
+        A +2 protection charm (ready)
+        1631 gold pieces (5 piles)
+    Depth 23:
+        A scroll of protect armor
+        A scroll of aggravate monsters
+        A potion of life
+        A potion of fire immunity
+        A scroll of protect armor
+        +3 scale mail of mutuality [7]<12>
+        A potion of creeping death
+        1872 gold pieces (5 piles)
+    Depth 24:
+        A wand of polymorphism [3]
+        +0 banded mail [7]<15>
+        A potion of hallucination
+        A wand of teleportation [3]
+        2629 gold pieces (7 piles)
+    Depth 25:
+        A +0 war hammer <20>
+        A scroll of recharging
+        A -2 sword <14>
+        2291 gold pieces (6 piles)
+        A potion of confusion (dragon)
+        A potion of fire immunity (dar blademaster)
+    Depth 26:
+        A scroll of enchanting
+        A scroll of protect weapon
+        A potion of invisibility
+        A scroll of shattering
+        A scroll of recharging
+        Some food
+        A door key (vault 6) (opens vault 4)
+        A staff of discord [2/2] (vault 6)
+        A +2 whip of speed <14> (vault 6)
+        A +0 spear <13> (vault 6)
+        A door key (opens vault 6)
+        2359 gold pieces (6 piles)
+        A +2 teleportation charm (ready) (dragon)
+        A shackled tentacle horror
+        A resurrection altar (vault 4)
+        A commutation altar (vault 2)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+    Depth 35:
+        A lumenstone from depth 35
+        Some food
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+        Some food
+    Depth 38:
+        A lumenstone from depth 38
+    Depth 39:
+        A lumenstone from depth 39
+        Some food
+    Depth 40:
+        A lumenstone from depth 40
+Seed 11:
+    Depth 1:
+        A potion of levitation
+        A potion of confusion
+        A +3 broadsword <19>
+        A +1 teleportation charm (ready)
+        A potion of levitation
+        A +3 sword <14>
+        A potion of caustic gas
+        215 gold pieces (3 piles)
+    Depth 2:
+        A potion of strength
+        A potion of life
+        A scroll of summon monsters
+        A potion of hallucination
+        A scroll of enchanting
+        A potion of speed
+        A staff of entrancement [3/3] (vault 1)
+        A +1 recharging charm (ready) (vault 1)
+        A wand of invisibility [3] (vault 1)
+        A +0 flail <17> (vault 1)
+        A wand of plenty [2] (vault 1)
+        A wand of negation [5] (vault 1)
+        5 +0 incendiary darts <12>
+    Depth 3:
+        A potion of levitation
+        A scroll of enchanting
+        A potion of creeping death
+        A scroll of aggravate monsters
+        A +0 war axe <19>
+        A potion of telepathy
+        Some food
+        354 gold pieces (3 piles)
+    Depth 4:
+        A scroll of enchanting
+        A scroll of aggravate monsters
+        A potion of levitation
+        A scroll of teleportation
+        224 gold pieces (2 piles)
+    Depth 5:
+        A scroll of summon monsters
+        A scroll of remove curse
+        A potion of incineration
+        150 gold pieces
+    Depth 6:
+        A +0 war hammer <20>
+        A potion of paralysis
+        +1 leather armor [4]<10>
+        -3 plate armor [8]<19>
+        A potion of life
+        958 gold pieces (6 piles)
+    Depth 7:
+        A scroll of identify
+        A potion of strength
+        A mango
+        A staff of obstruction [2/2] (vault 1)
+        A staff of firebolt [2/2] (vault 1)
+        A staff of tunneling [3/3] (vault 1)
+        A staff of poison [2/2] (vault 1)
+        A staff of conjuration [2/2] (vault 1)
+        677 gold pieces (4 piles)
+        A wand of slowness [2] (goblin mystic)
+    Depth 8:
+        A potion of confusion
+        A scroll of enchanting
+        A potion of hallucination
+        651 gold pieces (4 piles)
+    Depth 9:
+        A scroll of enchanting
+        A scroll of remove curse
+        A potion of telepathy
+        A scroll of protect armor
+        A scroll of shattering
+        A potion of caustic gas
+        A staff of protection [3/3]
+        A +1 ring of clairvoyance
+        A scroll of discord
+        446 gold pieces (2 piles)
+        A scroll of summon monsters (goblin conjurer)
+    Depth 10:
+        A potion of fire immunity
+        A scroll of recharging
+        Some food
+        747 gold pieces (4 piles)
+    Depth 11:
+        A potion of confusion
+        A scroll of enchanting
+        A potion of life
+        A potion of hallucination (vault 1)
+        A scroll of protect weapon (vault 1)
+        A potion of confusion (vault 1)
+        A potion of life (vault 1)
+        628 gold pieces (3 piles)
+        A shackled goblin mystic
+    Depth 12:
+        A scroll of recharging
+        A potion of detect magic
+        A potion of strength
+        Some food
+        880 gold pieces (4 piles)
+    Depth 13:
+        A scroll of enchanting
+        A wand of slowness [2]
+        +0 splint mail [9]<17>
+        A scroll of enchanting
+        A potion of descent
+        A staff of poison [3/3]
+        1194 gold pieces (5 piles)
+    Depth 14:
+        A scroll of enchanting
+        A potion of descent
+        A potion of strength
+        A door key (opens vault 1)
+        A scroll of enchanting (vault 1)
+        704 gold pieces (3 piles)
+        A shackled salamander
+    Depth 15:
+        A potion of fire immunity
+        A +0 war hammer <20>
+        A potion of strength
+        Some food
+        1003 gold pieces (4 piles)
+    Depth 16:
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of life
+        1417 gold pieces (5 piles)
+    Depth 17:
+        A staff of tunneling [2/2]
+        A potion of caustic gas
+        A potion of creeping death
+        A scroll of enchanting
+        A potion of strength
+        +0 leather armor [3]<10>
+        A potion of detect magic
+        A scroll of remove curse
+        A potion of darkness
+        A potion of fire immunity
+        1393 gold pieces (5 piles)
+        A shackled naga
+    Depth 18:
+        A potion of detect magic
+        A scroll of negation
+        A -3 spear <13>
+        A scroll of teleportation
+        A staff of firebolt [2/2]
+        A scroll of identify
+        A +1 ring of awareness
+        A potion of paralysis
+        A scroll of remove curse
+        Some food
+        1100 gold pieces (4 piles)
+    Depth 19:
+        A potion of fire immunity
+        A scroll of recharging
+        A potion of life
+        A door key (opens vault 1)
+        2084 gold pieces (6 piles)
+        A resurrection altar (vault 1)
+    Depth 20:
+        A scroll of enchanting
+        +1 scale mail [5]<12>
+        A potion of detect magic
+        A potion of strength
+        A potion of confusion
+        A mango
+        2237 gold pieces (7 piles)
+    Depth 21:
+        A potion of caustic gas
+        Some food
+        Some food
+        A door key (opens vault 1)
+        A scroll of enchanting (vault 1)
+        2195 gold pieces (6 piles)
+    Depth 22:
+        -3 leather armor [0]<10>
+        A potion of incineration
+        A potion of invisibility
+        1761 gold pieces (5 piles)
+        A shackled dar priestess
+    Depth 23:
+        A potion of caustic gas
+        A scroll of enchanting
+        A scroll of enchanting
+        2049 gold pieces (6 piles)
+        A shackled dar blademaster
+    Depth 24:
+        A scroll of summon monsters
+        A scroll of protect weapon
+        A scroll of identify
+        A potion of life
+        2422 gold pieces (6 piles)
+    Depth 25:
+        A +3 ring of clairvoyance
+        A potion of strength
+        +0 leather armor [3]<10>
+        A -2 rapier of mercy <15>
+        A scroll of magic mapping
+        A potion of fire immunity
+        Some food
+        A scroll of identify
+        1836 gold pieces (5 piles)
+    Depth 26:
+        A potion of strength
+        A scroll of recharging
+        A potion of strength
+        A potion of detect magic
+        A +0 flail <17>
+        2412 gold pieces (6 piles)
+        A potion of telepathy (dragon)
+        A shackled dar blademaster
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        Some food
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 12:
+    Depth 1:
+        +0 chain mail [5]<13>
+        A potion of levitation
+        A potion of levitation
+        A potion of detect magic
+        A potion of life
+        323 gold pieces (4 piles)
+    Depth 2:
+        A scroll of sanctuary
+        A potion of fire immunity
+        A scroll of summon monsters
+        A scroll of identify
+        A potion of invisibility
+        A potion of fire immunity
+        A potion of strength
+        105 gold pieces
+    Depth 3:
+        A +0 war hammer <20>
+        8 +0 javelins <15>
+        A wand of plenty [1]
+        A potion of invisibility
+        A scroll of enchanting
+        A mango
+        92 gold pieces
+        A shackled monkey
+    Depth 4:
+        8 +0 javelins <15>
+        +0 chain mail [5]<13>
+        A potion of levitation
+        A scroll of identify
+        415 gold pieces (3 piles)
+        A shackled monkey
+        A shackled monkey
+    Depth 5:
+        A scroll of enchanting
+        A scroll of remove curse
+        A potion of descent
+        A potion of hallucination
+        A cage key
+        445 gold pieces (3 piles)
+        A scroll of teleportation (goblin mystic)
+        A caged goblin conjurer
+        A caged goblin mystic
+        A caged goblin mystic
+    Depth 6:
+        A -1 war hammer of plenty <20>
+        A scroll of enchanting
+        A scroll of discord
+        A scroll of identify
+        A potion of detect magic
+        A potion of life
+        A +2 dagger <12>
+        A staff of firebolt [2/2] (vault 1)
+        A staff of poison [3/3] (vault 1)
+        A +0 mace <16> (vault 1)
+        A +3 axe <15> (vault 1)
+        A +0 sword <14> (vault 1)
+        A wand of polymorphism [3] (vault 1)
+        3 +0 incendiary darts <12>
+        387 gold pieces (3 piles)
+        A shackled goblin
+    Depth 7:
+        A scroll of sanctuary
+        A potion of fire immunity
+        Some food
+        836 gold pieces (5 piles)
+    Depth 8:
+        A staff of discord [3/3]
+        A scroll of enchanting
+        A +0 broadsword <19>
+        668 gold pieces (4 piles)
+    Depth 9:
+        A potion of incineration
+        A scroll of enchanting
+        A mango
+        A staff of conjuration [3/3] (vault 1)
+        A +1 recharging charm (ready) (vault 1)
+        +2 chain mail [7]<13> (vault 1)
+        A +0 war hammer <20> (vault 1)
+        A +0 mace <16> (vault 1)
+        A wand of slowness [3] (vault 1)
+        A door key (opens vault 1)
+        1011 gold pieces (5 piles)
+        A potion of darkness (goblin conjurer)
+        A scroll of protect armor (goblin conjurer)
+    Depth 10:
+        A scroll of discord
+        +0 scale mail [4]<12>
+        +0 plate armor [11]<19>
+        669 gold pieces (3 piles)
+        A scroll of aggravate monsters (goblin mystic)
+    Depth 11:
+        A scroll of enchanting
+        -1 banded mail [6]<15>
+        A potion of life
+        503 gold pieces (2 piles)
+        A potion of hallucination (dar blademaster)
+        A potion of detect magic (dar blademaster)
+    Depth 12:
+        Some food
+        A -2 dagger <12>
+        Some food
+        A potion of paralysis
+        +1 leather armor of multiplicity [4]<10> (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A scroll of enchanting (vault 1)
+        1000 gold pieces (5 piles)
+        A scroll of aggravate monsters (goblin mystic)
+        A potion of incineration (goblin mystic)
+        A potion of speed (goblin mystic)
+        A potion of levitation (goblin warlord)
+        A shackled ogre
+    Depth 13:
+        A potion of strength
+        A scroll of identify
+        A +0 axe <15>
+        A +2 ring of reaping
+        623 gold pieces (3 piles)
+        A shackled dar blademaster
+    Depth 14:
+        A potion of descent
+        A potion of strength
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of strength
+        1583 gold pieces (7 piles)
+    Depth 15:
+        A wand of domination [2]
+        A scroll of teleportation
+        A potion of fire immunity
+        A potion of strength
+        A potion of detect magic
+        A scroll of aggravate monsters
+        A potion of strength
+        A potion of life
+        A scroll of protect armor
+        1270 gold pieces (5 piles)
+    Depth 16:
+        A potion of detect magic
+        A scroll of summon monsters
+        A potion of caustic gas
+        1740 gold pieces (6 piles)
+    Depth 17:
+        A potion of detect magic
+        A scroll of enchanting
+        A scroll of aggravate monsters
+        Some food
+        833 gold pieces (3 piles)
+        A +2 telepathy charm (ready) (dar blademaster)
+        A shackled dar blademaster
+    Depth 18:
+        A potion of invisibility
+        A +0 spear <13>
+        A scroll of magic mapping
+        A scroll of enchanting
+        A +2 ring of stealth
+        A potion of strength
+        A scroll of enchanting
+        1870 gold pieces (6 piles)
+        A door key (imp) (opens vault 1)
+        A commutation altar (vault 1)
+    Depth 19:
+        A potion of telepathy
+        5 +0 incendiary darts <12>
+        A +2 guardian charm (ready)
+        A potion of speed
+        A potion of detect magic
+        A potion of life
+        A mango
+        A door key (opens vault 1)
+        1333 gold pieces (4 piles)
+        A shackled dar blademaster [vampiric]
+        A commutation altar (vault 1)
+    Depth 20:
+        A scroll of remove curse
+        A scroll of magic mapping
+        A scroll of identify
+        1871 gold pieces (6 piles)
+        A scroll of discord (dar priestess)
+    Depth 21:
+        A potion of detect magic
+        5 +0 incendiary darts <12>
+        A potion of levitation
+        A +0 war axe <19>
+        Some food
+        1566 gold pieces (5 piles)
+        A potion of detect magic (dar battlemage)
+        A shackled imp
+    Depth 22:
+        A potion of incineration
+        A scroll of enchanting
+        A potion of invisibility
+        2047 gold pieces (6 piles)
+    Depth 23:
+        A potion of incineration
+        A scroll of discord
+        A potion of strength
+        A potion of life (vault 1)
+        2524 gold pieces (7 piles)
+        A door key (stone guardian) (opens vault 1)
+    Depth 24:
+        A potion of creeping death
+        A potion of fire immunity
+        A potion of life
+        Some food
+        2353 gold pieces (6 piles)
+        A scroll of magic mapping (dar priestess)
+        A wand of teleportation [4] (dar blademaster)
+        A scroll of identify (dar blademaster [toxic])
+        A shackled dar blademaster
+    Depth 25:
+        A potion of descent
+        -1 leather armor [2]<10>
+        +0 banded mail [7]<15>
+        A potion of descent
+        A potion of paralysis
+        Some food
+        2184 gold pieces (6 piles)
+        A potion of paralysis (dar blademaster)
+        A shackled dar blademaster
+    Depth 26:
+        A scroll of identify
+        A potion of levitation
+        A +0 mace <16>
+        2115 gold pieces (5 piles)
+        A scroll of aggravate monsters (dragon)
+        A scroll of remove curse (dragon)
+        A shackled dar blademaster
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A mango
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        A mango
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+        Some food
+    Depth 40:
+        A lumenstone from depth 40
+Seed 13:
+    Depth 1:
+        A -2 whip of plenty <14>
+        A scroll of identify
+        A potion of speed
+        A scroll of sanctuary
+        A scroll of enchanting
+        299 gold pieces (3 piles)
+        A shackled monkey
+    Depth 2:
+        A +0 flail <17>
+        A scroll of enchanting
+        A wand of negation [4]
+        A scroll of aggravate monsters
+        A potion of life
+        A potion of strength
+    Depth 3:
+        A potion of levitation
+        A potion of incineration
+        A scroll of enchanting
+        A potion of descent
+        A wand of teleportation [4]
+        A +2 protection charm (ready)
+        A potion of hallucination
+        A potion of detect magic
+        A scroll of teleportation
+        +0 plate armor [11]<19>
+        A potion of speed
+        Some food
+        A +3 ring of stealth (vault 1)
+        A +1 invisibility charm (ready) (vault 1)
+        A +3 ring of awareness (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        +3 leather armor [6]<10> (vault 1)
+        A +0 mace <16> (vault 1)
+        A wand of beckoning [4] (vault 1)
+        A door key (opens vault 1)
+    Depth 4:
+        +0 scale mail [4]<12>
+        A scroll of identify
+        A scroll of shattering
+        A scroll of protect weapon
+        A +1 fire immunity charm (ready) (vault 1)
+        A staff of blinking [3/3] (vault 1)
+        A +3 ring of wisdom (vault 1)
+        A +0 axe <15> (vault 1)
+        A wand of plenty [2] (vault 1)
+        A +0 rapier <15> (vault 1)
+        A wand of slowness [5] (vault 1)
+        219 gold pieces (2 piles)
+    Depth 5:
+        A scroll of negation
+        A -3 whip of plenty <14>
+        A potion of incineration
+        A scroll of identify
+        281 gold pieces (2 piles)
+        A shackled monkey
+        A shackled goblin mystic
+    Depth 6:
+        A scroll of enchanting
+        A scroll of magic mapping
+        A scroll of protect weapon
+        474 gold pieces (3 piles)
+    Depth 7:
+        A scroll of sanctuary
+        A +1 rapier <15>
+        A potion of strength
+        Some food
+        607 gold pieces (4 piles)
+    Depth 8:
+        A potion of descent
+        A potion of strength
+        A scroll of enchanting
+        1002 gold pieces (6 piles)
+        A scroll of sanctuary (goblin mystic)
+        A shackled goblin mystic
+    Depth 9:
+        A potion of life
+        A +3 ring of transference
+        A scroll of identify
+        Some food
+        604 gold pieces (4 piles)
+    Depth 10:
+        +0 chain mail [5]<13>
+        A scroll of protect armor
+        A scroll of summon monsters
+        A scroll of enchanting
+        A potion of life
+        A +0 dagger <12>
+        A wand of domination [2]
+        900 gold pieces (5 piles)
+        -2 banded mail of burden [5]<15> (goblin conjurer)
+    Depth 11:
+        A scroll of negation
+        A potion of caustic gas
+        A +1 rapier <15>
+        A +2 ring of clairvoyance (vault 1)
+        A +3 ring of regeneration (vault 1)
+        A +4 ring of light (vault 1)
+        656 gold pieces (3 piles)
+        A scroll of magic mapping (goblin conjurer)
+    Depth 12:
+        A potion of creeping death
+        A scroll of shattering
+        A scroll of enchanting
+        887 gold pieces (4 piles)
+    Depth 13:
+        A +0 spear <13>
+        A potion of telepathy
+        Some food
+        A potion of incineration
+        669 gold pieces (3 piles)
+        A shackled ogre
+    Depth 14:
+        A potion of caustic gas
+        A wand of negation [5]
+        A +0 war axe <19>
+        1329 gold pieces (6 piles)
+    Depth 15:
+        A +0 broadsword <19>
+        A potion of telepathy
+        +0 splint mail [9]<17>
+        A potion of confusion
+        +1 splint mail [10]<17>
+        A scroll of enchanting
+        A potion of invisibility (vault 5)
+        A scroll of identify (vault 5)
+        A potion of life (vault 5)
+        A door key (vault 3) (opens vault 1)
+        A staff of obstruction [3/3] (vault 3)
+        +0 scale mail [4]<12> (vault 3)
+        A staff of firebolt [2/2] (vault 1)
+        A staff of obstruction [2/2] (vault 1)
+        703 gold pieces (3 piles)
+        A shackled naga [grappling]
+    Depth 16:
+        A potion of telepathy
+        A scroll of protect armor
+        A potion of life
+        A mango
+        2024 gold pieces (8 piles)
+    Depth 17:
+        A scroll of negation
+        A scroll of magic mapping
+        A potion of paralysis
+        A potion of strength
+        A scroll of enchanting
+        A staff of lightning [2/2]
+        A scroll of enchanting
+        +0 chain mail [5]<13>
+        A scroll of recharging
+        A mango
+        1164 gold pieces (4 piles)
+        A scroll of summon monsters (goblin conjurer)
+    Depth 18:
+        A potion of strength
+        A scroll of enchanting
+        A potion of life
+        A door key (opens vault 1)
+        A potion of telepathy (vault 1)
+        A potion of fire immunity (vault 1)
+        A potion of incineration (vault 1)
+        A potion of invisibility (vault 1)
+        A potion of darkness (vault 1)
+        1109 gold pieces (4 piles)
+    Depth 19:
+        A potion of levitation
+        A scroll of teleportation
+        A potion of strength
+        1225 gold pieces (4 piles)
+        A potion of invisibility (dar blademaster [reflective])
+        +2 banded mail [9]<15> (dar battlemage)
+        A potion of telepathy (dar blademaster)
+    Depth 20:
+        A scroll of enchanting
+        A +2 ring of wisdom
+        Some food
+        A door key (opens vault 1)
+        1621 gold pieces (5 piles)
+        A shackled imp
+        A resurrection altar (vault 1)
+    Depth 21:
+        A scroll of identify
+        A potion of caustic gas
+        A potion of invisibility
+        A +2 spear <13>
+        A scroll of identify
+        A potion of detect magic
+        Some food
+        A potion of speed
+        1652 gold pieces (5 piles)
+        A shackled dar blademaster [vampiric]
+    Depth 22:
+        A scroll of aggravate monsters
+        A scroll of magic mapping
+        A wand of slowness [5]
+        A potion of invisibility
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        A potion of detect magic
+        A potion of caustic gas
+        A staff of blinking [3/3]
+        A scroll of shattering
+        2654 gold pieces (7 piles)
+    Depth 23:
+        A potion of strength
+        A potion of levitation
+        A potion of paralysis
+        A potion of telepathy
+        A scroll of aggravate monsters
+        1664 gold pieces (5 piles)
+        A shackled dar battlemage
+    Depth 24:
+        A +0 war hammer <20>
+        A potion of life
+        A potion of fire immunity
+        A scroll of teleportation
+        +0 leather armor [3]<10>
+        A +1 ring of awareness
+        2277 gold pieces (6 piles)
+        A scroll of protect armor (dragon)
+        A staff of lightning [3/3] (dar priestess)
+    Depth 25:
+        A potion of strength
+        A scroll of enchanting
+        Some food
+        A scroll of summon monsters
+        2194 gold pieces (6 piles)
+        A scroll of identify (dar battlemage [infested])
+        A -2 mace of plenty <16> (dar priestess)
+        A +0 dagger <12> (dar blademaster)
+        A shackled golem
+    Depth 26:
+        A scroll of enchanting
+        A scroll of enchanting
+        Some food
+        2886 gold pieces (7 piles)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+    Depth 35:
+        A lumenstone from depth 35
+        A mango
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+        A mango
+    Depth 40:
+        A lumenstone from depth 40
+Seed 14:
+    Depth 1:
+        A +0 flail <17>
+        A potion of fire immunity
+        +2 banded mail [9]<15>
+        A potion of strength
+        A staff of firebolt [2/2]
+        A potion of levitation
+        A scroll of remove curse
+        A potion of caustic gas
+        189 gold pieces (2 piles)
+    Depth 2:
+        A +0 broadsword <19>
+        +2 banded mail of absorption [9]<15>
+        A potion of incineration
+        A scroll of protect weapon
+        A potion of speed
+        A scroll of identify
+        A potion of hallucination
+        A potion of telepathy
+        A potion of descent
+        A scroll of enchanting
+        10 +0 javelins <15>
+        A scroll of identify
+    Depth 3:
+        A potion of hallucination
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of strength
+        A staff of protection [3/3] (vault 1)
+        A staff of discord [3/3] (vault 1)
+        A +1 war axe <19> (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A wand of teleportation [4] (vault 1)
+        A wand of plenty [1] (vault 1)
+        A potion of incineration
+    Depth 4:
+        A potion of detect magic
+        A +0 mace <16>
+        A scroll of recharging
+        A scroll of magic mapping
+        A potion of life
+        Some food
+        109 gold pieces
+    Depth 5:
+        A potion of incineration
+        A scroll of enchanting
+        A potion of invisibility
+        535 gold pieces (4 piles)
+        A shackled monkey
+    Depth 6:
+        +0 splint mail [9]<17>
+        A potion of incineration
+        A scroll of enchanting
+        610 gold pieces (4 piles)
+    Depth 7:
+        A potion of hallucination
+        A -1 war hammer <20>
+        Some food
+        662 gold pieces (4 piles)
+        A shackled ogre
+        A shackled goblin mystic
+    Depth 8:
+        A +2 fire immunity charm (ready)
+        A potion of levitation
+        A wand of negation [5]
+        A potion of invisibility
+        A potion of strength
+        A potion of life
+        833 gold pieces (5 piles)
+    Depth 9:
+        A scroll of enchanting
+        A scroll of recharging
+        A potion of caustic gas
+        A scroll of identify
+        A scroll of shattering
+        731 gold pieces (4 piles)
+    Depth 10:
+        A potion of descent
+        A potion of strength
+        A potion of life
+        Some food
+        1005 gold pieces (5 piles)
+        +0 scale mail [4]<12> (dar blademaster)
+        A +1 war axe <19> (dar blademaster)
+        A potion of confusion (goblin mystic)
+        A potion of caustic gas (goblin mystic)
+    Depth 11:
+        A scroll of recharging
+        A scroll of protect weapon
+        A scroll of negation
+        A potion of detect magic
+        A +0 war pike <18> (vault 1)
+        16 +0 javelins <15> (vault 1)
+        +2 leather armor [5]<10> (vault 1)
+        A potion of life (vault 1)
+        661 gold pieces (3 piles)
+        A potion of descent (dar blademaster)
+        A +0 war pike <18> (goblin mystic)
+        A scroll of aggravate monsters (goblin mystic)
+        A potion of darkness (goblin conjurer)
+        A scroll of protect weapon (goblin mystic)
+    Depth 12:
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        A mango
+        1376 gold pieces (6 piles)
+        A potion of levitation (goblin conjurer)
+    Depth 13:
+        A potion of speed
+        +0 banded mail [7]<15>
+        A scroll of enchanting
+        A potion of descent
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        722 gold pieces (3 piles)
+    Depth 14:
+        A scroll of identify
+        +0 banded mail [7]<15>
+        A potion of incineration
+        A +1 teleportation charm (ready)
+        A scroll of identify
+        1098 gold pieces (4 piles)
+        A scroll of aggravate monsters (dar blademaster)
+    Depth 15:
+        A +3 ring of wisdom
+        A potion of darkness
+        A mango
+        +3 chain mail of reflection [8]<13>
+        1221 gold pieces (5 piles)
+    Depth 16:
+        A potion of paralysis
+        A scroll of enchanting
+        A +2 ring of stealth
+        A scroll of teleportation
+        A staff of discord [3/3]
+        1122 gold pieces (4 piles)
+        A +0 war pike <18> (goblin conjurer [explosive])
+    Depth 17:
+        A potion of caustic gas
+        A scroll of sanctuary
+        A scroll of identify
+        A potion of life
+        A potion of caustic gas
+        A +0 war pike <18>
+        A potion of strength
+        1463 gold pieces (5 piles)
+        A scroll of teleportation (dar priestess)
+        A shackled naga [infested]
+    Depth 18:
+        A scroll of identify
+        A potion of strength
+        A scroll of identify
+        A mango
+        1542 gold pieces (5 piles)
+        +0 scale mail [4]<12> (dar priestess)
+    Depth 19:
+        +1 banded mail [8]<15>
+        A scroll of enchanting
+        Some food
+        A potion of invisibility
+        A cage key
+        A cage key
+        1921 gold pieces (6 piles)
+        A caged dar blademaster
+        A caged troll [juggernaut]
+        A caged dar blademaster [infested]
+    Depth 20:
+        A scroll of enchanting
+        +0 scale mail [4]<12>
+        A scroll of teleportation
+        A +2 broadsword <19>
+        A staff of discord [2/2]
+        A scroll of enchanting
+        A potion of confusion
+        A potion of life
+        1745 gold pieces (5 piles)
+        A potion of descent (dar priestess)
+        A potion of invisibility (dar blademaster)
+    Depth 21:
+        A scroll of enchanting
+        A potion of confusion
+        A staff of lightning [4/4]
+        2817 gold pieces (8 piles)
+        A potion of levitation (dar blademaster)
+    Depth 22:
+        A scroll of recharging
+        A potion of incineration
+        A -1 rapier <15>
+        A potion of confusion
+        Some food
+        1452 gold pieces (4 piles)
+        A scroll of identify (dar battlemage)
+        A shackled tentacle horror
+        A shackled dar blademaster
+    Depth 23:
+        A potion of levitation
+        A scroll of protect armor
+        A scroll of recharging
+        A potion of strength
+        +0 splint mail [9]<17>
+        10 +0 javelins <15>
+        A crystal orb
+        1167 gold pieces (3 piles)
+        A +3 ring of transference (dar blademaster)
+        A shackled imp [toxic]
+        A shackled dar priestess
+        An allied unicorn
+    Depth 24:
+        A scroll of protect armor
+        A scroll of protect weapon
+        A potion of life
+        Some food
+        2305 gold pieces (6 piles)
+        A shackled dar blademaster
+    Depth 25:
+        A scroll of aggravate monsters
+        A potion of creeping death
+        A scroll of enchanting
+        A potion of fire immunity
+        A scroll of shattering
+        A scroll of remove curse
+        2007 gold pieces (5 piles)
+        A +0 whip <14> (dar blademaster)
+        A shackled dar blademaster
+        A shackled tentacle horror
+    Depth 26:
+        A potion of invisibility
+        +0 chain mail [5]<13>
+        A scroll of protect weapon
+        A potion of invisibility
+        A potion of paralysis
+        A +0 war pike <18>
+        Some food
+        A door key (opens vault 2)
+        A potion of life (vault 2)
+        2078 gold pieces (5 piles)
+        A scroll of teleportation (dar priestess)
+        A scroll of negation (dragon)
+        A shackled dar priestess
+        A commutation altar (vault 5)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        A mango
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+        Some food
+    Depth 36:
+        A lumenstone from depth 36
+    Depth 37:
+        A lumenstone from depth 37
+        Some food
+    Depth 38:
+        A lumenstone from depth 38
+    Depth 39:
+        A lumenstone from depth 39
+        Some food
+    Depth 40:
+        A lumenstone from depth 40
+Seed 15:
+    Depth 1:
+        A potion of invisibility
+        A potion of telepathy
+        A potion of fire immunity
+        A scroll of enchanting
+        A scroll of magic mapping
+        65 gold pieces
+    Depth 2:
+        A +2 telepathy charm (ready)
+        A scroll of remove curse
+        A potion of strength
+        A potion of strength
+        A scroll of teleportation
+        A potion of life
+        A potion of paralysis
+        A +2 ring of clairvoyance (vault 1)
+        A +2 ring of awareness (vault 1)
+        A +1 ring of light (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A +2 ring of transference (vault 3)
+        A staff of blinking [3/3] (vault 3)
+        A +1 sword of slowing <14> (vault 3)
+        A door key (opens vault 3)
+    Depth 3:
+        A +0 spear <13>
+        A potion of levitation
+        A potion of detect magic
+        Some food
+    Depth 4:
+        A +1 ring of light
+        A scroll of discord
+        A potion of fire immunity
+        A potion of detect magic
+        A potion of confusion
+        A staff of firebolt [2/2] (vault 1)
+        A staff of obstruction [3/3] (vault 1)
+        A +2 ring of awareness (vault 1)
+        A +1 dagger of slowing <12> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        A +0 flail <17> (vault 1)
+        A wand of invisibility [3] (vault 1)
+        A door key (opens vault 1)
+        158 gold pieces
+        A shackled goblin
+    Depth 5:
+        A wand of invisibility [4]
+        A staff of haste [2/2]
+        +0 splint mail [9]<17>
+        A door key (opens vault 1)
+        +3 chain mail of goblin immunity [8]<13> (vault 1)
+        248 gold pieces (2 piles)
+    Depth 6:
+        A scroll of enchanting
+        A +3 ring of light
+        A scroll of recharging
+        488 gold pieces (3 piles)
+    Depth 7:
+        A potion of paralysis
+        +0 banded mail [7]<15>
+        A potion of strength
+        580 gold pieces (4 piles)
+    Depth 8:
+        A potion of life
+        4 +0 incendiary darts <12>
+        Some food
+        945 gold pieces (5 piles)
+    Depth 9:
+        A potion of creeping death
+        A potion of paralysis
+        A potion of levitation
+        +2 leather armor of reflection [5]<10>
+        A scroll of identify
+        A potion of invisibility
+        983 gold pieces (5 piles)
+        A shackled ogre
+    Depth 10:
+        A staff of firebolt [2/2]
+        A potion of telepathy
+        Some food
+        1390 gold pieces (7 piles)
+        A shackled ogre
+    Depth 11:
+        A scroll of enchanting
+        A potion of strength
+        A scroll of enchanting
+        A potion of life
+        462 gold pieces (2 piles)
+    Depth 12:
+        A potion of telepathy
+        A potion of strength
+        A potion of descent
+        695 gold pieces (3 piles)
+    Depth 13:
+        A scroll of enchanting
+        A potion of levitation
+        A +3 war hammer <20>
+        A scroll of teleportation
+        Some food
+        638 gold pieces (3 piles)
+        A wand of invisibility [3] (goblin mystic)
+    Depth 14:
+        A potion of speed
+        A potion of life
+        A potion of descent
+        A potion of telepathy
+        11 +0 javelins <15>
+        1913 gold pieces (7 piles)
+        A shackled ogre
+    Depth 15:
+        4 +0 incendiary darts <12>
+        A potion of descent
+        Some food
+        A +1 recharging charm (ready)
+        A +2 health charm (ready)
+        752 gold pieces (3 piles)
+    Depth 16:
+        A scroll of enchanting
+        A potion of darkness
+        A potion of strength
+        A scroll of protect weapon
+        2017 gold pieces (7 piles)
+        +1 scale mail of reprisal [5]<12> (goblin mystic)
+        A scroll of aggravate monsters (goblin conjurer)
+    Depth 17:
+        +0 chain mail [5]<13>
+        A +0 whip <14>
+        A scroll of magic mapping
+        A +1 negation charm (ready)
+        1335 gold pieces (4 piles)
+    Depth 18:
+        A scroll of enchanting
+        A scroll of enchanting
+        Some food
+        1965 gold pieces (7 piles)
+        A shackled dar blademaster
+    Depth 19:
+        A scroll of enchanting
+        A scroll of protect weapon
+        A scroll of enchanting
+        A potion of invisibility
+        A door key (vault 6) (opens vault 4)
+        A +2 telepathy charm (ready) (vault 6)
+        +0 leather armor [3]<10> (vault 6)
+        A door key (opens vault 6)
+        A door key (opens vault 1)
+        A scroll of enchanting (vault 1)
+        591 gold pieces (2 piles)
+        A commutation altar (vault 4)
+    Depth 20:
+        A potion of life
+        A potion of confusion
+        A potion of fire immunity
+        1708 gold pieces (5 piles)
+        A scroll of sanctuary (dar blademaster)
+        A shackled dar blademaster
+    Depth 21:
+        A potion of invisibility
+        A potion of paralysis
+        A potion of detect magic
+        A potion of incineration
+        A scroll of enchanting
+        A potion of detect magic
+        A scroll of enchanting
+        A potion of strength
+        A wand of slowness [2]
+        A potion of telepathy
+        Some food
+        1709 gold pieces (5 piles)
+        A shackled dar blademaster
+    Depth 22:
+        A potion of detect magic
+        Some food
+        A potion of levitation
+        A potion of hallucination
+        A potion of hallucination
+        A scroll of enchanting
+        A potion of caustic gas
+        Some food
+        A potion of strength
+        1763 gold pieces (5 piles)
+    Depth 23:
+        A potion of telepathy
+        A scroll of identify
+        A scroll of teleportation
+        A scroll of negation
+        A potion of life
+        2233 gold pieces (6 piles)
+    Depth 24:
+        A potion of levitation
+        A scroll of enchanting
+        A potion of hallucination
+        A scroll of magic mapping
+        A scroll of identify
+        A scroll of magic mapping
+        A -3 dagger <12>
+        1816 gold pieces (5 piles)
+    Depth 25:
+        A +0 axe <15>
+        A potion of strength
+        A scroll of enchanting
+        2401 gold pieces (6 piles)
+    Depth 26:
+        A scroll of protect weapon
+        A scroll of enchanting
+        A potion of levitation
+        +3 chain mail [8]<13>
+        A scroll of recharging
+        2762 gold pieces (7 piles)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        Some food
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        A mango
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 16:
+    Depth 1:
+        A potion of paralysis
+        A potion of creeping death
+        A scroll of remove curse
+        A potion of incineration
+        A -1 mace <16>
+        A staff of conjuration [2/2] (vault 1)
+        A staff of lightning [2/2] (vault 1)
+        A staff of poison [2/2] (vault 1)
+        A staff of entrancement [3/3] (vault 1)
+        A staff of firebolt [2/2] (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A +2 guardian charm (ready) (vault 3)
+        A wand of negation [6] (vault 3)
+    Depth 2:
+        A potion of descent
+        A potion of hallucination
+        A potion of creeping death
+        A potion of strength
+        A potion of life
+        A potion of incineration
+        A scroll of sanctuary
+    Depth 3:
+        A potion of descent
+        A potion of hallucination
+        A potion of caustic gas
+        A +0 sword <14>
+        Some food
+        88 gold pieces
+    Depth 4:
+        A scroll of enchanting
+        A scroll of magic mapping
+        A scroll of magic mapping
+        A potion of strength
+        A scroll of teleportation
+        A scroll of enchanting
+        +0 splint mail [9]<17>
+        A potion of invisibility
+        +0 banded mail [7]<15>
+        115 gold pieces
+    Depth 5:
+        A scroll of enchanting
+        A scroll of sanctuary
+        A scroll of enchanting
+        A potion of fire immunity
+        113 gold pieces
+    Depth 6:
+        A scroll of summon monsters
+        A scroll of identify
+        A scroll of summon monsters
+        A staff of obstruction [4/4]
+        A scroll of discord
+        A mango
+        585 gold pieces (4 piles)
+    Depth 7:
+        A +1 teleportation charm (ready)
+        A scroll of summon monsters
+        A potion of life
+        A +2 ring of transference (vault 1)
+        A +2 ring of clairvoyance (vault 1)
+        A +2 ring of regeneration (vault 1)
+        627 gold pieces (4 piles)
+    Depth 8:
+        A potion of strength
+        A potion of strength
+        A potion of invisibility
+        A +1 invisibility charm (ready)
+        A potion of creeping death
+        A potion of fire immunity
+        802 gold pieces (5 piles)
+    Depth 9:
+        A scroll of identify
+        A potion of paralysis
+        Some food
+        775 gold pieces (4 piles)
+        A shackled goblin mystic
+    Depth 10:
+        A potion of confusion
+        A potion of incineration
+        A potion of life
+        A scroll of enchanting
+        1045 gold pieces (5 piles)
+    Depth 11:
+        A scroll of enchanting
+        A potion of detect magic
+        A scroll of identify
+        A potion of detect magic
+        A scroll of magic mapping
+        A potion of telepathy
+        A potion of confusion (vault 1)
+        A potion of detect magic (vault 1)
+        A potion of life (vault 1)
+        1067 gold pieces (5 piles)
+    Depth 12:
+        A -2 ring of transference
+        A +0 flail <17>
+        A potion of fire immunity
+        A potion of fire immunity
+        687 gold pieces (3 piles)
+    Depth 13:
+        A scroll of magic mapping
+        A scroll of teleportation
+        A mango
+        1521 gold pieces (6 piles)
+        A +0 broadsword <19> (dar blademaster)
+        A potion of descent (dar blademaster)
+    Depth 14:
+        A mango
+        A scroll of enchanting
+        A potion of life
+        A mango
+        A potion of descent
+        642 gold pieces (3 piles)
+        A shackled centaur
+        A shackled dar blademaster
+    Depth 15:
+        A scroll of protect weapon
+        A potion of paralysis
+        A wand of polymorphism [5]
+        A door key (vault 3) (opens vault 1)
+        A staff of conjuration [3/3] (vault 3)
+        A staff of discord [3/3] (vault 3)
+        +0 banded mail [7]<15> (vault 3)
+        1238 gold pieces (4 piles)
+        A commutation altar (vault 1)
+    Depth 16:
+        A potion of speed
+        A potion of strength
+        A scroll of enchanting
+        2268 gold pieces (8 piles)
+        A shackled dar blademaster
+    Depth 17:
+        A wand of slowness [2]
+        A potion of strength
+        A scroll of teleportation
+        A scroll of enchanting
+        608 gold pieces (2 piles)
+    Depth 18:
+        A staff of entrancement [3/3]
+        A potion of life
+        A +0 flail <17>
+        A scroll of identify
+        1358 gold pieces (4 piles)
+    Depth 19:
+        +0 banded mail [7]<15>
+        A potion of strength
+        Some food
+        A door key (opens vault 2)
+        A potion of life (vault 2)
+        A potion of descent (vault 1)
+        A potion of invisibility (vault 1)
+        A scroll of enchanting (vault 1)
+        1344 gold pieces (4 piles)
+    Depth 20:
+        A scroll of enchanting
+        A scroll of protect armor
+        A potion of strength
+        2295 gold pieces (7 piles)
+        A shackled dar blademaster
+    Depth 21:
+        A +0 mace <16>
+        A potion of invisibility
+        A mango
+        2168 gold pieces (6 piles)
+        +0 plate armor [11]<19> (dar battlemage)
+        A potion of fire immunity (dar blademaster)
+    Depth 22:
+        A potion of speed
+        A scroll of remove curse
+        A scroll of enchanting
+        A potion of darkness
+        A +1 protection charm (ready)
+        +1 banded mail [8]<15>
+        A potion of strength
+        A potion of levitation
+        2435 gold pieces (7 piles)
+        A potion of caustic gas (dar battlemage)
+        A staff of healing [3/3] (dar blademaster)
+        A shackled dar priestess [reflective]
+        A shackled dar battlemage
+    Depth 23:
+        A scroll of shattering
+        A potion of telepathy
+        Some food
+        1315 gold pieces (4 piles)
+    Depth 24:
+        A potion of speed
+        A scroll of enchanting
+        A potion of invisibility
+        A potion of life
+        1937 gold pieces (5 piles)
+        A scroll of identify (dar priestess)
+        A scroll of identify (dar battlemage)
+        +0 splint mail [9]<17> (dar priestess)
+        +0 leather armor [3]<10> (dar blademaster [vampiric])
+    Depth 25:
+        A potion of levitation
+        A -1 rapier <15>
+        A +2 sword <14>
+        A -2 war pike <18>
+        2235 gold pieces (6 piles)
+        A shackled dar priestess
+    Depth 26:
+        A potion of caustic gas
+        A potion of confusion
+        A +0 flail <17>
+        Some food
+        3213 gold pieces (8 piles)
+        A shackled dar priestess
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        Some food
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+        Some food
+    Depth 38:
+        A lumenstone from depth 38
+    Depth 39:
+        A lumenstone from depth 39
+        Some food
+    Depth 40:
+        A lumenstone from depth 40
+Seed 17:
+    Depth 1:
+        A potion of incineration
+        A potion of strength
+        A potion of life
+        A potion of fire immunity
+        A potion of invisibility
+        A scroll of enchanting
+        85 gold pieces
+    Depth 2:
+        A potion of invisibility
+        A scroll of identify
+        A scroll of teleportation
+        A potion of creeping death
+        A potion of paralysis
+        A scroll of summon monsters
+        A +0 mace <16>
+        A scroll of enchanting
+        A potion of strength
+        82 gold pieces
+    Depth 3:
+        A potion of confusion
+        A scroll of shattering
+        A staff of lightning [2/2]
+        A +0 broadsword <19>
+        A +3 ring of stealth
+        Some food
+        A +1 ring of light (vault 1)
+        A +1 ring of wisdom (vault 1)
+        A +1 ring of clairvoyance (vault 1)
+        A scroll of shattering
+        126 gold pieces
+        A scroll of aggravate monsters (goblin conjurer)
+        A shackled monkey
+    Depth 4:
+        A potion of fire immunity
+        A potion of darkness
+        A staff of poison [2/2]
+        A potion of descent
+        A potion of confusion
+        137 gold pieces
+    Depth 5:
+        3 +0 incendiary darts <12>
+        A +1 haste charm (ready)
+        +0 chain mail [5]<13>
+        A scroll of enchanting
+        A potion of descent
+        A potion of life
+        A wand of domination [2]
+        259 gold pieces (2 piles)
+        A staff of obstruction [2/2] (goblin conjurer)
+        A potion of levitation (goblin conjurer)
+    Depth 6:
+        A potion of strength
+        A scroll of summon monsters
+        A potion of confusion
+        A potion of caustic gas
+        Some food
+        562 gold pieces (4 piles)
+    Depth 7:
+        +0 chain mail [5]<13>
+        A potion of invisibility
+        A potion of caustic gas
+        A potion of descent
+        A scroll of identify
+        A potion of telepathy
+        758 gold pieces (5 piles)
+        A potion of darkness (goblin conjurer)
+        A shackled ogre
+        A shackled ogre
+    Depth 8:
+        A +0 war axe <19>
+        A potion of confusion
+        A potion of invisibility
+        659 gold pieces (4 piles)
+        A potion of incineration (dar blademaster)
+    Depth 9:
+        A potion of detect magic
+        A potion of paralysis
+        A scroll of enchanting
+        -3 chain mail [2]<13>
+        +0 plate armor [11]<19>
+        A potion of strength
+        A potion of telepathy
+        A scroll of enchanting
+        669 gold pieces (4 piles)
+    Depth 10:
+        A scroll of identify
+        A potion of invisibility
+        A scroll of aggravate monsters
+        A potion of descent
+        +0 splint mail [9]<17>
+        A potion of life
+        Some food
+        736 gold pieces (4 piles)
+    Depth 11:
+        +0 plate armor [11]<19>
+        A potion of descent
+        A scroll of enchanting
+        A staff of obstruction [2/2]
+        A potion of detect magic
+        A potion of strength
+        A cage key (vault 3)
+        A +2 ring of transference (vault 3)
+        +2 leather armor of multiplicity [5]<10> (vault 3)
+        A +2 dagger of speed <12> (vault 3)
+        821 gold pieces (4 piles)
+        A caged dar blademaster
+        A caged pixie
+        A caged pixie
+    Depth 12:
+        A scroll of recharging
+        A +0 whip <14>
+        +2 splint mail [11]<17>
+        1558 gold pieces (7 piles)
+    Depth 13:
+        A potion of invisibility
+        A potion of paralysis
+        A potion of fire immunity
+        A mango
+        771 gold pieces (3 piles)
+    Depth 14:
+        Some food
+        A scroll of identify
+        A scroll of enchanting
+        A scroll of protect weapon
+        A potion of strength
+        1048 gold pieces (4 piles)
+        A +0 sword <14> (goblin conjurer)
+    Depth 15:
+        A scroll of remove curse
+        Some food
+        A scroll of enchanting
+        A potion of levitation
+        A potion of caustic gas
+        A door key (opens vault 1)
+        A potion of caustic gas (vault 1)
+        A potion of speed (vault 1)
+        A potion of telepathy (vault 1)
+        A potion of detect magic (vault 1)
+        A potion of levitation (vault 1)
+        A potion of invisibility (vault 1)
+        1100 gold pieces (4 piles)
+    Depth 16:
+        A potion of caustic gas
+        A scroll of magic mapping
+        A scroll of identify
+        A potion of detect magic
+        A potion of life
+        1667 gold pieces (6 piles)
+        A shackled centaur
+    Depth 17:
+        A scroll of summon monsters
+        +0 splint mail [9]<17>
+        A potion of detect magic
+        1136 gold pieces (4 piles)
+    Depth 18:
+        A potion of caustic gas
+        A scroll of shattering
+        A potion of descent
+        A scroll of enchanting
+        2202 gold pieces (7 piles)
+        A staff of lightning [2/2] (dar battlemage)
+        A potion of telepathy (dar priestess)
+        A potion of invisibility (dar blademaster)
+        A shackled naga
+    Depth 19:
+        A wand of polymorphism [4]
+        A potion of fire immunity
+        A potion of detect magic
+        A potion of life
+        Some food
+        +0 chain mail [5]<13>
+        A potion of hallucination (vault 1)
+        A scroll of teleportation (vault 1)
+        A scroll of identify (vault 1)
+        A potion of life (vault 1)
+        581 gold pieces (2 piles)
+        +0 leather armor [3]<10> (dar battlemage)
+        A wand of plenty [2] (dar blademaster)
+        A +0 spear <13> (dar blademaster)
+    Depth 20:
+        A scroll of shattering
+        A potion of detect magic
+        A potion of invisibility
+        1967 gold pieces (6 piles)
+        A wand of negation [5] (dar priestess)
+    Depth 21:
+        A scroll of enchanting
+        A potion of strength
+        A potion of caustic gas
+        A scroll of summon monsters
+        A scroll of enchanting
+        1690 gold pieces (5 piles)
+    Depth 22:
+        A wand of teleportation [5]
+        A scroll of sanctuary
+        A potion of hallucination
+        A scroll of enchanting
+        A potion of invisibility
+        A scroll of recharging
+        2078 gold pieces (6 piles)
+    Depth 23:
+        -1 plate armor [10]<19>
+        A potion of descent
+        A scroll of teleportation
+        A wand of plenty [2]
+        A potion of incineration
+        A potion of fire immunity
+        A potion of darkness
+        A potion of strength
+        Some food
+        A potion of caustic gas
+        A scroll of enchanting
+        A potion of life
+        Some food
+        1776 gold pieces (5 piles)
+        A potion of incineration (dar blademaster)
+        A crystal orb (flamedancer)
+        A shackled dar priestess
+        A shackled dar priestess
+        An allied phoenix egg
+    Depth 24:
+        A +0 mace <16>
+        A scroll of enchanting
+        A +0 war pike <18>
+        A scroll of enchanting
+        A scroll of enchanting
+        1813 gold pieces (5 piles)
+    Depth 25:
+        A wand of teleportation [4]
+        A potion of caustic gas
+        +0 splint mail [9]<17>
+        A scroll of aggravate monsters
+        2210 gold pieces (6 piles)
+        A potion of incineration (dragon)
+        A shackled tentacle horror
+    Depth 26:
+        A potion of hallucination
+        A potion of strength
+        A mango
+        A wand of negation [4]
+        A staff of haste [2/2]
+        A potion of descent
+        1848 gold pieces (5 piles)
+        A scroll of protect weapon (dragon)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        A mango
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        A mango
+Seed 18:
+    Depth 1:
+        A potion of incineration
+        A scroll of discord
+        A +0 axe <15>
+        A potion of confusion
+        A scroll of remove curse
+        A potion of levitation
+        A potion of strength
+        A staff of tunneling [2/2] (vault 1)
+        A staff of blinking [2/2] (vault 1)
+        A staff of obstruction [2/2] (vault 1)
+        A staff of poison [2/2] (vault 1)
+        A door key (opens vault 1)
+        92 gold pieces
+    Depth 2:
+        A scroll of negation
+        A potion of strength
+        A scroll of identify
+        A potion of descent
+        A scroll of remove curse
+    Depth 3:
+        A potion of fire immunity
+        A scroll of identify
+        +0 leather armor [3]<10>
+        A scroll of aggravate monsters
+        A scroll of protect armor
+        A potion of creeping death
+        A +0 war pike <18>
+        A scroll of magic mapping
+        A potion of caustic gas
+        +0 plate armor [11]<19>
+        A scroll of recharging
+        A scroll of aggravate monsters
+        83 gold pieces
+    Depth 4:
+        A potion of levitation
+        A scroll of remove curse
+        A potion of levitation
+        A staff of firebolt [3/3]
+        A +3 ring of transference
+        A potion of caustic gas
+        A potion of life
+        Some food
+        219 gold pieces (2 piles)
+    Depth 5:
+        A potion of life
+        A scroll of enchanting
+        A scroll of negation
+        130 gold pieces
+    Depth 6:
+        A scroll of enchanting
+        A scroll of recharging
+        A scroll of summon monsters
+        A scroll of enchanting
+        A +1 ring of light (vault 1)
+        A +1 ring of wisdom (vault 1)
+        A +2 ring of transference (vault 1)
+        A door key (vault 4) (opens vault 2)
+        A +1 ring of stealth (vault 4)
+        A +0 sword <14> (vault 4)
+        A +0 war hammer <20> (vault 4)
+        A potion of levitation
+        A door key (opens vault 4)
+        370 gold pieces (3 piles)
+    Depth 7:
+        +5 plate armor [16]<19>
+        A scroll of protect weapon
+        A mango
+        532 gold pieces (3 piles)
+    Depth 8:
+        A potion of caustic gas
+        A scroll of protect weapon
+        A scroll of enchanting
+        +0 chain mail [5]<13>
+        964 gold pieces (5 piles)
+    Depth 9:
+        A scroll of enchanting
+        A potion of caustic gas
+        A potion of caustic gas
+        1029 gold pieces (6 piles)
+    Depth 10:
+        A potion of speed
+        A wand of slowness [3]
+        A scroll of summon monsters
+        Some food
+        1021 gold pieces (5 piles)
+    Depth 11:
+        A potion of incineration
+        +0 leather armor [3]<10>
+        A scroll of enchanting
+        A potion of life
+        A door key (opens vault 1)
+        +1 scale mail of dampening [5]<12> (vault 1)
+        665 gold pieces (3 piles)
+    Depth 12:
+        A potion of descent
+        A +2 recharging charm (ready)
+        A scroll of enchanting
+        A potion of strength
+        Some food
+        700 gold pieces (3 piles)
+        A shackled ogre
+    Depth 13:
+        A potion of strength
+        A scroll of enchanting
+        A potion of strength
+        A scroll of identify
+        A scroll of enchanting
+        A potion of hallucination
+        1027 gold pieces (4 piles)
+        A -1 spear <13> (goblin conjurer)
+    Depth 14:
+        A potion of telepathy
+        A scroll of protect weapon
+        A scroll of negation
+        A potion of strength
+        A potion of fire immunity
+        A scroll of protect weapon
+        A door key (opens vault 1)
+        A staff of discord [3/3] (vault 1)
+        A staff of conjuration [3/3] (vault 1)
+        992 gold pieces (4 piles)
+    Depth 15:
+        A scroll of protect armor
+        A potion of life
+        A mango
+        977 gold pieces (4 piles)
+    Depth 16:
+        A mango
+        A potion of detect magic
+        A scroll of enchanting
+        A potion of strength
+        A scroll of aggravate monsters
+        A potion of confusion
+        A +2 ring of transference
+        1098 gold pieces (4 piles)
+        A shackled pixie
+    Depth 17:
+        A potion of caustic gas
+        A scroll of remove curse
+        A scroll of recharging
+        A door key (opens vault 1)
+        A potion of life (vault 1)
+        1395 gold pieces (5 piles)
+    Depth 18:
+        A scroll of enchanting
+        A scroll of teleportation
+        A +2 ring of clairvoyance
+        A wand of teleportation [3]
+        A potion of hallucination
+        A potion of telepathy
+        A potion of speed
+        1831 gold pieces (6 piles)
+        A scroll of magic mapping (dar priestess)
+    Depth 19:
+        A potion of life
+        A scroll of discord
+        A potion of fire immunity
+        A potion of strength
+        1556 gold pieces (5 piles)
+    Depth 20:
+        A wand of invisibility [4]
+        A scroll of enchanting
+        A mango
+        1732 gold pieces (5 piles)
+        A +0 war axe <19> (dar priestess)
+    Depth 21:
+        A potion of confusion
+        A scroll of recharging
+        A scroll of enchanting
+        A potion of darkness
+        A mango
+        1676 gold pieces (5 piles)
+    Depth 22:
+        A potion of fire immunity
+        A potion of speed
+        A potion of caustic gas
+        Some food
+        A scroll of enchanting
+        2132 gold pieces (6 piles)
+    Depth 23:
+        A scroll of protect weapon
+        A potion of detect magic
+        A scroll of teleportation
+        A potion of incineration
+        1957 gold pieces (5 piles)
+        A scroll of summon monsters (dar priestess)
+        A +1 ring of wisdom (dar blademaster)
+        A scroll of recharging (dar blademaster)
+        A cage key (vampire)
+        A shackled tentacle horror
+        A caged dar blademaster
+        A caged imp
+        A shackled tentacle horror
+        A shackled tentacle horror
+    Depth 24:
+        A potion of life
+        A +3 ring of reaping
+        A scroll of magic mapping
+        1797 gold pieces (5 piles)
+    Depth 25:
+        A scroll of discord
+        A potion of incineration
+        Some food
+        2428 gold pieces (6 piles)
+        A scroll of aggravate monsters (dar battlemage [agile])
+        A scroll of recharging (dar blademaster)
+        A scroll of protect armor (dragon)
+        A cage key (vampire)
+        A shackled dar priestess
+        A caged dar battlemage [agile]
+        A caged imp
+        A caged dar blademaster
+        A caged dar blademaster [agile]
+        A shackled dragon
+        A shackled tentacle horror
+    Depth 26:
+        A +3 ring of clairvoyance
+        A potion of detect magic
+        A +0 whip <14>
+        2715 gold pieces (7 piles)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A mango
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        A mango
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        Some food
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+    Depth 35:
+        A lumenstone from depth 35
+        Some food
+    Depth 36:
+        A lumenstone from depth 36
+    Depth 37:
+        A lumenstone from depth 37
+        A mango
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 19:
+    Depth 1:
+        A scroll of sanctuary
+        A scroll of identify
+        A potion of darkness
+        A wand of empowerment [1]
+        Some food
+        174 gold pieces (2 piles)
+    Depth 2:
+        A potion of fire immunity
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of life
+        A +2 broadsword <19>
+        A potion of strength
+        A potion of telepathy
+        A potion of caustic gas
+        A potion of strength
+        100 gold pieces
+    Depth 3:
+        A scroll of identify
+        A scroll of magic mapping
+        A scroll of remove curse
+        A potion of caustic gas
+        A scroll of teleportation
+        A +2 health charm (ready) (vault 1)
+        A staff of conjuration [2/2] (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        +0 splint mail [9]<17> (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A wand of beckoning [4] (vault 1)
+        A potion of incineration
+        A shackled monkey
+    Depth 4:
+        A potion of caustic gas
+        A +2 guardian charm (ready)
+        A scroll of aggravate monsters
+        A +2 invisibility charm (ready)
+        A potion of telepathy
+        A potion of telepathy
+        251 gold pieces (2 piles)
+    Depth 5:
+        A scroll of enchanting
+        +0 chain mail [5]<13>
+        A scroll of teleportation
+        A scroll of teleportation
+        587 gold pieces (4 piles)
+        A shackled monkey
+    Depth 6:
+        A scroll of sanctuary
+        A scroll of identify
+        A potion of levitation
+        Some food
+        610 gold pieces (4 piles)
+    Depth 7:
+        A potion of strength
+        A potion of fire immunity
+        A potion of life
+        A +0 rapier <15> (vault 1)
+        A +0 war axe <19> (vault 1)
+        5 +0 incendiary darts <12> (vault 1)
+        A potion of life (vault 1)
+        530 gold pieces (3 piles)
+        A -2 broadsword <19> (goblin mystic)
+        A potion of incineration (goblin conjurer)
+        A shackled goblin
+    Depth 8:
+        A potion of detect magic
+        A potion of invisibility
+        A potion of darkness
+        +0 chain mail [5]<13>
+        703 gold pieces (4 piles)
+    Depth 9:
+        A potion of invisibility
+        +0 banded mail [7]<15>
+        A potion of invisibility
+        A potion of paralysis
+        A scroll of shattering
+        717 gold pieces (4 piles)
+    Depth 10:
+        Some food
+        A wand of negation [5]
+        Some food
+        987 gold pieces (5 piles)
+        +3 splint mail [12]<17> (goblin conjurer)
+    Depth 11:
+        A wand of teleportation [3]
+        A +0 axe <15>
+        A scroll of enchanting
+        Some food
+        A door key (opens vault 4)
+        A potion of life (vault 4)
+        A door key (opens vault 1)
+        A scroll of enchanting (vault 1)
+        669 gold pieces (3 piles)
+        A scroll of identify (goblin conjurer)
+    Depth 12:
+        A potion of strength
+        A +0 rapier <15>
+        A potion of invisibility
+        A potion of fire immunity
+        A potion of life
+        1108 gold pieces (5 piles)
+    Depth 13:
+        A potion of hallucination
+        A potion of strength
+        A potion of paralysis
+        880 gold pieces (4 piles)
+        A scroll of identify (goblin conjurer)
+    Depth 14:
+        A scroll of remove curse
+        A scroll of identify
+        A +2 dagger of undead slaying <12>
+        14 +0 javelins <15>
+        745 gold pieces (3 piles)
+    Depth 15:
+        A potion of telepathy
+        A potion of fire immunity
+        A staff of discord [2/2]
+        A scroll of enchanting
+        A potion of strength
+        A potion of telepathy
+        781 gold pieces (3 piles)
+    Depth 16:
+        A potion of levitation
+        A +2 ring of light
+        A scroll of enchanting
+        A potion of life
+        A potion of descent
+        1838 gold pieces (7 piles)
+    Depth 17:
+        A potion of incineration
+        A potion of hallucination
+        A scroll of enchanting
+        A door key (opens vault 3)
+        A scroll of enchanting (vault 3)
+        A potion of caustic gas (vault 1)
+        A potion of hallucination (vault 1)
+        A potion of confusion (vault 1)
+        A potion of detect magic (vault 1)
+        A potion of telepathy (vault 1)
+        1455 gold pieces (5 piles)
+    Depth 18:
+        A potion of strength
+        A potion of telepathy
+        A mango
+        1557 gold pieces (5 piles)
+    Depth 19:
+        A scroll of enchanting
+        A potion of life
+        Some food
+        A scroll of recharging (vault 5)
+        A scroll of shattering (vault 5)
+        A scroll of aggravate monsters (vault 5)
+        A scroll of teleportation (vault 5)
+        A scroll of sanctuary (vault 5)
+        1198 gold pieces (4 piles)
+        A door key (stone guardian) (opens vault 1)
+        A commutation altar (vault 1)
+    Depth 20:
+        A staff of blinking [2/2]
+        A scroll of enchanting
+        A +3 ring of stealth
+        1892 gold pieces (6 piles)
+        A scroll of remove curse (dar blademaster)
+    Depth 21:
+        A scroll of enchanting
+        A +0 war pike <18>
+        A scroll of enchanting
+        A +3 flail of paralysis <17>
+        A scroll of protect weapon
+        2439 gold pieces (7 piles)
+    Depth 22:
+        +0 chain mail [5]<13>
+        A potion of telepathy
+        A potion of caustic gas
+        2154 gold pieces (6 piles)
+        A potion of confusion (dar blademaster)
+    Depth 23:
+        A scroll of enchanting
+        A potion of life
+        Some food
+        2478 gold pieces (7 piles)
+        A potion of speed (dar blademaster)
+        A shackled tentacle horror [vampiric]
+    Depth 24:
+        A scroll of sanctuary
+        A potion of caustic gas
+        A scroll of enchanting
+        A scroll of aggravate monsters
+        A potion of strength
+        +0 scale mail [4]<12>
+        Some food
+        A cage key (vault 2)
+        A +2 ring of clairvoyance (vault 2)
+        A +0 mace <16> (vault 2)
+        A door key (opens vault 2)
+        2278 gold pieces (6 piles)
+        A scroll of sanctuary (dar blademaster)
+        A potion of paralysis (dar battlemage)
+        A shackled imp
+        A caged dar blademaster
+        A caged dar battlemage
+        A caged dar priestess
+    Depth 25:
+        A potion of confusion
+        A scroll of aggravate monsters
+        +0 leather armor [3]<10>
+        A potion of telepathy
+        A scroll of enchanting
+        A potion of strength
+        1947 gold pieces (5 piles)
+        A potion of levitation (dragon)
+    Depth 26:
+        A scroll of summon monsters
+        A scroll of magic mapping
+        A potion of invisibility
+        A potion of invisibility
+        1840 gold pieces (5 piles)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        Some food
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        Some food
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+    Depth 35:
+        A lumenstone from depth 35
+        Some food
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 20:
+    Depth 1:
+        A -3 spear <13>
+        A potion of fire immunity
+        A potion of levitation
+        A potion of descent
+        A potion of detect magic
+        A staff of poison [2/2] (vault 1)
+        A staff of tunneling [3/3] (vault 1)
+        A staff of blinking [3/3] (vault 1)
+        A staff of entrancement [3/3] (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A +1 health charm (ready) (vault 3)
+        A +0 sword <14> (vault 3)
+        A +0 whip <14> (vault 3)
+        A door key (opens vault 3)
+        215 gold pieces (2 piles)
+    Depth 2:
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of strength
+        A scroll of identify
+        A potion of speed
+        A +1 health charm (ready) (vault 1)
+        A +2 ring of awareness (vault 1)
+        A +2 ring of light (vault 1)
+        A +0 dagger <12> (vault 1)
+        +3 scale mail [7]<12> (vault 1)
+        A wand of polymorphism [5] (vault 1)
+        A wand of empowerment [1] (vault 1)
+        A door key (opens vault 1)
+        179 gold pieces (2 piles)
+    Depth 3:
+        Some food
+        A scroll of enchanting
+        A potion of telepathy
+        Some food
+        A +1 ring of light (vault 1)
+        A +1 teleportation charm (ready) (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A +0 mace <16> (vault 1)
+        +1 scale mail [5]<12> (vault 1)
+        A wand of invisibility [5] (vault 1)
+        A door key (opens vault 1)
+        113 gold pieces
+    Depth 4:
+        A potion of descent
+        -1 chain mail [4]<13>
+        A potion of incineration
+        A scroll of discord
+        A scroll of identify
+        A potion of life
+        A potion of levitation
+        A potion of detect magic
+        A scroll of enchanting
+        234 gold pieces (2 piles)
+    Depth 5:
+        A scroll of protect weapon
+        +3 banded mail of mutuality [10]<15>
+        A potion of detect magic
+        A potion of telepathy
+        A potion of darkness
+        160 gold pieces
+    Depth 6:
+        A potion of strength
+        A potion of confusion
+        A potion of levitation
+        A potion of life
+        A +0 dagger <12> (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A potion of life (vault 1)
+        616 gold pieces (4 piles)
+        A shackled goblin
+    Depth 7:
+        A potion of telepathy
+        A potion of telepathy
+        A scroll of protect weapon
+        748 gold pieces (4 piles)
+    Depth 8:
+        A potion of telepathy
+        A scroll of magic mapping
+        A scroll of remove curse
+        A +0 spear <13> (vault 3)
+        A +0 sword <14> (vault 3)
+        A scroll of enchanting (vault 3)
+        A staff of firebolt [2/2] (vault 1)
+        A staff of obstruction [3/3] (vault 1)
+        A +1 ring of clairvoyance (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A +3 war pike <18> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        A wand of invisibility [3] (vault 1)
+        887 gold pieces (5 piles)
+        A potion of darkness (goblin mystic)
+    Depth 9:
+        A scroll of identify
+        A potion of fire immunity
+        A scroll of enchanting
+        342 gold pieces (2 piles)
+        A shackled ogre
+    Depth 10:
+        A scroll of magic mapping
+        A potion of life
+        A mango
+        710 gold pieces (4 piles)
+    Depth 11:
+        A scroll of recharging
+        A potion of strength
+        +0 leather armor [3]<10>
+        A scroll of enchanting
+        A potion of detect magic
+        A door key (opens vault 1)
+        A staff of obstruction [2/2] (vault 1)
+        A staff of firebolt [3/3] (vault 1)
+        945 gold pieces (5 piles)
+        A scroll of aggravate monsters (goblin mystic)
+        A +1 dagger of speed <12> (goblin mystic)
+    Depth 12:
+        A potion of creeping death
+        A +3 war axe <19>
+        A potion of strength
+        A potion of detect magic
+        A mango
+        759 gold pieces (4 piles)
+        A shackled ogre
+    Depth 13:
+        A scroll of enchanting
+        A scroll of identify
+        A scroll of enchanting
+        A scroll of enchanting
+        1160 gold pieces (5 piles)
+        A scroll of summon monsters (goblin conjurer)
+    Depth 14:
+        A +0 broadsword <19>
+        A scroll of identify
+        Some food
+        A potion of detect magic
+        1051 gold pieces (5 piles)
+    Depth 15:
+        A potion of paralysis
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        733 gold pieces (3 piles)
+    Depth 16:
+        A potion of strength
+        A scroll of remove curse
+        A staff of poison [3/3]
+        A scroll of recharging
+        A scroll of enchanting
+        A scroll of discord
+        A potion of telepathy
+        1123 gold pieces (4 piles)
+    Depth 17:
+        A +3 ring of transference
+        +0 plate armor [11]<19>
+        A potion of darkness
+        A potion of incineration
+        A potion of caustic gas
+        1505 gold pieces (5 piles)
+        A shackled centaur
+    Depth 18:
+        A potion of invisibility
+        A +0 spear <13>
+        A +0 spear <13>
+        A potion of life
+        Some food
+        A potion of telepathy
+        2180 gold pieces (7 piles)
+    Depth 19:
+        A potion of strength
+        A scroll of identify
+        A staff of firebolt [2/2]
+        A scroll of enchanting
+        A scroll of protect armor
+        A scroll of protect armor
+        A scroll of magic mapping
+        +0 splint mail [9]<17>
+        A wand of slowness [5]
+        1642 gold pieces (5 piles)
+        A shackled dar blademaster
+    Depth 20:
+        -3 splint mail of vulnerability [6]<17>
+        A potion of invisibility
+        Some food
+        1748 gold pieces (5 piles)
+    Depth 21:
+        A potion of strength
+        +0 banded mail [7]<15>
+        A scroll of summon monsters
+        A scroll of sanctuary
+        A door key (opens vault 1)
+        2407 gold pieces (7 piles)
+        A commutation altar (vault 1)
+    Depth 22:
+        +2 splint mail [11]<17>
+        A potion of paralysis
+        A scroll of sanctuary
+        A scroll of protect weapon
+        A potion of descent
+        A potion of strength
+        Some food
+        A door key (vault 3) (opens vault 1)
+        A +4 ring of regeneration (vault 3)
+        A +1 ring of reaping (vault 3)
+        +1 chain mail of multiplicity [6]<13> (vault 3)
+        A door key (opens vault 3)
+        A potion of life (vault 1)
+        2812 gold pieces (8 piles)
+        A potion of confusion (dar priestess [reflective])
+        A shackled dar blademaster
+    Depth 23:
+        A +3 ring of reaping
+        A scroll of enchanting
+        A scroll of recharging
+        A potion of telepathy
+        A scroll of sanctuary
+        A potion of life
+        957 gold pieces (3 piles)
+        A shackled dar blademaster
+    Depth 24:
+        A +0 spear <13>
+        A potion of caustic gas
+        Some food
+        2201 gold pieces (6 piles)
+    Depth 25:
+        A potion of confusion
+        A potion of invisibility
+        A potion of detect magic
+        A scroll of enchanting
+        3 +0 incendiary darts <12>
+        A potion of confusion
+        3134 gold pieces (8 piles)
+        +0 chain mail [5]<13> (dragon)
+        A shackled dar priestess
+    Depth 26:
+        A potion of hallucination
+        A -1 war pike of mercy <18>
+        A scroll of discord
+        A potion of detect magic
+        A potion of telepathy
+        +0 scale mail [4]<12>
+        A -1 ring of clairvoyance
+        A mango
+        A scroll of summon monsters
+        2076 gold pieces (5 piles)
+        A scroll of recharging (dragon)
+        A shackled dar priestess
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+        A mango
+    Depth 40:
+        A lumenstone from depth 40
+Seed 21:
+    Depth 1:
+        A scroll of enchanting
+        A potion of levitation
+        +0 leather armor [3]<10>
+        A potion of fire immunity
+        A +0 broadsword <19>
+        -1 scale mail [3]<12>
+        A staff of entrancement [2/2] (vault 1)
+        A +3 ring of clairvoyance (vault 1)
+        A +3 ring of awareness (vault 1)
+        A +0 axe <15> (vault 1)
+        A +0 spear <13> (vault 1)
+        +0 plate armor [11]<19> (vault 1)
+        A wand of teleportation [3] (vault 1)
+        3 +0 incendiary darts <12>
+        62 gold pieces
+    Depth 2:
+        A scroll of recharging
+        A potion of telepathy
+        +2 chain mail [7]<13>
+        A scroll of enchanting
+        A potion of incineration
+        A scroll of aggravate monsters
+        A potion of strength
+        A staff of blinking [3/3] (vault 1)
+        A +1 recharging charm (ready) (vault 1)
+        A staff of healing [3/3] (vault 1)
+        +0 splint mail [9]<17> (vault 1)
+        A +0 broadsword <19> (vault 1)
+        A +0 sword <14> (vault 1)
+        A wand of empowerment [1] (vault 1)
+        A potion of incineration
+        115 gold pieces
+    Depth 3:
+        A wand of slowness [3]
+        A staff of protection [3/3]
+        A potion of descent
+        A wand of teleportation [4]
+        A potion of caustic gas
+        A +2 war axe <19>
+        Some food
+        105 gold pieces
+    Depth 4:
+        A potion of strength
+        A potion of fire immunity
+        A potion of life
+        A scroll of enchanting
+        A scroll of identify
+        A potion of invisibility
+        308 gold pieces (3 piles)
+    Depth 5:
+        A scroll of protect weapon
+        +3 leather armor [6]<10>
+        A scroll of aggravate monsters
+        A scroll of identify
+        A potion of darkness
+        127 gold pieces
+    Depth 6:
+        A +0 war axe <19>
+        A +0 war axe <19>
+        A +2 ring of wisdom
+        A potion of detect magic
+        A staff of tunneling [2/2] (vault 4)
+        A staff of blinking [3/3] (vault 4)
+        A staff of discord [3/3] (vault 4)
+        A staff of firebolt [4/4] (vault 4)
+        A staff of poison [2/2] (vault 4)
+        A staff of lightning [4/4] (vault 1)
+        A +4 negation charm (ready) (vault 1)
+        A +2 ring of clairvoyance (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        +0 plate armor [11]<19> (vault 1)
+        +2 leather armor [5]<10> (vault 1)
+        A wand of slowness [2] (vault 1)
+        590 gold pieces (4 piles)
+        A door key (black jelly) (opens vault 1)
+    Depth 7:
+        A scroll of identify
+        A potion of telepathy
+        A potion of strength
+        Some food
+        662 gold pieces (4 piles)
+    Depth 8:
+        A scroll of enchanting
+        A potion of life
+        A potion of paralysis
+        A potion of fire immunity
+        A potion of invisibility
+        A potion of strength
+        +0 banded mail [7]<15>
+        733 gold pieces (4 piles)
+    Depth 9:
+        A scroll of aggravate monsters
+        A wand of negation [4]
+        A potion of descent
+        A scroll of teleportation
+        A potion of paralysis
+        A scroll of identify
+        A potion of descent
+        A potion of caustic gas
+        +0 scale mail [4]<12>
+        A scroll of teleportation
+        A door key (opens vault 4)
+        A staff of blinking [3/3] (vault 4)
+        A staff of firebolt [2/2] (vault 4)
+        917 gold pieces (5 piles)
+        A shackled ogre
+    Depth 10:
+        A scroll of enchanting
+        A potion of life
+        Some food
+        722 gold pieces (4 piles)
+        A potion of telepathy (goblin conjurer)
+    Depth 11:
+        A potion of descent
+        A potion of speed
+        A potion of strength
+        A potion of hallucination
+        A potion of telepathy
+        615 gold pieces (3 piles)
+        A shackled ogre
+    Depth 12:
+        A scroll of enchanting
+        A -2 war hammer <20>
+        A scroll of enchanting
+        1714 gold pieces (7 piles)
+        A scroll of aggravate monsters (goblin conjurer)
+        A scroll of recharging (dar blademaster)
+        A shackled dar blademaster
+    Depth 13:
+        A -1 flail <17>
+        A scroll of enchanting
+        Some food
+        901 gold pieces (4 piles)
+    Depth 14:
+        A potion of paralysis
+        A potion of darkness
+        A potion of life
+        A potion of creeping death
+        A scroll of identify
+        945 gold pieces (4 piles)
+    Depth 15:
+        A potion of levitation
+        A mango
+        A scroll of teleportation
+        A scroll of enchanting
+        1218 gold pieces (4 piles)
+        A shackled salamander
+    Depth 16:
+        A wand of empowerment [1]
+        A scroll of identify
+        +0 scale mail [4]<12>
+        A potion of fire immunity
+        A scroll of remove curse
+        A scroll of teleportation
+        -3 banded mail of immolation [4]<15>
+        A +0 spear <13>
+        A scroll of enchanting
+        A +2 recharging charm (ready)
+        A potion of descent
+        A potion of strength
+        A potion of confusion
+        1026 gold pieces (4 piles)
+    Depth 17:
+        A scroll of discord
+        A +3 flail <17>
+        +0 splint mail [9]<17>
+        A scroll of identify
+        A +0 flail <17>
+        A door key (vault 3) (opens vault 1)
+        A +3 ring of light (vault 3)
+        A staff of entrancement [4/4] (vault 3)
+        +0 splint mail [9]<17> (vault 3)
+        A door key (opens vault 3)
+        1062 gold pieces (4 piles)
+        +0 banded mail [7]<15> (goblin mystic)
+        A commutation altar (vault 1)
+    Depth 18:
+        A -1 rapier of mercy <15>
+        A scroll of enchanting
+        A scroll of identify
+        Some food
+        1504 gold pieces (5 piles)
+    Depth 19:
+        A scroll of identify
+        A wand of polymorphism [4]
+        A potion of incineration
+        A potion of speed
+        A scroll of negation
+        A potion of strength
+        A potion of life
+        1498 gold pieces (5 piles)
+    Depth 20:
+        A wand of invisibility [3]
+        A scroll of summon monsters
+        A mango
+        2232 gold pieces (7 piles)
+        A potion of fire immunity (dar priestess)
+    Depth 21:
+        A potion of incineration
+        A scroll of enchanting
+        A potion of confusion
+        A potion of invisibility
+        A door key (opens vault 4)
+        A potion of darkness (vault 4)
+        A potion of caustic gas (vault 4)
+        A potion of confusion (vault 4)
+        A potion of fire immunity (vault 4)
+        A potion of paralysis (vault 4)
+        A potion of invisibility (vault 4)
+        A potion of telepathy (vault 4)
+        A door key (opens vault 1)
+        1683 gold pieces (5 piles)
+        A scroll of summon monsters (dar battlemage)
+        A potion of speed (dar blademaster)
+        A shackled golem
+        A shackled golem
+        A commutation altar (vault 1)
+    Depth 22:
+        A scroll of protect weapon
+        A scroll of enchanting
+        +2 chain mail [7]<13>
+        +2 leather armor [5]<10>
+        Some food
+        1977 gold pieces (6 piles)
+    Depth 23:
+        +0 scale mail [4]<12>
+        A scroll of remove curse
+        A scroll of negation
+        1834 gold pieces (5 piles)
+    Depth 24:
+        A potion of strength
+        A potion of darkness
+        A potion of paralysis
+        A potion of life
+        Some food
+        2197 gold pieces (6 piles)
+        13 +0 javelins <15> (dragon)
+        A scroll of recharging (dragon)
+        A shackled dar priestess
+    Depth 25:
+        A potion of telepathy
+        +0 plate armor [11]<19>
+        A scroll of enchanting
+        2341 gold pieces (6 piles)
+        A potion of hallucination (dragon)
+        A shackled dar battlemage
+    Depth 26:
+        A -1 ring of clairvoyance
+        A potion of incineration
+        A potion of fire immunity
+        A scroll of enchanting
+        A potion of life
+        Some food
+        2499 gold pieces (6 piles)
+        A potion of confusion (dragon)
+        A shackled imp
+        A shackled dar priestess [agile]
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+        Some food
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 22:
+    Depth 1:
+        A scroll of enchanting
+        A scroll of sanctuary
+        A potion of descent
+        A -1 ring of light
+        Some food
+        A +1 ring of light
+        A potion of telepathy
+        A potion of telepathy
+        A potion of strength
+    Depth 2:
+        A potion of paralysis
+        +0 splint mail [9]<17>
+        A scroll of magic mapping
+        +0 banded mail [7]<15>
+        A +0 spear <13>
+        A scroll of summon monsters
+        A shackled monkey
+    Depth 3:
+        A potion of detect magic
+        A scroll of enchanting
+        A wand of slowness [5]
+        A scroll of protect armor
+        A potion of hallucination
+        A +1 ring of regeneration (vault 1)
+        A +3 ring of reaping (vault 1)
+        A +1 ring of stealth (vault 1)
+        128 gold pieces
+    Depth 4:
+        A potion of detect magic
+        A +2 ring of stealth
+        A scroll of protect armor
+        A potion of life
+        97 gold pieces
+        A shackled goblin
+    Depth 5:
+        -2 plate armor of immolation [9]<19>
+        A potion of fire immunity
+        A potion of invisibility
+        A potion of descent
+        120 gold pieces
+    Depth 6:
+        A staff of firebolt [4/4]
+        A scroll of enchanting
+        A +0 spear <13>
+        487 gold pieces (3 piles)
+        A scroll of aggravate monsters (goblin mystic)
+        A shackled goblin
+    Depth 7:
+        A wand of beckoning [4]
+        A potion of strength
+        A scroll of enchanting
+        Some food
+        A +2 health charm (ready)
+        A +1 whip of paralysis <14>
+        A +0 rapier <15> (vault 1)
+        A +0 dagger <12> (vault 1)
+        A +0 whip <14> (vault 1)
+        A scroll of enchanting (vault 1)
+        671 gold pieces (4 piles)
+    Depth 8:
+        A potion of paralysis
+        A potion of strength
+        A potion of life
+        774 gold pieces (4 piles)
+    Depth 9:
+        A potion of paralysis
+        A scroll of identify
+        -2 scale mail [2]<12>
+        A potion of life
+        1302 gold pieces (7 piles)
+    Depth 10:
+        A scroll of enchanting
+        A potion of descent
+        A potion of strength
+        Some food
+        1081 gold pieces (6 piles)
+    Depth 11:
+        5 +0 incendiary darts <12>
+        A potion of hallucination
+        A -2 mace <16>
+        A -2 whip of plenty <14>
+        6 +0 incendiary darts <12>
+        A scroll of identify
+        A potion of descent
+        A mango
+        A potion of fire immunity
+        A door key (vault 3) (opens vault 1)
+        A +2 invisibility charm (ready) (vault 3)
+        A +1 ring of wisdom (vault 3)
+        +0 leather armor [3]<10> (vault 3)
+        A door key (opens vault 3)
+        A potion of life (vault 1)
+        423 gold pieces (2 piles)
+    Depth 12:
+        A scroll of enchanting
+        A -1 flail <17>
+        A potion of strength
+        A +3 ring of light
+        A scroll of enchanting
+        A potion of fire immunity
+        814 gold pieces (4 piles)
+    Depth 13:
+        A scroll of enchanting
+        +0 splint mail [9]<17>
+        A potion of invisibility
+        1621 gold pieces (7 piles)
+        A potion of detect magic (dar blademaster)
+    Depth 14:
+        A +0 axe <15>
+        A scroll of discord
+        A scroll of identify
+        1379 gold pieces (6 piles)
+        A scroll of aggravate monsters (goblin conjurer)
+    Depth 15:
+        A potion of life
+        A scroll of enchanting
+        Some food
+        966 gold pieces (4 piles)
+        A wand of empowerment [1] (dar blademaster)
+    Depth 16:
+        A scroll of protect weapon
+        A +0 dagger <12>
+        A scroll of teleportation
+        +1 chain mail of reprisal [6]<13>
+        A scroll of teleportation
+        1048 gold pieces (4 piles)
+    Depth 17:
+        16 +0 javelins <15>
+        A scroll of recharging
+        A scroll of aggravate monsters
+        A potion of telepathy
+        A wand of invisibility [4]
+        Some food
+        1233 gold pieces (4 piles)
+        A shackled troll
+    Depth 18:
+        A potion of fire immunity
+        A potion of strength
+        A potion of strength
+        1039 gold pieces (4 piles)
+    Depth 19:
+        A scroll of identify
+        A +1 ring of clairvoyance
+        A potion of life
+        1387 gold pieces (4 piles)
+    Depth 20:
+        A potion of invisibility
+        A scroll of enchanting
+        A potion of caustic gas
+        Some food
+        1999 gold pieces (6 piles)
+        A shackled dar blademaster
+        A shackled naga
+        A shackled naga
+    Depth 21:
+        +0 scale mail [4]<12>
+        +0 scale mail [4]<12>
+        A potion of telepathy
+        A scroll of aggravate monsters
+        A +0 broadsword <19>
+        A +0 rapier <15>
+        A potion of detect magic
+        1942 gold pieces (6 piles)
+    Depth 22:
+        A +2 ring of clairvoyance
+        A potion of confusion
+        A scroll of sanctuary
+        2132 gold pieces (6 piles)
+        A scroll of identify (dar battlemage)
+        A shackled dar battlemage
+    Depth 23:
+        A +0 sword <14>
+        A potion of strength
+        Some food
+        A door key (opens vault 1)
+        2263 gold pieces (6 piles)
+        A potion of descent (dar blademaster)
+        A potion of telepathy (dar blademaster)
+        A shackled imp
+        A resurrection altar (vault 1)
+    Depth 24:
+        A potion of creeping death
+        A scroll of discord
+        A potion of speed
+        2856 gold pieces (7 piles)
+        +0 splint mail [9]<17> (dar blademaster)
+        A +0 dagger <12> (dar blademaster [infested])
+        A scroll of protect armor (dragon [reflective])
+        A shackled dragon
+        A shackled dragon [reflective]
+    Depth 25:
+        A potion of strength
+        A potion of caustic gas
+        A potion of caustic gas
+        A potion of paralysis
+        A wand of empowerment [1]
+        A scroll of enchanting
+        A scroll of enchanting
+        A +0 axe <15>
+        A potion of strength
+        +0 splint mail [9]<17>
+        A potion of hallucination
+        A scroll of enchanting
+        A scroll of negation
+        A potion of descent
+        A scroll of aggravate monsters
+        +0 banded mail [7]<15>
+        A potion of life
+        A mango
+        1942 gold pieces (5 piles)
+        A +0 whip <14> (dar blademaster)
+    Depth 26:
+        A potion of caustic gas
+        A +0 war pike <18>
+        A potion of invisibility
+        Some food
+        2266 gold pieces (6 piles)
+        A potion of levitation (dragon)
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        Some food
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        A mango
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+        A mango
+    Depth 40:
+        A lumenstone from depth 40
+Seed 23:
+    Depth 1:
+        A potion of paralysis
+        Some food
+        A wand of invisibility [5]
+        A scroll of enchanting
+        A +2 ring of regeneration
+        A scroll of discord
+        91 gold pieces
+    Depth 2:
+        A +2 ring of light
+        A scroll of enchanting
+        A potion of strength
+        A scroll of protect weapon
+        A scroll of shattering
+        234 gold pieces (2 piles)
+        A shackled monkey
+    Depth 3:
+        +3 splint mail [12]<17>
+        A scroll of aggravate monsters
+        A potion of descent
+        A scroll of magic mapping
+        A potion of life
+        A scroll of shattering
+        A wand of plenty [2]
+        A staff of entrancement [2/2] (vault 1)
+        A staff of discord [2/2] (vault 1)
+        A staff of tunneling [3/3] (vault 1)
+        A staff of poison [3/3] (vault 1)
+        A door key (opens vault 1)
+    Depth 4:
+        A potion of levitation
+        A scroll of teleportation
+        A potion of confusion
+        A scroll of enchanting
+        330 gold pieces (3 piles)
+    Depth 5:
+        A potion of caustic gas
+        A scroll of enchanting
+        Some food
+        A door key (opens vault 1)
+        +2 scale mail of multiplicity [6]<12> (vault 1)
+        493 gold pieces (4 piles)
+    Depth 6:
+        A scroll of protect armor
+        A +2 ring of stealth
+        A scroll of remove curse
+        A potion of life
+        569 gold pieces (4 piles)
+        A scroll of magic mapping (goblin mystic)
+        A shackled goblin mystic
+        A shackled goblin mystic
+    Depth 7:
+        Some food
+        A potion of descent
+        A potion of strength
+        461 gold pieces (3 piles)
+        A shackled goblin
+    Depth 8:
+        A potion of paralysis
+        A potion of invisibility
+        A scroll of recharging
+        A potion of detect magic
+        911 gold pieces (5 piles)
+    Depth 9:
+        A potion of creeping death
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        889 gold pieces (5 piles)
+        A potion of levitation (goblin conjurer)
+        A shackled ogre
+    Depth 10:
+        A potion of strength
+        A scroll of enchanting
+        A potion of life
+        393 gold pieces (2 piles)
+        A shackled ogre
+    Depth 11:
+        A +2 guardian charm (ready)
+        A scroll of enchanting
+        A potion of hallucination
+        A potion of levitation (vault 1)
+        A potion of confusion (vault 1)
+        A potion of caustic gas (vault 1)
+        A potion of invisibility (vault 1)
+        A potion of paralysis (vault 1)
+        A potion of hallucination (vault 1)
+        653 gold pieces (3 piles)
+    Depth 12:
+        A scroll of teleportation
+        A scroll of teleportation
+        A scroll of enchanting
+        A +0 mace <16>
+        543 gold pieces (3 piles)
+    Depth 13:
+        A potion of levitation
+        A scroll of identify
+        A potion of incineration
+        Some food
+        1148 gold pieces (5 piles)
+        A shackled ogre
+    Depth 14:
+        A potion of strength
+        A +1 recharging charm (ready)
+        A scroll of enchanting
+        A potion of fire immunity
+        A scroll of protect armor
+        747 gold pieces (3 piles)
+    Depth 15:
+        A scroll of identify
+        A potion of strength
+        A potion of descent
+        1471 gold pieces (5 piles)
+        A potion of confusion (goblin conjurer)
+        +0 splint mail [9]<17> (dar battlemage)
+        A door key (imp [explosive]) (opens vault 1)
+        A cage key (vampire)
+        A caged naga
+        A caged pixie
+        A caged dar battlemage
+        A caged pixie
+        A shackled dar blademaster
+        A resurrection altar (vault 1)
+    Depth 16:
+        A potion of detect magic
+        A potion of life
+        Some food
+        A staff of healing [2/2]
+        A staff of obstruction [2/2]
+        1634 gold pieces (6 piles)
+    Depth 17:
+        A potion of levitation
+        A potion of strength
+        A potion of strength
+        +2 chain mail of mage immunity [7]<13>
+        A potion of levitation
+        4 +0 incendiary darts <12>
+        A scroll of protect armor
+        1329 gold pieces (4 piles)
+    Depth 18:
+        A potion of paralysis
+        A scroll of enchanting
+        A potion of descent
+        A potion of telepathy
+        A potion of speed
+        A potion of invisibility
+        A potion of incineration
+        A potion of levitation
+        Some food
+        2531 gold pieces (8 piles)
+        A potion of fire immunity (dar blademaster)
+    Depth 19:
+        A potion of strength
+        A +2 ring of light
+        A +1 ring of clairvoyance
+        A scroll of enchanting
+        A scroll of enchanting
+        -1 chain mail [4]<13>
+        1557 gold pieces (5 piles)
+        A shackled pixie
+    Depth 20:
+        Some food
+        A +2 rapier of paralysis <15>
+        A potion of life
+        A scroll of identify
+        1094 gold pieces (3 piles)
+    Depth 21:
+        A wand of negation [5]
+        A potion of caustic gas
+        A potion of descent
+        A potion of invisibility
+        A +0 broadsword <19>
+        A potion of speed
+        A potion of fire immunity
+        A potion of invisibility
+        A scroll of aggravate monsters
+        A potion of telepathy
+        1626 gold pieces (5 piles)
+    Depth 22:
+        A +3 ring of transference
+        A +2 negation charm (ready)
+        A mango
+        2142 gold pieces (6 piles)
+        A potion of creeping death (dar blademaster)
+        A shackled imp
+    Depth 23:
+        A wand of polymorphism [5]
+        A potion of fire immunity
+        Some food
+        A potion of strength
+        A -2 war hammer of plenty <20>
+        A +0 war hammer <20>
+        2046 gold pieces (6 piles)
+        A +0 whip <14> (dar blademaster)
+        A shackled golem
+    Depth 24:
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of life
+        2690 gold pieces (7 piles)
+        A scroll of negation (dragon)
+    Depth 25:
+        A potion of invisibility
+        A scroll of enchanting
+        A potion of incineration
+        A potion of caustic gas
+        A +0 mace <16>
+        2065 gold pieces (5 piles)
+    Depth 26:
+        A +3 ring of transference
+        A potion of levitation
+        A staff of lightning [3/3]
+        2410 gold pieces (6 piles)
+        A -2 war pike <18> (dragon)
+        A potion of levitation (dragon)
+        A shackled tentacle horror
+        A shackled dar blademaster
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        Some food
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        A mango
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+        Some food
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        A mango
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+        Some food
+    Depth 40:
+        A lumenstone from depth 40
+Seed 24:
+    Depth 1:
+        A scroll of enchanting
+        A staff of blinking [3/3]
+        4 +0 incendiary darts <12>
+        A potion of detect magic
+        A potion of incineration
+        A potion of levitation
+        94 gold pieces
+    Depth 2:
+        Some food
+        A -1 sword <14>
+        A scroll of enchanting
+        A +0 axe <15>
+        A staff of obstruction [2/2]
+        A shackled monkey
+    Depth 3:
+        A scroll of negation
+        A +0 war axe <19>
+        A scroll of remove curse
+        A potion of levitation
+        A scroll of identify
+        A +1 ring of reaping (vault 1)
+        A +1 ring of clairvoyance (vault 1)
+        A +1 ring of stealth (vault 1)
+        A door key (opens vault 1)
+    Depth 4:
+        A scroll of aggravate monsters
+        A potion of strength
+        A scroll of identify
+        A potion of life
+        392 gold pieces (3 piles)
+    Depth 5:
+        A potion of descent
+        A potion of incineration
+        A scroll of enchanting
+        A staff of protection [4/4] (vault 1)
+        A staff of tunneling [3/3] (vault 1)
+        171 gold pieces
+    Depth 6:
+        +0 leather armor [3]<10>
+        A scroll of teleportation
+        A scroll of enchanting
+        A scroll of discord
+        A potion of strength
+        A scroll of enchanting
+        A potion of descent
+        Some food
+        A scroll of summon monsters
+        A scroll of magic mapping
+        815 gold pieces (5 piles)
+        A shackled ogre
+    Depth 7:
+        A potion of fire immunity
+        A staff of lightning [2/2]
+        A potion of strength
+        664 gold pieces (4 piles)
+    Depth 8:
+        A potion of telepathy
+        A mango
+        A +4 flail <17>
+        A potion of life
+        1328 gold pieces (7 piles)
+    Depth 9:
+        A potion of fire immunity
+        A potion of fire immunity
+        A potion of levitation
+        346 gold pieces (2 piles)
+    Depth 10:
+        A scroll of enchanting
+        A scroll of aggravate monsters
+        A potion of strength
+        879 gold pieces (4 piles)
+        A scroll of shattering (goblin conjurer)
+    Depth 11:
+        +0 banded mail [7]<15>
+        A scroll of discord
+        A potion of fire immunity
+        +0 splint mail [9]<17>
+        A potion of fire immunity
+        A door key (vault 3) (opens vault 1)
+        A staff of lightning [3/3] (vault 3)
+        +0 leather armor [3]<10> (vault 3)
+        +0 chain mail [5]<13> (vault 3)
+        A door key (opens vault 3)
+        A scroll of enchanting (vault 1)
+        393 gold pieces (2 piles)
+    Depth 12:
+        A scroll of remove curse
+        A potion of strength
+        A scroll of summon monsters
+        A potion of life
+        A potion of paralysis
+        969 gold pieces (4 piles)
+    Depth 13:
+        +0 plate armor [11]<19>
+        A scroll of summon monsters
+        Some food
+        869 gold pieces (3 piles)
+        A shackled troll
+    Depth 14:
+        A scroll of recharging
+        A scroll of protect weapon
+        A potion of paralysis
+        1151 gold pieces (5 piles)
+    Depth 15:
+        A potion of confusion
+        A +0 rapier <15>
+        A scroll of enchanting
+        A mango
+        838 gold pieces (3 piles)
+        A shackled centaur
+        A shackled salamander
+        A commutation altar (vault 1)
+    Depth 16:
+        A wand of invisibility [3]
+        A potion of strength
+        A potion of life
+        A door key (opens vault 1)
+        A potion of hallucination (vault 1)
+        A potion of confusion (vault 1)
+        A potion of telepathy (vault 1)
+        A potion of caustic gas (vault 1)
+        A potion of darkness (vault 1)
+        1265 gold pieces (5 piles)
+        A scroll of shattering (goblin conjurer)
+    Depth 17:
+        A +4 ring of reaping
+        A +1 protection charm (ready)
+        Some food
+        A scroll of identify
+        1240 gold pieces (4 piles)
+    Depth 18:
+        A potion of invisibility
+        A potion of detect magic
+        A potion of descent
+        A scroll of shattering
+        A +0 sword <14>
+        1238 gold pieces (4 piles)
+    Depth 19:
+        -3 chain mail of burden [2]<13>
+        A potion of hallucination
+        A potion of life
+        Some food
+        1699 gold pieces (6 piles)
+    Depth 20:
+        A +2 ring of stealth
+        A potion of confusion
+        A scroll of enchanting
+        1884 gold pieces (6 piles)
+        A potion of caustic gas (dar blademaster)
+        A shackled golem
+    Depth 21:
+        A potion of darkness
+        +3 plate armor [14]<19>
+        A staff of obstruction [4/4]
+        1553 gold pieces (5 piles)
+    Depth 22:
+        A potion of paralysis
+        A scroll of enchanting
+        A scroll of protect armor
+        Some food
+        1934 gold pieces (6 piles)
+    Depth 23:
+        A scroll of enchanting
+        A potion of strength
+        A potion of telepathy
+        A scroll of enchanting
+        A scroll of enchanting
+        A +2 rapier <15>
+        2487 gold pieces (7 piles)
+        A door key (flamedancer) (opens vault 1)
+        A commutation altar (vault 1)
+    Depth 24:
+        A +0 whip <14>
+        A potion of life
+        Some food
+        2273 gold pieces (6 piles)
+        A potion of telepathy (dar blademaster)
+    Depth 25:
+        A potion of telepathy
+        Some food
+        A scroll of enchanting
+        1887 gold pieces (5 piles)
+    Depth 26:
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of incineration
+        2146 gold pieces (5 piles)
+        A shackled dar blademaster
+        A shackled dar battlemage
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+    Depth 38:
+        A lumenstone from depth 38
+        Some food
+    Depth 39:
+        A lumenstone from depth 39
+    Depth 40:
+        A lumenstone from depth 40
+        Some food
+Seed 25:
+    Depth 1:
+        A potion of paralysis
+        A potion of confusion
+        A potion of confusion
+        +0 leather armor [3]<10>
+        A -3 axe <15>
+        +0 leather armor [3]<10>
+        A shackled monkey
+    Depth 2:
+        A scroll of protect armor
+        A +2 ring of clairvoyance
+        A potion of fire immunity
+        A potion of life
+        A scroll of sanctuary
+        A potion of strength
+    Depth 3:
+        A potion of detect magic
+        A scroll of teleportation
+        A -2 ring of transference
+        +0 chain mail [5]<13>
+        A scroll of enchanting
+        A scroll of enchanting
+        A mango
+        A staff of protection [2/2] (vault 1)
+        A +3 ring of light (vault 1)
+        A +1 flail of confusion <17> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        +2 chain mail [7]<13> (vault 1)
+        A wand of invisibility [5] (vault 1)
+        A scroll of shattering
+    Depth 4:
+        A scroll of aggravate monsters
+        A scroll of remove curse
+        A potion of invisibility
+        +0 scale mail [4]<12>
+        A -1 dagger <12>
+        A +1 haste charm (ready)
+        A +0 broadsword <19>
+        98 gold pieces
+    Depth 5:
+        A scroll of identify
+        A potion of strength
+        A potion of fire immunity
+        A potion of speed
+        220 gold pieces (2 piles)
+        A shackled monkey
+    Depth 6:
+        A scroll of enchanting
+        A potion of strength
+        A scroll of enchanting
+        Some food
+        664 gold pieces (4 piles)
+    Depth 7:
+        A scroll of enchanting
+        A +2 whip of quietus <14>
+        A potion of life
+        A +2 ring of wisdom (vault 4)
+        A +3 ring of awareness (vault 4)
+        A staff of entrancement [2/2] (vault 4)
+        +0 scale mail [4]<12> (vault 4)
+        A wand of slowness [5] (vault 4)
+        A wand of negation [6] (vault 4)
+        A wand of polymorphism [3] (vault 4)
+        A door key (opens vault 4)
+        A potion of creeping death
+        A potion of creeping death
+        A door key (opens vault 1)
+        +2 chain mail of absorption [7]<13> (vault 1)
+        812 gold pieces (5 piles)
+        A shackled ogre
+    Depth 8:
+        A +0 whip <14>
+        A scroll of aggravate monsters
+        A wand of slowness [3]
+        -2 banded mail [5]<15>
+        A scroll of identify
+        A scroll of enchanting
+        A scroll of negation
+        A potion of strength
+        927 gold pieces (5 piles)
+    Depth 9:
+        A potion of incineration
+        A scroll of remove curse
+        A potion of confusion
+        A scroll of enchanting
+        A potion of hallucination
+        769 gold pieces (4 piles)
+        A shackled goblin mystic
+    Depth 10:
+        A potion of levitation
+        A +3 dagger of paralysis <12>
+        Some food
+        1768 gold pieces (8 piles)
+    Depth 11:
+        A scroll of protect armor
+        A potion of telepathy
+        A scroll of enchanting
+        712 gold pieces (3 piles)
+        A scroll of protect weapon (goblin conjurer)
+        A scroll of identify (goblin conjurer)
+    Depth 12:
+        A scroll of sanctuary
+        A scroll of aggravate monsters
+        A potion of levitation
+        A potion of levitation
+        A mango
+        A potion of invisibility
+        A potion of life
+        Some food
+        A +1 invisibility charm (ready) (vault 1)
+        A +2 ring of reaping (vault 1)
+        A +0 broadsword <19> (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        A wand of slowness [5] (vault 1)
+        A wand of negation [6] (vault 1)
+        A door key (opens vault 1)
+        674 gold pieces (3 piles)
+    Depth 13:
+        A scroll of remove curse
+        A scroll of summon monsters
+        A scroll of enchanting
+        A potion of strength
+        A scroll of recharging
+        1666 gold pieces (7 piles)
+        A shackled ogre
+    Depth 14:
+        A potion of descent
+        A potion of strength
+        A potion of life
+        A staff of blinking [2/2]
+        228 gold pieces
+    Depth 15:
+        +2 banded mail [9]<15>
+        A potion of hallucination
+        A potion of telepathy
+        A scroll of aggravate monsters
+        A scroll of magic mapping
+        A potion of telepathy
+        1015 gold pieces (4 piles)
+        A commutation altar (vault 1)
+    Depth 16:
+        A scroll of identify
+        A potion of incineration
+        A potion of strength
+        A scroll of enchanting
+        A +3 ring of light
+        A scroll of identify
+        1483 gold pieces (6 piles)
+        A shackled pixie
+    Depth 17:
+        A potion of detect magic
+        A +2 ring of stealth
+        Some food
+        1460 gold pieces (5 piles)
+        A scroll of negation (goblin mystic)
+        A potion of caustic gas (goblin conjurer)
+    Depth 18:
+        A staff of lightning [3/3]
+        A scroll of enchanting
+        A scroll of enchanting
+        1210 gold pieces (4 piles)
+    Depth 19:
+        A +3 war axe <19>
+        A potion of life
+        Some food
+        1331 gold pieces (4 piles)
+    Depth 20:
+        A +3 ring of light
+        A scroll of recharging
+        A potion of paralysis
+        2475 gold pieces (8 piles)
+        A resurrection altar (vault 1)
+    Depth 21:
+        A potion of paralysis
+        A potion of confusion
+        A potion of fire immunity
+        A scroll of remove curse
+        A scroll of enchanting
+        A scroll of enchanting (vault 1)
+        1931 gold pieces (6 piles)
+        A shackled imp
+    Depth 22:
+        A scroll of identify
+        A potion of life
+        A mango
+        2122 gold pieces (6 piles)
+        A potion of descent (dar priestess)
+    Depth 23:
+        A +2 war hammer <20>
+        A potion of darkness
+        A potion of strength
+        A potion of incineration
+        1784 gold pieces (5 piles)
+        A scroll of teleportation (dar priestess)
+        A shackled dar blademaster
+    Depth 24:
+        A scroll of enchanting
+        A scroll of identify
+        Some food
+        1872 gold pieces (5 piles)
+        A potion of detect magic (dar battlemage)
+        A potion of hallucination (dar priestess)
+        A scroll of identify (dar blademaster)
+    Depth 25:
+        A scroll of sanctuary
+        A potion of telepathy
+        A potion of darkness
+        A scroll of enchanting
+        A potion of strength
+        A scroll of negation
+        2667 gold pieces (7 piles)
+        A potion of telepathy (dragon)
+        A scroll of identify (dar blademaster)
+        A shackled dar blademaster
+    Depth 26:
+        A scroll of recharging
+        A scroll of enchanting
+        A potion of invisibility
+        Some food
+        2269 gold pieces (6 piles)
+        A shackled dar blademaster
+        A shackled dar battlemage
+    Depth 27:
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+        A lumenstone from depth 27
+    Depth 28:
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+        A lumenstone from depth 28
+    Depth 29:
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        A lumenstone from depth 29
+        Some food
+    Depth 30:
+        A lumenstone from depth 30
+        A lumenstone from depth 30
+        Some food
+    Depth 31:
+        A lumenstone from depth 31
+        A lumenstone from depth 31
+    Depth 32:
+        A lumenstone from depth 32
+        A lumenstone from depth 32
+        Some food
+    Depth 33:
+        A lumenstone from depth 33
+        A lumenstone from depth 33
+    Depth 34:
+        A lumenstone from depth 34
+        A lumenstone from depth 34
+        Some food
+    Depth 35:
+        A lumenstone from depth 35
+    Depth 36:
+        A lumenstone from depth 36
+        Some food
+    Depth 37:
+        A lumenstone from depth 37
+        Some food
+    Depth 38:
+        A lumenstone from depth 38
+    Depth 39:
+        A lumenstone from depth 39
+        Some food
+    Depth 40:
+        A lumenstone from depth 40

--- a/test/seed_catalogs/seed_catalog_rapid_brogue.txt
+++ b/test/seed_catalogs/seed_catalog_rapid_brogue.txt
@@ -1,0 +1,3679 @@
+Brogue seed catalog, seeds 1 to 25, through depth 10.
+Generated with RB 1.5.0-dev.8736c7c.feature/fix_rb_seed519. Dungeons unchanged since RB 1.5.
+
+To play one of these seeds, select Play>New Seeded Game from the title screen.
+Seed 1:
+    Depth 1:
+        A potion of creeping death
+        A potion of incineration
+        A scroll of shattering
+        A scroll of identify
+        A potion of levitation
+        A scroll of recharging
+        A scroll of identify
+        A wand of beckoning [3]
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of firebolt [4/4] (vault 1)
+        A staff of tunneling [2/2] (vault 1)
+        A staff of protection [2/2] (vault 1)
+        A staff of obstruction [3/3] (vault 1)
+        A door key (opens vault 1)
+        298 gold pieces (2 piles)
+    Depth 2:
+        A potion of telepathy
+        A scroll of enchanting
+        A potion of detect magic
+        A wand of negation [3]
+        A -1 sword <14>
+        A potion of confusion
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of obstruction [2/2]
+        A +2 teleportation charm (ready)
+        +2 leather armor of reprisal [5]<10>
+        +2 leather armor of dampening [5]<10>
+        +0 plate armor [11]<19> (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A potion of life (vault 1)
+        983 gold pieces (6 piles)
+        A staff of tunneling [2/2] (monkey)
+        A +0 broadsword <19> (goblin conjurer)
+    Depth 3:
+        A scroll of identify
+        A +3 invisibility charm (ready)
+        A potion of paralysis
+        A potion of fire immunity
+        A potion of caustic gas
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        A door key (vault 3) (opens vault 1)
+        A +1 recharging charm (ready) (vault 3)
+        A +3 ring of reaping (vault 3)
+        +0 chain mail [5]<13> (vault 3)
+        A +3 whip of speed <14> (vault 3)
+        A door key (opens vault 3)
+        A potion of detect magic (vault 1)
+        A potion of fire immunity (vault 1)
+        A potion of confusion (vault 1)
+        A potion of descent (vault 1)
+        A potion of invisibility (vault 1)
+        A potion of telepathy (vault 1)
+        A potion of caustic gas (vault 1)
+        1368 gold pieces (6 piles)
+        A potion of levitation (goblin mystic)
+    Depth 4:
+        A staff of conjuration [2/2]
+        A scroll of negation
+        A potion of detect magic
+        A potion of caustic gas
+        Some food
+        Some food
+        A potion of speed
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (opens vault 12)
+        A cage key (vault 8)
+        A staff of obstruction [2/2] (vault 8)
+        A staff of lightning [2/2] (vault 8)
+        A wand of teleportation [1] (vault 8)
+        A door key (opens vault 9)
+        A +3 recharging charm (ready) (vault 4)
+        A staff of lightning [3/3] (vault 4)
+        A +0 flail <17> (vault 4)
+        A wand of plenty [1] (vault 4)
+        +0 banded mail [7]<15> (vault 4)
+        A wand of beckoning [3] (vault 4)
+        A door key (opens vault 1)
+        1767 gold pieces (7 piles)
+        A cage key (monkey)
+        A shackled pixie
+        A shackled troll
+        A caged naga
+        A caged troll
+        A caged naga
+        A caged dar battlemage
+    Depth 5:
+        A scroll of teleportation
+        A potion of confusion
+        A scroll of recharging
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        2084 gold pieces (7 piles)
+        A +1 ring of regeneration (goblin conjurer)
+        A scroll of identify (goblin conjurer)
+    Depth 6:
+        A potion of confusion
+        A scroll of remove curse
+        A +2 ring of regeneration
+        A potion of incineration
+        A scroll of magic mapping
+        A potion of strength
+        A potion of life
+        3962 gold pieces (11 piles)
+        A potion of speed (dar priestess)
+        A scroll of discord (dar blademaster)
+        A potion of hallucination (dar priestess)
+        A potion of telepathy (dar battlemage)
+        A potion of incineration (dar blademaster)
+        A shackled dar priestess
+        A shackled golem
+        A shackled dar priestess
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 2:
+    Depth 1:
+        A -2 war pike <18>
+        A staff of firebolt [3/3]
+        A potion of descent
+        A scroll of protect armor
+        A -3 dagger of mercy <12>
+        A scroll of magic mapping
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of healing [2/2] (vault 3)
+        A staff of lightning [2/2] (vault 3)
+        A staff of conjuration [4/4] (vault 3)
+        A staff of protection [2/2] (vault 3)
+        A staff of firebolt [2/2] (vault 3)
+        A +2 protection charm (ready) (vault 1)
+        A +3 ring of transference (vault 1)
+        A +0 axe <15> (vault 1)
+        +1 leather armor of absorption [4]<10> (vault 1)
+        A +0 broadsword <19> (vault 1)
+        A wand of beckoning [2] (vault 1)
+        266 gold pieces (2 piles)
+    Depth 2:
+        A scroll of discord
+        A scroll of identify
+        A potion of confusion
+        A potion of speed
+        A scroll of identify
+        A scroll of protect weapon
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A cage key
+        A +0 mace <16> (vault 1)
+        A +0 war hammer <20> (vault 1)
+        A +0 war axe <19> (vault 1)
+        A scroll of enchanting (vault 1)
+        382 gold pieces (2 piles)
+        +3 chain mail of mutuality [8]<13> (goblin warlord)
+        A shackled ogre
+        A caged goblin
+        A caged monkey
+        A caged goblin
+        A shackled goblin mystic
+        A shackled ogre
+    Depth 3:
+        A scroll of summon monsters
+        A scroll of magic mapping
+        A scroll of teleportation
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        Some food
+        1712 gold pieces (8 piles)
+    Depth 4:
+        +0 leather armor [3]<10>
+        A scroll of identify
+        A potion of detect magic
+        A potion of creeping death
+        A potion of detect magic
+        A scroll of shattering
+        A potion of strength
+        A potion of life
+        A door key (vault 3) (opens vault 1)
+        A potion of invisibility (vault 1)
+        A potion of detect magic (vault 1)
+        A potion of telepathy (vault 1)
+        A potion of creeping death (vault 1)
+        A potion of incineration (vault 1)
+        2042 gold pieces (8 piles)
+        A shackled pixie
+    Depth 5:
+        A potion of creeping death
+        A potion of incineration
+        -3 leather armor [0]<10>
+        A potion of detect magic
+        A potion of paralysis
+        A +0 rapier <15>
+        A potion of hallucination
+        A potion of invisibility
+        A scroll of enchanting
+        A door key (vault 12) (opens vault 10)
+        A +3 ring of transference (vault 12)
+        +2 splint mail [11]<17> (vault 12)
+        A +2 dagger of slowing <12> (vault 10)
+        A door key (opens vault 7)
+        A staff of blinking [2/2]
+        A staff of poison [2/2]
+        2234 gold pieces (7 piles)
+        A staff of poison [3/3] (goblin conjurer)
+        A door key (vampire) (opens vault 4)
+    Depth 6:
+        +0 splint mail [9]<17>
+        A scroll of identify
+        A potion of hallucination
+        A scroll of identify
+        A scroll of discord
+        A scroll of identify
+        A potion of incineration
+        A scroll of summon monsters
+        A wand of negation [4]
+        A potion of detect magic
+        A potion of telepathy
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        2425 gold pieces (7 piles)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        Some food
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        Some food
+Seed 3:
+    Depth 1:
+        +0 scale mail [4]<12>
+        A scroll of shattering
+        A scroll of remove curse
+        A potion of telepathy
+        A scroll of identify
+        A potion of speed
+        A potion of speed
+        A potion of invisibility
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 ring of awareness (vault 3)
+        A +3 ring of light (vault 3)
+        A +3 ring of transference (vault 3)
+        A +3 ring of reaping (vault 3)
+        A door key (vault 5) (opens vault 3)
+        A +2 negation charm (ready) (vault 5)
+        +0 banded mail [7]<15> (vault 5)
+        A staff of obstruction [2/2] (vault 1)
+        A +1 telepathy charm (ready) (vault 1)
+        A +2 war pike <18> (vault 1)
+        +0 splint mail [9]<17> (vault 1)
+        A wand of polymorphism [2] (vault 1)
+        A wand of teleportation [2] (vault 1)
+        112 gold pieces
+        A door key (monkey) (opens vault 5)
+    Depth 2:
+        A scroll of protect armor
+        A scroll of aggravate monsters
+        A scroll of magic mapping
+        A scroll of remove curse
+        A potion of confusion
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +2 guardian charm (ready) (vault 1)
+        A +3 ring of awareness (vault 1)
+        A +1 haste charm (ready) (vault 1)
+        A +0 mace <16> (vault 1)
+        A wand of invisibility [4] (vault 1)
+        A +0 war hammer <20> (vault 1)
+        A wand of plenty [1] (vault 1)
+        A potion of levitation
+        A door key (opens vault 1)
+        572 gold pieces (3 piles)
+    Depth 3:
+        A scroll of identify
+        A staff of entrancement [2/2]
+        A scroll of teleportation
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A mango
+        A door key (opens vault 4)
+        A scroll of shattering (vault 4)
+        A scroll of summon monsters (vault 4)
+        A scroll of aggravate monsters (vault 4)
+        A scroll of identify (vault 4)
+        A door key (opens vault 1)
+        A +3 rapier of force <15> (vault 1)
+        1372 gold pieces (6 piles)
+        A scroll of magic mapping (dar blademaster)
+        A scroll of aggravate monsters (goblin mystic)
+        A shackled ogre
+        A shackled ogre
+    Depth 4:
+        A +0 war hammer <20>
+        A scroll of identify
+        A scroll of aggravate monsters
+        A potion of creeping death
+        A +0 axe <15>
+        A potion of creeping death
+        A scroll of sanctuary
+        A potion of darkness
+        A scroll of enchanting
+        A door key (opens vault 11)
+        A potion of life (vault 11)
+        A +2 ring of wisdom (vault 7)
+        A +2 ring of reaping (vault 7)
+        A wand of slowness [4] (vault 7)
+        A +0 sword <14> (vault 7)
+        A wand of plenty [2] (vault 7)
+        A wand of beckoning [3] (vault 7)
+        A scroll of teleportation
+        A door key (opens vault 7)
+        A door key (opens vault 4)
+        A +1 ring of transference (vault 1)
+        A staff of lightning [3/3] (vault 1)
+        A +0 sword <14> (vault 1)
+        A +0 mace <16> (vault 1)
+        A +0 flail <17> (vault 1)
+        A wand of negation [3] (vault 1)
+        A door key (opens vault 1)
+        1989 gold pieces (8 piles)
+    Depth 5:
+        A scroll of summon monsters
+        A wand of invisibility [4]
+        A potion of telepathy
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A door key (vault 3) (opens vault 1)
+        A +3 health charm (ready) (vault 3)
+        A +0 flail <17> (vault 3)
+        +3 plate armor [14]<19> (vault 3)
+        2975 gold pieces (9 piles)
+        A potion of detect magic (dar blademaster)
+        A scroll of aggravate monsters (dar blademaster)
+        A shackled tentacle horror
+        A shackled centaur [reflective]
+    Depth 6:
+        A scroll of negation
+        A scroll of recharging
+        A potion of speed
+        A potion of telepathy
+        A scroll of identify
+        A mango
+        A scroll of identify
+        A scroll of teleportation
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        2676 gold pieces (7 piles)
+        A potion of detect magic (dar blademaster)
+        A shackled dar battlemage
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 4:
+    Depth 1:
+        A scroll of enchanting
+        A scroll of recharging
+        A scroll of protect armor
+        A potion of hallucination
+        A scroll of sanctuary
+        A scroll of aggravate monsters
+        A potion of fire immunity
+        A scroll of negation
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 ring of awareness (vault 6)
+        A staff of healing [3/3] (vault 6)
+        A wand of plenty [2] (vault 6)
+        A wand of empowerment [1] (vault 6)
+        A wand of slowness [2] (vault 6)
+        A wand of teleportation [2] (vault 6)
+        A +2 ring of clairvoyance (vault 3)
+        A +1 fire immunity charm (ready) (vault 3)
+        A +3 ring of wisdom (vault 3)
+        A +0 war pike <18> (vault 3)
+        A +0 flail <17> (vault 3)
+        +0 plate armor [11]<19> (vault 3)
+        A wand of invisibility [3] (vault 3)
+        A door key (opens vault 3)
+        A +1 negation charm (ready) (vault 1)
+        A +1 ring of light (vault 1)
+        A staff of poison [3/3] (vault 1)
+        A wand of negation [4] (vault 1)
+        A +0 dagger <12> (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        A wand of empowerment [1] (vault 1)
+        269 gold pieces (2 piles)
+    Depth 2:
+        A scroll of identify
+        A scroll of aggravate monsters
+        +0 plate armor [11]<19>
+        A potion of telepathy
+        A potion of levitation
+        A potion of speed
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        486 gold pieces (3 piles)
+    Depth 3:
+        A potion of caustic gas
+        A potion of speed
+        +0 chain mail [5]<13>
+        A scroll of recharging
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A mango
+        A door key (opens vault 3)
+        A scroll of recharging (vault 3)
+        A scroll of aggravate monsters (vault 3)
+        A scroll of discord (vault 3)
+        A scroll of remove curse (vault 3)
+        A scroll of magic mapping (vault 3)
+        A scroll of teleportation (vault 3)
+        A +1 spear of quietus <13>
+        1677 gold pieces (8 piles)
+    Depth 4:
+        A scroll of remove curse
+        A scroll of aggravate monsters
+        +3 banded mail [10]<15>
+        +0 splint mail [9]<17>
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (opens vault 3)
+        3 +0 incendiary darts <12> (vault 1)
+        A +0 rapier <15> (vault 1)
+        A scroll of enchanting (vault 1)
+        1657 gold pieces (6 piles)
+        A potion of invisibility (goblin mystic)
+        A scroll of recharging (goblin conjurer)
+        A potion of levitation (goblin warlord)
+    Depth 5:
+        A scroll of remove curse
+        A potion of detect magic
+        A scroll of identify
+        A scroll of magic mapping
+        A potion of invisibility
+        A wand of teleportation [1]
+        A +1 sword of force <14>
+        A scroll of identify (vault 4)
+        A scroll of summon monsters (vault 4)
+        A scroll of remove curse (vault 4)
+        A potion of life (vault 4)
+        A door key (opens vault 1)
+        2447 gold pieces (8 piles)
+    Depth 6:
+        A scroll of identify
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        Some food
+        3319 gold pieces (8 piles)
+        A shackled tentacle horror
+        A shackled dragon [agile]
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        Some food
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 5:
+    Depth 1:
+        +0 banded mail [7]<15>
+        A potion of caustic gas
+        A scroll of teleportation
+        A potion of detect magic
+        A potion of paralysis
+        A potion of fire immunity
+        A potion of levitation
+        A scroll of protect weapon
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of firebolt [3/3] (vault 4)
+        A +2 teleportation charm (ready) (vault 4)
+        A +1 ring of reaping (vault 4)
+        +0 plate armor [11]<19> (vault 4)
+        +0 banded mail [7]<15> (vault 4)
+        A +3 war pike <18> (vault 4)
+        A wand of plenty [1] (vault 4)
+        A +3 ring of light (vault 1)
+        A +3 ring of stealth (vault 1)
+        A +3 teleportation charm (ready) (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        A +0 war axe <19> (vault 1)
+        A wand of beckoning [3] (vault 1)
+        A door key (opens vault 1)
+        248 gold pieces (2 piles)
+    Depth 2:
+        A scroll of remove curse
+        A potion of levitation
+        A potion of confusion
+        A scroll of protect weapon
+        A scroll of enchanting
+        A scroll of negation
+        A potion of descent
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of obstruction [3/3] (vault 1)
+        A +3 ring of clairvoyance (vault 1)
+        A staff of haste [3/3] (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        +0 plate armor [11]<19> (vault 1)
+        A +0 war pike <18> (vault 1)
+        A wand of beckoning [2] (vault 1)
+        A door key (opens vault 1)
+        819 gold pieces (4 piles)
+    Depth 3:
+        A potion of confusion
+        A scroll of remove curse
+        A staff of poison [3/3]
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        A scroll of recharging (vault 3)
+        A scroll of discord (vault 3)
+        A scroll of protect armor (vault 3)
+        A scroll of identify (vault 3)
+        A +2 recharging charm (ready)
+        1203 gold pieces (5 piles)
+        A door key (stone guardian) (opens vault 3)
+    Depth 4:
+        A scroll of remove curse
+        A scroll of identify
+        A scroll of identify
+        A potion of caustic gas
+        A potion of telepathy
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of obstruction [2/2] (vault 4)
+        A +3 ring of light (vault 4)
+        +0 chain mail [5]<13> (vault 4)
+        +0 banded mail [7]<15> (vault 4)
+        A wand of beckoning [3] (vault 4)
+        A wand of empowerment [1] (vault 4)
+        A door key (opens vault 4)
+        A potion of descent
+        A crystal orb
+        1644 gold pieces (6 piles)
+        An allied unicorn
+    Depth 5:
+        A potion of telepathy
+        A scroll of magic mapping
+        A potion of telepathy
+        A potion of incineration
+        A scroll of magic mapping
+        A potion of strength
+        A potion of life
+        A potion of life (vault 1)
+        2338 gold pieces (7 piles)
+        A potion of telepathy (dar priestess)
+        A potion of descent (dar blademaster)
+    Depth 6:
+        A potion of fire immunity
+        +0 chain mail [5]<13>
+        A potion of invisibility
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A cage key (vault 3)
+        A +1 ring of awareness (vault 3)
+        A staff of blinking [3/3] (vault 3)
+        +0 banded mail [7]<15> (vault 3)
+        3401 gold pieces (9 piles)
+        A scroll of protect armor (dar blademaster [infested])
+        A shackled dar blademaster
+        A caged dar priestess
+        A caged dar battlemage
+        A caged dar blademaster
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        Some food
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A mango
+Seed 6:
+    Depth 1:
+        A +1 ring of reaping
+        A potion of telepathy
+        A potion of invisibility
+        A scroll of summon monsters
+        A -2 war pike <18>
+        A potion of levitation
+        A potion of invisibility
+        A scroll of enchanting
+        A scroll of protect weapon
+        A potion of caustic gas
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +3 ring of stealth (vault 1)
+        A staff of blinking [3/3] (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        A +0 war axe <19> (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A wand of slowness [3] (vault 1)
+        A door key (opens vault 1)
+        216 gold pieces (2 piles)
+    Depth 2:
+        +0 scale mail [4]<12>
+        A potion of telepathy
+        A potion of detect magic
+        A potion of confusion
+        A potion of paralysis
+        A scroll of protect weapon
+        A potion of hallucination
+        Some food
+        A potion of telepathy
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A door key (opens vault 3)
+        +3 leather armor of infernal immunity [6]<10> (vault 3)
+        A staff of blinking [2/2] (vault 1)
+        A +3 ring of awareness (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A +0 rapier <15> (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        A wand of empowerment [1] (vault 1)
+        A scroll of shattering
+        521 gold pieces (3 piles)
+    Depth 3:
+        5 +0 incendiary darts <12>
+        A potion of caustic gas
+        A scroll of sanctuary
+        A potion of descent
+        A potion of confusion
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (vault 5) (opens vault 3)
+        A +1 fire immunity charm (ready) (vault 5)
+        A +3 ring of regeneration (vault 5)
+        A +0 dagger <12> (vault 5)
+        A +0 sword <14> (vault 5)
+        +2 splint mail of multiplicity [11]<17> (vault 3)
+        A potion of telepathy (vault 1)
+        A potion of paralysis (vault 1)
+        A potion of detect magic (vault 1)
+        A potion of invisibility (vault 1)
+        A potion of incineration (vault 1)
+        A potion of darkness (vault 1)
+        A potion of descent (vault 1)
+        1095 gold pieces (5 piles)
+        A potion of speed (goblin mystic)
+        A door key (stone guardian) (opens vault 5)
+    Depth 4:
+        A scroll of teleportation
+        A potion of descent
+        -3 leather armor [0]<10>
+        A potion of levitation
+        A potion of confusion
+        A potion of hallucination
+        A potion of detect magic
+        A scroll of protect weapon
+        A potion of darkness
+        A scroll of enchanting
+        +0 banded mail [7]<15> (vault 1)
+        A +0 rapier <15> (vault 1)
+        A scroll of enchanting (vault 1)
+        1521 gold pieces (6 piles)
+    Depth 5:
+        A scroll of recharging
+        A scroll of identify
+        A potion of caustic gas
+        +0 banded mail [7]<15>
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (opens vault 14)
+        A scroll of enchanting (vault 14)
+        A door key (vault 5) (opens vault 3)
+        A +2 ring of stealth (vault 5)
+        A +0 broadsword <19> (vault 5)
+        +0 chain mail [5]<13> (vault 5)
+        A door key (opens vault 5)
+        A potion of life (vault 3)
+        A crystal orb
+        2109 gold pieces (7 piles)
+        A scroll of aggravate monsters (dar blademaster)
+        A staff of healing [2/2] (dar blademaster)
+        A staff of firebolt [3/3] (imp) (vault 14)
+        A staff of poison [2/2] (imp)
+        An allied mangrove dryad
+    Depth 6:
+        A scroll of sanctuary
+        A scroll of discord
+        A wand of empowerment [1]
+        A potion of invisibility
+        A scroll of shattering
+        +2 leather armor [5]<10>
+        A scroll of aggravate monsters
+        A -1 rapier of plenty <15>
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        2568 gold pieces (7 piles)
+        +3 splint mail [12]<17> (dar blademaster)
+        A scroll of identify (dragon)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        Some food
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        Some food
+Seed 7:
+    Depth 1:
+        A potion of levitation
+        A scroll of teleportation
+        +0 plate armor [11]<19>
+        A potion of telepathy
+        A potion of telepathy
+        A potion of descent
+        A scroll of remove curse
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 protection charm (ready) (vault 4)
+        A staff of discord [3/3] (vault 4)
+        A staff of haste [3/3] (vault 4)
+        +1 leather armor [4]<10> (vault 4)
+        A +0 sword <14> (vault 4)
+        +0 plate armor [11]<19> (vault 4)
+        A wand of slowness [4] (vault 4)
+        A door key (opens vault 4)
+        A staff of firebolt [2/2] (vault 1)
+        A staff of poison [2/2] (vault 1)
+        A +3 ring of light (vault 1)
+        A +0 spear <13> (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A +0 flail <17> (vault 1)
+        A wand of teleportation [2] (vault 1)
+        A door key (opens vault 1)
+        148 gold pieces
+    Depth 2:
+        A scroll of remove curse
+        A scroll of shattering
+        A potion of incineration
+        A scroll of recharging
+        A scroll of summon monsters
+        Some food
+        A potion of levitation
+        A scroll of teleportation
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 ring of stealth (vault 1)
+        A +2 ring of clairvoyance (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A +0 whip <14> (vault 1)
+        A wand of polymorphism [1] (vault 1)
+        A wand of negation [3] (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A staff of haste [3/3] (vault 3)
+        A +0 rapier <15> (vault 3)
+        +3 banded mail [10]<15> (vault 3)
+        506 gold pieces (3 piles)
+        A door key (monkey) (opens vault 3)
+    Depth 3:
+        A scroll of identify
+        A +1 fire immunity charm (ready)
+        A scroll of teleportation
+        A potion of detect magic
+        A potion of paralysis
+        +0 leather armor [3]<10>
+        A potion of telepathy
+        A scroll of aggravate monsters
+        A scroll of enchanting
+        +2 leather armor of reflection [5]<10> (vault 7)
+        A door key (opens vault 2)
+        A staff of obstruction [4/4] (vault 2)
+        A staff of protection [2/2] (vault 2)
+        1175 gold pieces (5 piles)
+        A door key (stone guardian) (opens vault 7)
+        A scroll of summon monsters (dar blademaster)
+        A shackled dar blademaster
+        A shackled dar blademaster
+    Depth 4:
+        A potion of speed
+        A scroll of identify
+        +0 plate armor [11]<19>
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        1899 gold pieces (7 piles)
+        A potion of telepathy (dar battlemage)
+        A potion of speed (dar priestess)
+    Depth 5:
+        A potion of fire immunity
+        A potion of incineration
+        A scroll of protect armor
+        A potion of telepathy
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (vault 13) (opens vault 9)
+        +3 banded mail of absorption [10]<15> (vault 7)
+        +1 scale mail of multiplicity [5]<12>
+        2228 gold pieces (7 piles)
+    Depth 6:
+        A scroll of remove curse
+        A scroll of discord
+        A potion of paralysis
+        A potion of creeping death
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A cage key
+        2467 gold pieces (7 piles)
+        A potion of caustic gas (dar battlemage)
+        A scroll of teleportation (dar blademaster)
+        A caged naga
+        A caged imp
+        A caged naga
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        Some food
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        Some food
+Seed 8:
+    Depth 1:
+        A potion of invisibility
+        A scroll of enchanting
+        A potion of fire immunity
+        A scroll of sanctuary
+        A scroll of identify
+        +1 splint mail [10]<17>
+        A scroll of aggravate monsters
+        A potion of descent
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 recharging charm (ready) (vault 3)
+        A +3 ring of reaping (vault 3)
+        +3 splint mail [12]<17> (vault 3)
+        A wand of invisibility [2] (vault 3)
+        A +0 broadsword <19> (vault 3)
+        A wand of empowerment [1] (vault 3)
+        A door key (opens vault 3)
+        A staff of discord [2/2] (vault 1)
+        A +2 ring of light (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A wand of invisibility [2] (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A wand of beckoning [2] (vault 1)
+        A potion of incineration
+        290 gold pieces (2 piles)
+    Depth 2:
+        A potion of caustic gas
+        A potion of incineration
+        A potion of darkness
+        A potion of hallucination
+        +0 leather armor [3]<10>
+        A scroll of sanctuary
+        A scroll of identify
+        A potion of fire immunity
+        A scroll of protect armor
+        A potion of caustic gas
+        A scroll of aggravate monsters
+        A scroll of protect armor
+        A scroll of recharging
+        A potion of creeping death
+        A potion of incineration
+        A scroll of enchanting
+        A potion of speed
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A door key (vault 3) (opens vault 1)
+        A +3 ring of stealth (vault 3)
+        A wand of beckoning [4] (vault 3)
+        A +0 dagger <12> (vault 3)
+        A door key (vault 5) (opens vault 3)
+        A staff of firebolt [2/2] (vault 5)
+        A staff of conjuration [2/2] (vault 5)
+        +0 plate armor [11]<19> (vault 5)
+        A wand of empowerment [1] (vault 5)
+        A door key (opens vault 5)
+        A staff of haste [2/2] (vault 1)
+        A staff of obstruction [2/2] (vault 1)
+        792 gold pieces (5 piles)
+    Depth 3:
+        A potion of caustic gas
+        A scroll of remove curse
+        A potion of paralysis
+        A +2 ring of stealth
+        A scroll of recharging
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        Some food
+        A scroll of recharging
+        A +2 spear of multiplicity <13> (vault 3)
+        1224 gold pieces (5 piles)
+        A door key (goblin warlord) (opens vault 3)
+        A crystal orb (monkey)
+        An allied ifrit
+    Depth 4:
+        A wand of beckoning [3]
+        A scroll of identify
+        A +3 ring of regeneration
+        A +3 ring of transference
+        A scroll of sanctuary
+        A +1 axe <15>
+        A potion of detect magic
+        A potion of incineration
+        A +0 war axe <19>
+        A +3 spear of speed <13>
+        A +2 health charm (ready)
+        A potion of invisibility
+        A scroll of negation
+        A scroll of enchanting
+        A door key (vault 8) (opens vault 6)
+        A scroll of enchanting (vault 6)
+        A scroll of shattering
+        A +1 ring of light (vault 1)
+        A +2 recharging charm (ready) (vault 1)
+        +3 splint mail [12]<17> (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A +0 dagger <12> (vault 1)
+        A wand of polymorphism [1] (vault 1)
+        A door key (opens vault 1)
+        1600 gold pieces (6 piles)
+        A scroll of identify (dar blademaster)
+    Depth 5:
+        Some food
+        A potion of invisibility
+        A potion of telepathy
+        A potion of levitation
+        A +0 sword <14>
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A potion of life (vault 1)
+        2844 gold pieces (9 piles)
+        A scroll of sanctuary (dar blademaster)
+    Depth 6:
+        A potion of fire immunity
+        A scroll of shattering
+        A scroll of negation
+        A scroll of protect weapon
+        A potion of incineration
+        A potion of fire immunity
+        A scroll of enchanting
+        2550 gold pieces (7 piles)
+        A scroll of magic mapping (dar blademaster)
+        A door key (imp) (opens vault 2)
+        A shackled tentacle horror
+        A shackled dar blademaster
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A mango
+Seed 9:
+    Depth 1:
+        A potion of strength
+        A potion of descent
+        A scroll of remove curse
+        A potion of invisibility
+        A potion of incineration
+        A potion of levitation
+        A scroll of sanctuary
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 health charm (ready) (vault 3)
+        A +2 recharging charm (ready) (vault 3)
+        A +1 ring of reaping (vault 3)
+        +0 chain mail [5]<13> (vault 3)
+        A +0 axe <15> (vault 3)
+        +0 plate armor [11]<19> (vault 3)
+        A wand of polymorphism [1] (vault 3)
+        A door key (opens vault 3)
+        A +2 negation charm (ready) (vault 1)
+        A staff of protection [3/3] (vault 1)
+        A +0 axe <15> (vault 1)
+        A +0 war pike <18> (vault 1)
+        A +0 war axe <19> (vault 1)
+        A wand of plenty [1] (vault 1)
+        150 gold pieces
+    Depth 2:
+        A potion of incineration
+        A potion of darkness
+        A scroll of negation
+        A +2 teleportation charm (ready)
+        A scroll of shattering
+        A potion of levitation
+        A scroll of identify
+        A potion of detect magic
+        A potion of life
+        A scroll of enchanting
+        A +2 whip of paralysis <14>
+        A scroll of shattering
+        A +3 spear of speed <13> (vault 1)
+        1116 gold pieces (6 piles)
+    Depth 3:
+        A potion of telepathy
+        A potion of paralysis
+        A scroll of identify
+        A +3 ring of reaping
+        A scroll of protect weapon
+        A potion of detect magic
+        A scroll of enchanting
+        Some food
+        A +1 shattering charm (ready) (vault 5)
+        A +3 ring of wisdom (vault 1)
+        A +1 ring of light (vault 1)
+        +3 chain mail of absorption [8]<13> (vault 1)
+        A wand of beckoning [3] (vault 1)
+        A +0 spear <13> (vault 1)
+        A wand of slowness [3] (vault 1)
+        1026 gold pieces (5 piles)
+        A +1 invisibility charm (ready) (monkey)
+        A +1 ring of transference (dar blademaster)
+        A shackled dar blademaster
+        A shackled dar priestess
+    Depth 4:
+        A potion of darkness
+        A +0 rapier <15>
+        A scroll of sanctuary
+        A scroll of sanctuary
+        A scroll of sanctuary
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A cage key (vault 4)
+        A +2 negation charm (ready) (vault 4)
+        A staff of poison [3/3] (vault 4)
+        +0 banded mail [7]<15> (vault 4)
+        A +3 spear of paralysis <13>
+        2553 gold pieces (10 piles)
+        A scroll of teleportation (dar blademaster)
+        A caged troll
+        A caged salamander
+        A caged naga
+        A caged salamander
+        A caged dar blademaster
+    Depth 5:
+        A potion of detect magic
+        A potion of incineration
+        A potion of fire immunity
+        A potion of paralysis
+        A potion of incineration
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (opens vault 1)
+        A +2 dagger of multiplicity <12> (vault 1)
+        2229 gold pieces (7 piles)
+        A scroll of identify (dar priestess [reflective])
+    Depth 6:
+        A potion of confusion
+        A scroll of protect armor
+        A +3 ring of stealth
+        A potion of levitation
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (vault 5) (opens vault 3)
+        A scroll of remove curse (vault 3)
+        A scroll of discord (vault 3)
+        A scroll of teleportation (vault 3)
+        A scroll of protect armor (vault 3)
+        A scroll of identify (vault 3)
+        3101 gold pieces (8 piles)
+        A potion of fire immunity (dar battlemage)
+        A scroll of recharging (dragon)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        Some food
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        Some food
+Seed 10:
+    Depth 1:
+        A +0 war axe <19>
+        A scroll of remove curse
+        A potion of invisibility
+        -3 leather armor of vulnerability [0]<10>
+        6 +0 incendiary darts <12>
+        A scroll of summon monsters
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +3 ring of transference (vault 1)
+        A +2 ring of light (vault 1)
+        A +1 ring of awareness (vault 1)
+        A +2 ring of regeneration (vault 1)
+        A potion of incineration
+        257 gold pieces (2 piles)
+    Depth 2:
+        A potion of darkness
+        A potion of paralysis
+        A potion of telepathy
+        A scroll of sanctuary
+        A potion of hallucination
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of healing [3/3] (vault 4)
+        A staff of protection [4/4] (vault 4)
+        A staff of haste [2/2] (vault 1)
+        A +1 ring of reaping (vault 1)
+        A staff of firebolt [3/3] (vault 1)
+        A +0 rapier <15> (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A +2 sword of paralysis <14> (vault 1)
+        A wand of negation [3] (vault 1)
+        A door key (opens vault 1)
+        367 gold pieces (2 piles)
+    Depth 3:
+        A potion of detect magic
+        A scroll of identify
+        A scroll of sanctuary
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        Some food
+        A +2 ring of regeneration (vault 3)
+        A +3 ring of reaping (vault 3)
+        A +2 ring of light (vault 3)
+        A +2 axe of slowing <15>
+        1113 gold pieces (5 piles)
+    Depth 4:
+        A potion of paralysis
+        A +2 negation charm (ready)
+        A scroll of identify
+        A scroll of recharging
+        +0 banded mail [7]<15>
+        A potion of hallucination
+        A potion of detect magic
+        A potion of hallucination
+        A potion of strength
+        A potion of life
+        A staff of conjuration [2/2] (vault 4)
+        A staff of tunneling [2/2] (vault 4)
+        A +3 spear of slowing <13> (vault 1)
+        1903 gold pieces (7 piles)
+        A door key (monkey) (opens vault 1)
+        A shackled pixie
+    Depth 5:
+        A potion of detect magic
+        A potion of darkness
+        A potion of detect magic
+        A scroll of negation
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +3 axe of paralysis <15>
+        2397 gold pieces (7 piles)
+        A scroll of remove curse (dar priestess [reflective])
+        A potion of levitation (dar blademaster)
+        A scroll of discord (dar priestess)
+    Depth 6:
+        +2 plate armor [13]<19>
+        A potion of confusion
+        A potion of hallucination
+        A scroll of discord
+        A scroll of recharging
+        A potion of paralysis
+        A potion of levitation
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A mango
+        A door key (opens vault 6)
+        A door key (opens vault 2)
+        2789 gold pieces (8 piles)
+        A scroll of recharging (dragon)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A mango
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 11:
+    Depth 1:
+        A scroll of protect weapon
+        A potion of incineration
+        A potion of paralysis
+        A scroll of recharging
+        A scroll of identify
+        A potion of darkness
+        A potion of speed
+        A scroll of magic mapping
+        A potion of hallucination
+        A potion of descent
+        A scroll of enchanting
+        A scroll of identify
+        A staff of conjuration [2/2]
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of tunneling [3/3] (vault 1)
+        A +1 invisibility charm (ready) (vault 1)
+        A staff of firebolt [2/2] (vault 1)
+        A +2 whip of force <14> (vault 1)
+        +3 plate armor [14]<19> (vault 1)
+        A +0 war axe <19> (vault 1)
+        A wand of invisibility [3] (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A staff of discord [2/2] (vault 3)
+        A +0 rapier <15> (vault 3)
+        A door key (opens vault 3)
+        95 gold pieces
+    Depth 2:
+        A potion of speed
+        A scroll of sanctuary
+        A scroll of recharging
+        A potion of telepathy
+        A -3 war axe <19>
+        +0 scale mail [4]<12>
+        A scroll of discord
+        A potion of fire immunity
+        A wand of slowness [3]
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A staff of lightning [3/3] (vault 3)
+        A +1 ring of wisdom (vault 3)
+        +0 leather armor [3]<10> (vault 3)
+        +0 banded mail [7]<15> (vault 3)
+        A wand of negation [4] (vault 3)
+        A wand of slowness [2] (vault 3)
+        A scroll of shattering
+        A staff of entrancement [3/3] (vault 1)
+        A staff of discord [3/3] (vault 1)
+        +0 splint mail [9]<17> (vault 1)
+        A wand of polymorphism [2] (vault 1)
+        A wand of plenty [1] (vault 1)
+        A wand of domination [1] (vault 1)
+        353 gold pieces (2 piles)
+    Depth 3:
+        A scroll of identify
+        A potion of darkness
+        A potion of hallucination
+        A potion of incineration
+        A potion of confusion
+        +0 plate armor [11]<19>
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A mango
+        A crystal orb
+        A door key (opens vault 1)
+        A +1 whip of force <14> (vault 1)
+        1204 gold pieces (5 piles)
+        A shackled goblin mystic
+        An allied ifrit
+    Depth 4:
+        A wand of polymorphism [2]
+        A scroll of discord
+        A scroll of identify
+        A -3 spear of mercy <13>
+        A scroll of discord
+        A potion of fire immunity
+        A potion of levitation
+        A potion of strength
+        A potion of life
+        A door key (opens vault 4)
+        A scroll of teleportation
+        A door key (opens vault 1)
+        A scroll of enchanting (vault 1)
+        1688 gold pieces (6 piles)
+        A shackled pixie
+    Depth 5:
+        A potion of detect magic
+        A scroll of summon monsters
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A door key (opens vault 14)
+        A cage key
+        A +2 sword of ogre slaying <14> (vault 9)
+        A scroll of teleportation
+        A door key (opens vault 1)
+        2409 gold pieces (7 piles)
+        A door key (vampire) (opens vault 9)
+        A door key (imp) (opens vault 4)
+        A caged dar battlemage [explosive]
+        A caged ogre
+        A caged ogre [explosive]
+    Depth 6:
+        A potion of caustic gas
+        A scroll of recharging
+        A potion of hallucination
+        -2 chain mail [3]<13>
+        A scroll of remove curse
+        A scroll of negation
+        A potion of invisibility
+        A potion of strength
+        A potion of life
+        Some food
+        3391 gold pieces (9 piles)
+        A scroll of remove curse (dar priestess)
+        A door key (stone guardian) (opens vault 2)
+        A shackled imp
+        A shackled tentacle horror
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        Some food
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 12:
+    Depth 1:
+        A scroll of summon monsters
+        A potion of invisibility
+        A scroll of magic mapping
+        +0 banded mail [7]<15>
+        A scroll of enchanting
+        A scroll of identify
+        A scroll of remove curse
+        A staff of firebolt [2/2]
+        A scroll of remove curse
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +3 ring of awareness (vault 4)
+        A +1 ring of regeneration (vault 4)
+        A +3 ring of stealth (vault 4)
+        A door key (opens vault 4)
+        A staff of blinking [2/2] (vault 1)
+        A staff of conjuration [3/3] (vault 1)
+        A staff of lightning [3/3] (vault 1)
+        A staff of poison [3/3] (vault 1)
+        A staff of obstruction [2/2] (vault 1)
+        A door key (opens vault 1)
+        190 gold pieces (2 piles)
+    Depth 2:
+        A potion of levitation
+        A scroll of negation
+        A potion of descent
+        A scroll of aggravate monsters
+        A scroll of summon monsters
+        A potion of hallucination
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A +2 ring of clairvoyance (vault 1)
+        A staff of blinking [2/2] (vault 1)
+        A +1 war hammer <20> (vault 1)
+        A wand of invisibility [4] (vault 1)
+        A +0 war pike <18> (vault 1)
+        A wand of teleportation [1] (vault 1)
+        A door key (opens vault 1)
+        662 gold pieces (4 piles)
+    Depth 3:
+        A scroll of remove curse
+        A potion of incineration
+        A potion of detect magic
+        A potion of fire immunity
+        A potion of confusion
+        A potion of descent
+        A potion of telepathy
+        A +0 sword <14>
+        A scroll of remove curse
+        A scroll of protect weapon
+        A scroll of enchanting
+        A door key (opens vault 9)
+        A +2 spear of speed <13> (vault 9)
+        A door key (opens vault 6)
+        A scroll of protect weapon (vault 6)
+        A scroll of shattering (vault 6)
+        A scroll of remove curse (vault 6)
+        A scroll of magic mapping (vault 6)
+        A scroll of aggravate monsters (vault 6)
+        A scroll of identify (vault 6)
+        A door key (opens vault 3)
+        A +1 dagger of multiplicity <12> (vault 3)
+        A potion of caustic gas (vault 1)
+        A potion of hallucination (vault 1)
+        A potion of detect magic (vault 1)
+        A potion of descent (vault 1)
+        A potion of incineration (vault 1)
+        A potion of levitation (vault 1)
+        1048 gold pieces (5 piles)
+        A shackled ogre
+        A shackled ogre
+    Depth 4:
+        A potion of caustic gas
+        A +0 war axe <19>
+        A potion of speed
+        A scroll of aggravate monsters
+        A scroll of identify
+        A potion of caustic gas
+        A potion of confusion
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        1872 gold pieces (7 piles)
+        A shackled centaur
+    Depth 5:
+        A scroll of aggravate monsters
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A door key (opens vault 1)
+        A scroll of enchanting (vault 1)
+        2592 gold pieces (8 piles)
+    Depth 6:
+        A scroll of identify
+        A scroll of recharging
+        A potion of telepathy
+        A scroll of teleportation
+        A scroll of remove curse
+        A scroll of remove curse
+        A potion of strength
+        A potion of life
+        A door key (opens vault 5)
+        A door key (opens vault 2)
+        2637 gold pieces (7 piles)
+        A shackled dar priestess
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        Some food
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A mango
+Seed 13:
+    Depth 1:
+        A potion of darkness
+        A scroll of enchanting
+        A scroll of identify
+        A potion of invisibility
+        A potion of invisibility
+        A potion of descent
+        A scroll of summon monsters
+        4 +0 incendiary darts <12>
+        A scroll of sanctuary
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of discord [3/3] (vault 1)
+        A staff of firebolt [3/3] (vault 1)
+        A staff of healing [3/3] (vault 1)
+        A staff of obstruction [3/3] (vault 1)
+        A staff of haste [2/2] (vault 1)
+        A door key (opens vault 1)
+        221 gold pieces (2 piles)
+    Depth 2:
+        -2 leather armor of burden [1]<10>
+        A scroll of enchanting
+        A scroll of magic mapping
+        A potion of detect magic
+        A potion of descent
+        A potion of detect magic
+        A potion of speed
+        A potion of strength
+        A potion of life
+        A potion of telepathy
+        A cage key (vault 7)
+        A staff of conjuration [4/4] (vault 7)
+        +0 banded mail [7]<15> (vault 7)
+        A door key (opens vault 7)
+        A cage key
+        A staff of protection [2/2] (vault 1)
+        A staff of obstruction [4/4] (vault 1)
+        A +1 protection charm (ready) (vault 1)
+        +2 banded mail of dampening [9]<15> (vault 1)
+        A +0 rapier <15> (vault 1)
+        A wand of plenty [1] (vault 1)
+        A wand of slowness [4] (vault 1)
+        A door key (opens vault 1)
+        577 gold pieces (3 piles)
+        A scroll of protect armor (goblin conjurer)
+        A cage key (stone guardian)
+        A scroll of protect weapon (goblin mystic)
+        A caged goblin mystic
+        A caged goblin conjurer
+        A caged goblin mystic
+        A caged monkey
+        A caged monkey
+        A caged goblin mystic
+        A caged goblin mystic
+        A caged goblin
+        A caged goblin mystic
+    Depth 3:
+        A potion of detect magic
+        A scroll of protect armor
+        A potion of speed
+        A scroll of protect armor
+        A potion of caustic gas
+        A potion of incineration
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        A +2 ring of reaping (vault 1)
+        A +2 ring of wisdom (vault 1)
+        A staff of lightning [2/2] (vault 1)
+        A +0 spear <13> (vault 1)
+        A +0 rapier <15> (vault 1)
+        A wand of beckoning [3] (vault 1)
+        A wand of polymorphism [1] (vault 1)
+        1398 gold pieces (7 piles)
+        A door key (stone guardian) (opens vault 1)
+    Depth 4:
+        A wand of polymorphism [2]
+        A scroll of aggravate monsters
+        A potion of hallucination
+        +0 scale mail [4]<12>
+        A potion of descent
+        A potion of creeping death
+        A scroll of identify
+        A potion of invisibility
+        A scroll of recharging
+        A potion of confusion
+        A potion of hallucination
+        Some food
+        A scroll of remove curse
+        A scroll of identify
+        A scroll of protect armor (vault 3)
+        A scroll of sanctuary (vault 3)
+        A scroll of enchanting (vault 3)
+        A potion of speed (vault 1)
+        A potion of incineration (vault 1)
+        A potion of confusion (vault 1)
+        A potion of fire immunity (vault 1)
+        A potion of descent (vault 1)
+        A potion of invisibility (vault 1)
+        2016 gold pieces (8 piles)
+    Depth 5:
+        A potion of telepathy
+        A scroll of identify
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A cage key (vault 2)
+        A +3 ring of stealth (vault 2)
+        A +2 dagger <12> (vault 2)
+        A wand of negation [4] (vault 2)
+        A door key (opens vault 2)
+        2633 gold pieces (9 piles)
+        A potion of levitation (dar blademaster)
+        A scroll of identify (dar battlemage)
+        A shackled troll
+        A caged dar battlemage
+        A caged dar battlemage
+        A caged pixie
+    Depth 6:
+        A +0 whip <14>
+        A potion of caustic gas
+        A potion of fire immunity
+        A scroll of teleportation
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        2593 gold pieces (7 piles)
+        A potion of confusion (dar priestess [explosive])
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        Some food
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 14:
+    Depth 1:
+        A potion of hallucination
+        A potion of caustic gas
+        A scroll of protect weapon
+        A scroll of sanctuary
+        A scroll of protect armor
+        A potion of speed
+        A scroll of enchanting
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +3 ring of regeneration (vault 1)
+        A staff of entrancement [2/2] (vault 1)
+        +0 splint mail [9]<17> (vault 1)
+        A +0 war axe <19> (vault 1)
+        A wand of invisibility [4] (vault 1)
+        A wand of slowness [3] (vault 1)
+        A potion of incineration
+        413 gold pieces (3 piles)
+    Depth 2:
+        A scroll of remove curse
+        A scroll of shattering
+        A scroll of remove curse
+        A potion of descent
+        A potion of incineration
+        A potion of confusion
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A +2 negation charm (ready)
+        A +2 spear of quietus <13> (vault 3)
+        A staff of blinking [2/2] (vault 1)
+        A +2 guardian charm (ready) (vault 1)
+        A +1 negation charm (ready) (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        +0 plate armor [11]<19> (vault 1)
+        A +0 spear <13> (vault 1)
+        A wand of negation [2] (vault 1)
+        367 gold pieces (2 piles)
+        A +2 guardian charm (ready) (monkey)
+    Depth 3:
+        A scroll of teleportation
+        A scroll of identify
+        A potion of telepathy
+        A potion of creeping death
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        A +1 ring of clairvoyance (vault 1)
+        A +3 ring of reaping (vault 1)
+        A +3 ring of wisdom (vault 1)
+        A +2 ring of transference (vault 1)
+        A door key (opens vault 1)
+        1085 gold pieces (5 piles)
+        A shackled ogre
+    Depth 4:
+        A +0 mace <16>
+        A potion of hallucination
+        A potion of detect magic
+        A scroll of remove curse
+        A potion of confusion
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A potion of invisibility (vault 1)
+        A potion of telepathy (vault 1)
+        A potion of darkness (vault 1)
+        A potion of creeping death (vault 1)
+        A potion of descent (vault 1)
+        A potion of fire immunity (vault 1)
+        2064 gold pieces (8 piles)
+        A scroll of remove curse (goblin mystic)
+    Depth 5:
+        A scroll of aggravate monsters
+        A scroll of teleportation
+        A potion of descent
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A door key (opens vault 15)
+        A staff of tunneling [3/3]
+        A staff of firebolt [3/3]
+        A cage key (vault 4)
+        A staff of lightning [3/3] (vault 4)
+        +1 splint mail [10]<17> (vault 4)
+        +0 plate armor [11]<19> (vault 4)
+        A scroll of shattering
+        A scroll of enchanting (vault 1)
+        2133 gold pieces (7 piles)
+        A cage key (stone guardian)
+        A door key (vampire) (opens vault 4)
+        A potion of fire immunity (dar battlemage)
+        A caged pixie
+        A caged dar battlemage
+        A caged ogre
+    Depth 6:
+        A potion of hallucination
+        A scroll of protect armor
+        A scroll of remove curse
+        A scroll of remove curse
+        A potion of incineration
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        A scroll of enchanting (vault 8)
+        A door key (opens vault 5)
+        A door key (opens vault 2)
+        A potion of life (vault 2)
+        3804 gold pieces (10 piles)
+        A scroll of identify (dragon)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        Some food
+Seed 15:
+    Depth 1:
+        A scroll of discord
+        A scroll of teleportation
+        A scroll of remove curse
+        A potion of caustic gas
+        A potion of darkness
+        A potion of descent
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 ring of light (vault 4)
+        A +3 ring of wisdom (vault 4)
+        A +2 ring of awareness (vault 4)
+        A door key (vault 6) (opens vault 4)
+        A +2 ring of regeneration (vault 6)
+        A staff of lightning [2/2] (vault 6)
+        A wand of domination [1] (vault 6)
+        +0 scale mail [4]<12> (vault 6)
+        A +1 ring of clairvoyance (vault 1)
+        A +2 ring of light (vault 1)
+        A +2 ring of reaping (vault 1)
+        A +1 ring of wisdom (vault 1)
+        A potion of creeping death
+        A potion of creeping death
+        A door key (opens vault 1)
+        103 gold pieces
+        A door key (monkey) (opens vault 6)
+    Depth 2:
+        +3 scale mail [7]<12>
+        A scroll of enchanting
+        A potion of creeping death
+        A potion of paralysis
+        A scroll of remove curse
+        A potion of fire immunity
+        A scroll of sanctuary
+        A scroll of magic mapping
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        +0 banded mail [7]<15> (vault 3)
+        A +3 flail <17> (vault 3)
+        A potion of life (vault 3)
+        +2 banded mail of reflection [9]<15>
+        408 gold pieces (2 piles)
+        A scroll of aggravate monsters (goblin conjurer)
+        A scroll of remove curse (goblin conjurer)
+        A scroll of sanctuary (goblin mystic)
+    Depth 3:
+        A potion of paralysis
+        A potion of telepathy
+        6 +0 incendiary darts <12>
+        A potion of detect magic
+        A potion of incineration
+        A scroll of identify
+        A potion of confusion
+        A potion of detect magic
+        A scroll of magic mapping
+        Some food
+        A +1 negation charm (ready) (vault 1)
+        A staff of tunneling [4/4] (vault 1)
+        A +3 mace of quietus <16> (vault 1)
+        +0 plate armor [11]<19> (vault 1)
+        A +0 broadsword <19> (vault 1)
+        A wand of empowerment [1] (vault 1)
+        A door key (opens vault 1)
+        1273 gold pieces (6 piles)
+        A shackled ogre
+        A shackled ogre
+    Depth 4:
+        A staff of lightning [4/4]
+        A potion of confusion
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A crystal orb (vault 7)
+        A staff of conjuration [2/2] (vault 7)
+        A +2 ring of clairvoyance (vault 7)
+        A +1 war hammer <20> (vault 7)
+        A +0 war axe <19> (vault 7)
+        A door key (opens vault 3)
+        A potion of descent (vault 3)
+        A potion of caustic gas (vault 3)
+        A potion of paralysis (vault 3)
+        A potion of confusion (vault 3)
+        A potion of invisibility (vault 3)
+        A scroll of shattering
+        1581 gold pieces (6 piles)
+        An allied phoenix egg
+    Depth 5:
+        A scroll of recharging
+        A scroll of identify
+        A scroll of protect armor
+        A potion of invisibility
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        2343 gold pieces (7 piles)
+        A shackled ogre
+    Depth 6:
+        A scroll of remove curse
+        A scroll of identify
+        A scroll of teleportation
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A mango
+        A potion of life (vault 5)
+        A door key (opens vault 2)
+        2946 gold pieces (8 piles)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        Some food
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 16:
+    Depth 1:
+        A scroll of protect weapon
+        A potion of strength
+        A scroll of aggravate monsters
+        A scroll of identify
+        A potion of detect magic
+        A scroll of enchanting
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 haste charm (ready) (vault 4)
+        A staff of protection [3/3] (vault 4)
+        A +3 invisibility charm (ready) (vault 4)
+        A wand of negation [3] (vault 4)
+        A wand of slowness [3] (vault 4)
+        A wand of domination [1] (vault 4)
+        A wand of polymorphism [2] (vault 4)
+        A door key (opens vault 4)
+        A +1 ring of regeneration (vault 1)
+        A +3 ring of awareness (vault 1)
+        A +3 ring of reaping (vault 1)
+        A door key (opens vault 1)
+        98 gold pieces
+    Depth 2:
+        A potion of telepathy
+        A potion of incineration
+        A potion of speed
+        A scroll of protect weapon
+        A scroll of teleportation
+        A potion of detect magic
+        A scroll of enchanting
+        A -3 broadsword of plenty <19>
+        A potion of darkness
+        A potion of life
+        A +2 guardian charm (ready) (vault 2)
+        A staff of lightning [2/2] (vault 2)
+        A +1 ring of clairvoyance (vault 2)
+        A +1 broadsword <19> (vault 2)
+        A door key (opens vault 2)
+        333 gold pieces (2 piles)
+    Depth 3:
+        A scroll of remove curse
+        A potion of invisibility
+        A potion of descent
+        A potion of fire immunity
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        A staff of blinking [3/3]
+        A staff of lightning [3/3]
+        +2 scale mail of dampening [6]<12>
+        +1 leather armor of multiplicity [4]<10>
+        A staff of lightning [2/2]
+        A staff of tunneling [3/3]
+        A +1 fire immunity charm (ready)
+        A +1 negation charm (ready)
+        A door key (opens vault 1)
+        A scroll of aggravate monsters (vault 1)
+        A scroll of remove curse (vault 1)
+        A scroll of protect weapon (vault 1)
+        A scroll of discord (vault 1)
+        A scroll of identify (vault 1)
+        1667 gold pieces (7 piles)
+        A staff of discord [3/3] (monkey)
+        A staff of poison [2/2] (monkey)
+        A shackled ogre
+    Depth 4:
+        A staff of firebolt [2/2]
+        A scroll of protect weapon
+        A potion of caustic gas
+        A wand of slowness [3]
+        A potion of invisibility
+        Some food
+        A scroll of recharging
+        A +2 ring of reaping
+        A scroll of remove curse
+        A potion of telepathy
+        A +0 dagger <12>
+        A scroll of identify
+        A potion of confusion
+        A potion of incineration
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        2453 gold pieces (9 piles)
+    Depth 5:
+        A scroll of magic mapping
+        A +2 recharging charm (ready)
+        A potion of descent
+        A potion of descent
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        3332 gold pieces (10 piles)
+        A scroll of sanctuary (dar blademaster)
+        A scroll of teleportation (dar blademaster)
+    Depth 6:
+        A scroll of protect armor
+        A scroll of identify
+        +0 banded mail [7]<15>
+        A potion of speed
+        A scroll of identify
+        A potion of levitation
+        A scroll of summon monsters
+        A potion of strength
+        A potion of life
+        2821 gold pieces (7 piles)
+        A scroll of teleportation (dar priestess)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 17:
+    Depth 1:
+        A potion of levitation
+        A potion of fire immunity
+        A potion of strength
+        A potion of confusion
+        A potion of hallucination
+        A +0 sword <14>
+        A +2 health charm (ready)
+        A +2 ring of light
+        A scroll of enchanting
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        139 gold pieces
+        A shackled monkey
+        A shackled ogre
+        A shackled goblin
+    Depth 2:
+        A potion of incineration
+        A scroll of enchanting
+        A potion of confusion
+        A potion of caustic gas
+        A scroll of discord
+        A potion of invisibility
+        A potion of paralysis
+        A potion of speed
+        A potion of telepathy
+        A potion of detect magic
+        A potion of life
+        A cage key (vault 7)
+        A cage key
+        A +3 broadsword <19> (vault 4)
+        +0 splint mail [9]<17> (vault 4)
+        +3 plate armor [14]<19> (vault 4)
+        A scroll of enchanting (vault 4)
+        A scroll of teleportation
+        A door key (opens vault 1)
+        +2 chain mail of reflection [7]<13> (vault 1)
+        576 gold pieces (3 piles)
+        A scroll of discord (goblin mystic)
+        A potion of telepathy (goblin conjurer)
+        A caged goblin conjurer
+        A caged goblin
+        A caged goblin mystic
+    Depth 3:
+        A +1 ring of wisdom
+        +0 plate armor [11]<19>
+        A scroll of shattering
+        A scroll of identify
+        A scroll of aggravate monsters
+        A potion of confusion
+        A potion of descent
+        A mango
+        A door key (opens vault 7)
+        +2 leather armor of absorption [5]<10> (vault 7)
+        A potion of creeping death (vault 4)
+        A potion of invisibility (vault 4)
+        A potion of levitation (vault 4)
+        A potion of confusion (vault 4)
+        A potion of caustic gas (vault 4)
+        A potion of telepathy (vault 4)
+        A +1 ring of stealth (vault 1)
+        A +2 haste charm (ready) (vault 1)
+        A wand of domination [1] (vault 1)
+        +0 plate armor [11]<19> (vault 1)
+        A +0 mace <16> (vault 1)
+        A wand of slowness [3] (vault 1)
+        A door key (opens vault 1)
+        1068 gold pieces (5 piles)
+        A +1 ring of light (goblin conjurer)
+        A door key (vampire) (opens vault 4)
+    Depth 4:
+        A scroll of sanctuary
+        A potion of fire immunity
+        A +0 war hammer <20>
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A potion of speed (vault 7)
+        A potion of invisibility (vault 7)
+        A potion of descent (vault 7)
+        A potion of caustic gas (vault 7)
+        A potion of telepathy (vault 7)
+        A potion of detect magic (vault 7)
+        A door key (vault 4) (opens vault 1)
+        A +1 guardian charm (ready) (vault 4)
+        A +1 recharging charm (ready) (vault 4)
+        A +0 war pike <18> (vault 4)
+        +0 plate armor [11]<19> (vault 4)
+        A potion of fire immunity
+        A door key (opens vault 4)
+        1654 gold pieces (6 piles)
+        A shackled naga
+    Depth 5:
+        A wand of polymorphism [1]
+        A potion of creeping death
+        A potion of telepathy
+        A potion of invisibility
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        2810 gold pieces (9 piles)
+        A potion of invisibility (dar battlemage)
+        A -3 spear <13> (dar blademaster)
+    Depth 6:
+        A scroll of discord
+        A potion of paralysis
+        A scroll of identify
+        A scroll of shattering
+        A potion of confusion
+        A potion of telepathy
+        A scroll of teleportation
+        A potion of detect magic
+        A scroll of aggravate monsters
+        A potion of levitation
+        A potion of levitation
+        3303 gold pieces (9 piles)
+        A potion of incineration (dragon)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A mango
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        Some food
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 18:
+    Depth 1:
+        A potion of fire immunity
+        A potion of invisibility
+        A potion of fire immunity
+        A scroll of identify
+        A scroll of protect armor
+        A potion of incineration
+        A scroll of enchanting
+        A potion of descent
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of tunneling [3/3] (vault 4)
+        A staff of blinking [4/4] (vault 4)
+        A staff of conjuration [3/3] (vault 4)
+        A staff of healing [3/3] (vault 4)
+        A +2 ring of stealth (vault 1)
+        A staff of blinking [3/3] (vault 1)
+        A +0 rapier <15> (vault 1)
+        A +0 axe <15> (vault 1)
+        +1 chain mail of absorption [6]<13> (vault 1)
+        A wand of slowness [3] (vault 1)
+        A potion of levitation
+        A door key (opens vault 1)
+        157 gold pieces
+    Depth 2:
+        A potion of invisibility
+        A scroll of shattering
+        A potion of incineration
+        A potion of incineration
+        A potion of invisibility
+        A potion of confusion
+        A potion of levitation
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A +2 ring of light (vault 1)
+        A staff of entrancement [3/3] (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        A +0 flail <17> (vault 1)
+        A wand of invisibility [2] (vault 1)
+        A wand of slowness [4] (vault 1)
+        712 gold pieces (4 piles)
+        A scroll of summon monsters (goblin conjurer)
+        A door key (monkey) (opens vault 1)
+    Depth 3:
+        A scroll of aggravate monsters
+        A potion of fire immunity
+        A potion of caustic gas
+        A scroll of magic mapping
+        A potion of hallucination
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A mango
+        A +1 sword of speed <14>
+        A +2 spear of troll slaying <13>
+        A scroll of sanctuary (vault 8)
+        A scroll of teleportation (vault 8)
+        A scroll of identify (vault 8)
+        A scroll of protect armor (vault 8)
+        A scroll of discord (vault 8)
+        A door key (vault 7) (opens vault 5)
+        A +2 spear of fireborne slaying <13> (vault 5)
+        A +0 mace <16> (vault 4)
+        A +0 spear <13> (vault 4)
+        A +0 axe <15> (vault 4)
+        A potion of life (vault 4)
+        A +2 negation charm (ready) (vault 1)
+        A +1 ring of clairvoyance (vault 1)
+        A wand of beckoning [2] (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        A wand of slowness [2] (vault 1)
+        A door key (opens vault 1)
+        1162 gold pieces (5 piles)
+        A potion of invisibility (goblin mystic)
+    Depth 4:
+        A potion of telepathy
+        A +2 ring of reaping
+        A scroll of protect weapon
+        A potion of detect magic
+        A scroll of recharging
+        A potion of speed
+        A potion of strength
+        A potion of life
+        1821 gold pieces (7 piles)
+        A shackled ogre
+    Depth 5:
+        A potion of invisibility
+        A potion of telepathy
+        A +2 haste charm (ready)
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        2639 gold pieces (8 piles)
+        A scroll of negation (dar blademaster)
+        A scroll of negation (dragon)
+    Depth 6:
+        A staff of firebolt [2/2]
+        A potion of creeping death
+        A scroll of protect weapon
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        Some food
+        A crystal orb
+        2611 gold pieces (7 piles)
+        A +2 ring of wisdom (dragon)
+        A potion of confusion (dragon)
+        A shackled dar battlemage
+        A shackled dragon
+        A shackled golem
+        An allied ifrit
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A mango
+Seed 19:
+    Depth 1:
+        A scroll of magic mapping
+        A potion of descent
+        A wand of empowerment [1]
+        A potion of caustic gas
+        A potion of fire immunity
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of firebolt [3/3] (vault 1)
+        A staff of healing [2/2] (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A +0 whip <14> (vault 1)
+        +0 splint mail [9]<17> (vault 1)
+        A wand of beckoning [2] (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A +1 ring of reaping (vault 3)
+        A wand of polymorphism [1] (vault 3)
+        A +0 war hammer <20> (vault 3)
+        239 gold pieces (2 piles)
+        A shackled ogre
+    Depth 2:
+        A potion of fire immunity
+        A scroll of enchanting
+        A potion of caustic gas
+        +0 banded mail [7]<15>
+        A potion of fire immunity
+        A scroll of teleportation
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        8 +0 javelins <15> (vault 5)
+        A +0 flail <17> (vault 5)
+        A potion of life (vault 5)
+        +0 chain mail [5]<13> (vault 4)
+        A +0 war pike <18> (vault 4)
+        A potion of life (vault 4)
+        A +1 ring of awareness (vault 1)
+        A +2 ring of reaping (vault 1)
+        A +2 ring of clairvoyance (vault 1)
+        A +3 ring of wisdom (vault 1)
+        493 gold pieces (3 piles)
+        A potion of detect magic (goblin mystic)
+        A scroll of identify (goblin mystic)
+        A potion of hallucination (goblin warlord)
+        A door key (stone guardian) (opens vault 1)
+    Depth 3:
+        A potion of telepathy
+        A +1 protection charm (ready)
+        A scroll of sanctuary
+        +0 chain mail [5]<13>
+        A scroll of identify
+        A scroll of recharging
+        A potion of hallucination
+        A scroll of magic mapping
+        1066 gold pieces (5 piles)
+        A potion of creeping death (goblin conjurer)
+        A shackled ogre
+        A shackled goblin mystic
+        A shackled dar priestess
+    Depth 4:
+        A scroll of magic mapping
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A mango
+        A door key (opens vault 4)
+        A scroll of enchanting (vault 4)
+        A +2 ring of reaping (vault 1)
+        A +1 ring of stealth (vault 1)
+        A +1 ring of awareness (vault 1)
+        A door key (opens vault 1)
+        1896 gold pieces (7 piles)
+        A scroll of shattering (goblin conjurer)
+        A wand of teleportation [2] (goblin conjurer)
+    Depth 5:
+        A scroll of protect armor
+        A scroll of recharging
+        +0 leather armor [3]<10>
+        A scroll of protect armor
+        A scroll of sanctuary
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (vault 3) (opens vault 1)
+        2753 gold pieces (9 piles)
+    Depth 6:
+        A scroll of remove curse
+        A potion of creeping death
+        A -3 ring of stealth
+        A potion of telepathy
+        A scroll of protect armor
+        A scroll of magic mapping
+        A potion of incineration
+        A scroll of sanctuary
+        A door key (opens vault 2)
+        2716 gold pieces (7 piles)
+        A potion of telepathy (dragon)
+        A scroll of protect weapon (dragon)
+        A potion of confusion (dar blademaster)
+        A potion of confusion (dar blademaster)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        Some food
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A mango
+Seed 20:
+    Depth 1:
+        A potion of levitation
+        A scroll of enchanting
+        A potion of hallucination
+        A scroll of recharging
+        A potion of levitation
+        A potion of darkness
+        A potion of darkness
+        A potion of caustic gas
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +3 ring of regeneration (vault 4)
+        A +2 health charm (ready) (vault 4)
+        A +1 spear of slowing <13> (vault 4)
+        A +0 mace <16> (vault 4)
+        +0 scale mail [4]<12> (vault 4)
+        A wand of invisibility [4] (vault 4)
+        A door key (opens vault 4)
+        A +1 ring of light (vault 1)
+        A staff of blinking [2/2] (vault 1)
+        A +0 broadsword <19> (vault 1)
+        A +0 rapier <15> (vault 1)
+        +0 scale mail [4]<12> (vault 1)
+        A wand of beckoning [4] (vault 1)
+        A door key (opens vault 1)
+        411 gold pieces (3 piles)
+        A shackled goblin
+        A shackled monkey
+    Depth 2:
+        A scroll of identify
+        A scroll of enchanting
+        A scroll of identify
+        A scroll of sanctuary
+        A potion of levitation
+        +2 splint mail [11]<17>
+        A potion of confusion
+        A potion of descent
+        A potion of creeping death
+        A potion of confusion
+        A scroll of protect armor
+        A +1 ring of regeneration
+        A potion of paralysis
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A staff of firebolt [3/3] (vault 1)
+        A staff of blinking [3/3] (vault 1)
+        A staff of healing [3/3] (vault 1)
+        A staff of lightning [3/3] (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A staff of discord [3/3] (vault 3)
+        A +3 mace <16> (vault 3)
+        A door key (opens vault 3)
+        504 gold pieces (3 piles)
+    Depth 3:
+        A scroll of shattering
+        A scroll of teleportation
+        A potion of detect magic
+        A potion of invisibility
+        A scroll of magic mapping
+        +0 plate armor [11]<19>
+        A scroll of shattering
+        A potion of strength
+        A potion of life
+        A mango
+        A scroll of shattering
+        A +3 dagger of quietus <12> (vault 2)
+        A +0 war pike <18> (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        +2 plate armor [13]<19> (vault 1)
+        A scroll of enchanting (vault 1)
+        1352 gold pieces (6 piles)
+    Depth 4:
+        A potion of telepathy
+        A scroll of identify
+        A potion of caustic gas
+        A scroll of recharging
+        A potion of creeping death
+        A scroll of protect armor
+        A wand of invisibility [3]
+        A scroll of summon monsters
+        A scroll of recharging
+        A potion of levitation
+        A scroll of identify
+        A scroll of enchanting
+        A door key (opens vault 4)
+        A door key (opens vault 1)
+        2056 gold pieces (7 piles)
+    Depth 5:
+        +0 splint mail [9]<17>
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        2557 gold pieces (8 piles)
+        A scroll of shattering (goblin conjurer)
+        A shackled troll
+        A shackled golem [toxic]
+    Depth 6:
+        A scroll of summon monsters
+        A -2 ring of regeneration
+        A scroll of identify
+        A scroll of recharging
+        A scroll of aggravate monsters
+        A potion of strength
+        A potion of life
+        Some food
+        A cage key
+        A door key (opens vault 2)
+        A potion of telepathy (vault 2)
+        A potion of confusion (vault 2)
+        A potion of caustic gas (vault 2)
+        A potion of speed (vault 2)
+        A potion of fire immunity (vault 2)
+        A potion of levitation (vault 2)
+        A potion of detect magic (vault 2)
+        3806 gold pieces (10 piles)
+        A caged imp
+        A caged dar priestess
+        A caged naga
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A mango
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 21:
+    Depth 1:
+        A +0 sword <14>
+        A scroll of recharging
+        A potion of caustic gas
+        A potion of strength
+        A wand of polymorphism [2]
+        A potion of caustic gas
+        A potion of detect magic
+        A -2 dagger of mercy <12>
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of tunneling [2/2] (vault 1)
+        A staff of firebolt [3/3] (vault 1)
+        A staff of discord [2/2] (vault 1)
+        A staff of lightning [3/3] (vault 1)
+        A potion of levitation
+        A door key (opens vault 1)
+        390 gold pieces (3 piles)
+        A shackled monkey
+    Depth 2:
+        A scroll of summon monsters
+        A potion of telepathy
+        A scroll of remove curse
+        A potion of darkness
+        A scroll of remove curse
+        A scroll of identify
+        A scroll of identify
+        A scroll of recharging
+        A potion of speed
+        A potion of life
+        A scroll of enchanting
+        A +2 whip of confusion <14> (vault 2)
+        531 gold pieces (3 piles)
+        A door key (black jelly) (opens vault 2)
+        A shackled ogre
+        A shackled goblin mystic
+    Depth 3:
+        A potion of darkness
+        A scroll of recharging
+        A scroll of identify
+        A scroll of magic mapping
+        A potion of speed
+        A potion of caustic gas
+        A scroll of shattering
+        A scroll of enchanting
+        Some food
+        A door key (opens vault 9)
+        +3 leather armor of mutuality [6]<10> (vault 9)
+        A door key (opens vault 6)
+        A +2 spear of quietus <13> (vault 6)
+        A staff of blinking [3/3] (vault 3)
+        A staff of obstruction [3/3] (vault 3)
+        A staff of conjuration [3/3] (vault 3)
+        A staff of poison [3/3] (vault 3)
+        A staff of lightning [2/2] (vault 3)
+        A potion of levitation
+        A door key (opens vault 3)
+        1364 gold pieces (6 piles)
+        A cage key (stone guardian)
+        A shackled goblin mystic
+        A caged salamander
+        A caged goblin
+        A caged salamander
+    Depth 4:
+        A scroll of shattering
+        A scroll of remove curse
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        1833 gold pieces (7 piles)
+        A potion of darkness (goblin conjurer)
+        A shackled troll
+    Depth 5:
+        A scroll of protect weapon
+        +3 splint mail [12]<17>
+        A wand of empowerment [1]
+        A scroll of shattering
+        A scroll of aggravate monsters
+        A potion of invisibility
+        A wand of beckoning [2]
+        A potion of paralysis
+        A door key (vault 3) (opens vault 1)
+        A staff of firebolt [3/3] (vault 3)
+        A +2 health charm (ready) (vault 3)
+        A +0 dagger <12> (vault 3)
+        A +0 axe <15> (vault 3)
+        A door key (opens vault 3)
+        A potion of paralysis (vault 1)
+        A potion of fire immunity (vault 1)
+        A potion of caustic gas (vault 1)
+        A potion of telepathy (vault 1)
+        A potion of descent (vault 1)
+        A potion of darkness (vault 1)
+        2417 gold pieces (8 piles)
+        A shackled dar priestess
+    Depth 6:
+        A potion of paralysis
+        A potion of invisibility
+        A scroll of identify
+        A +0 war hammer <20>
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (opens vault 2)
+        A potion of levitation (vault 2)
+        A potion of darkness (vault 2)
+        A potion of telepathy (vault 2)
+        A potion of detect magic (vault 2)
+        A potion of invisibility (vault 2)
+        3056 gold pieces (8 piles)
+        A scroll of identify (dar priestess)
+        A shackled golem
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A mango
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A mango
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 22:
+    Depth 1:
+        A potion of detect magic
+        A scroll of aggravate monsters
+        A potion of confusion
+        A scroll of enchanting
+        A potion of strength
+        A scroll of recharging
+        A potion of caustic gas
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of poison [4/4] (vault 3)
+        A staff of conjuration [2/2] (vault 3)
+        A staff of obstruction [2/2] (vault 3)
+        A staff of healing [2/2] (vault 3)
+        A staff of tunneling [2/2] (vault 3)
+        A door key (opens vault 3)
+        A +3 ring of clairvoyance (vault 1)
+        A +1 ring of wisdom (vault 1)
+        A +3 ring of reaping (vault 1)
+        204 gold pieces (2 piles)
+        A shackled goblin
+    Depth 2:
+        A scroll of remove curse
+        A potion of telepathy
+        A wand of invisibility [2]
+        A wand of teleportation [1]
+        A scroll of remove curse
+        A +0 broadsword <19>
+        A +0 flail <17>
+        A potion of descent
+        A potion of life
+        A +1 recharging charm (ready) (vault 1)
+        A staff of healing [2/2] (vault 1)
+        A staff of blinking [2/2] (vault 1)
+        +3 scale mail [7]<12> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        +0 chain mail [5]<13> (vault 1)
+        A wand of domination [2] (vault 1)
+        A door key (opens vault 1)
+        537 gold pieces (3 piles)
+    Depth 3:
+        A scroll of teleportation
+        A +1 ring of light
+        A potion of darkness
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A mango
+        A +1 ring of awareness (vault 3)
+        A +3 ring of transference (vault 3)
+        A +2 ring of light (vault 3)
+        A door key (opens vault 3)
+        A +2 ring of regeneration (vault 1)
+        A +3 ring of wisdom (vault 1)
+        A +1 ring of light (vault 1)
+        A +3 ring of awareness (vault 1)
+        1308 gold pieces (6 piles)
+    Depth 4:
+        A scroll of recharging
+        A potion of caustic gas
+        A potion of hallucination
+        A scroll of remove curse
+        A potion of telepathy
+        A potion of speed
+        A potion of detect magic
+        A scroll of enchanting
+        1913 gold pieces (7 piles)
+        A potion of levitation (dar blademaster)
+        A shackled golem
+        A shackled dar blademaster
+    Depth 5:
+        A potion of speed
+        A potion of fire immunity
+        A scroll of aggravate monsters
+        A potion of levitation
+        A scroll of protect armor
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A potion of detect magic
+        A +2 health charm (ready)
+        A +2 guardian charm (ready)
+        A door key (opens vault 1)
+        2774 gold pieces (8 piles)
+        A scroll of aggravate monsters (goblin mystic)
+    Depth 6:
+        A potion of hallucination
+        +0 chain mail [5]<13>
+        A scroll of protect armor
+        A potion of telepathy
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A door key (vault 4) (opens vault 2)
+        A +1 teleportation charm (ready) (vault 4)
+        A staff of firebolt [3/3] (vault 4)
+        A wand of negation [3] (vault 4)
+        A +2 axe <15> (vault 4)
+        A scroll of teleportation
+        A door key (opens vault 4)
+        4242 gold pieces (11 piles)
+        A potion of caustic gas (dragon)
+        +0 splint mail [9]<17> (dar blademaster)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A mango
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        Some food
+Seed 23:
+    Depth 1:
+        A potion of confusion
+        A scroll of protect weapon
+        A potion of creeping death
+        A potion of telepathy
+        A scroll of identify
+        A potion of confusion
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +2 ring of transference (vault 6)
+        A +2 ring of awareness (vault 6)
+        A +4 ring of clairvoyance (vault 6)
+        A scroll of shattering
+        A staff of blinking [2/2] (vault 1)
+        A staff of poison [2/2] (vault 1)
+        A wand of domination [1] (vault 1)
+        A +0 mace <16> (vault 1)
+        +0 banded mail [7]<15> (vault 1)
+        A wand of invisibility [3] (vault 1)
+        A door key (vault 3) (opens vault 1)
+        A +2 ring of awareness (vault 3)
+        A +0 spear <13> (vault 3)
+        A +0 broadsword <19> (vault 3)
+        A door key (opens vault 3)
+        445 gold pieces (3 piles)
+        A potion of incineration (goblin conjurer)
+    Depth 2:
+        A scroll of sanctuary
+        A +3 ring of clairvoyance
+        A scroll of aggravate monsters
+        A potion of invisibility
+        A potion of levitation
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A cage key (vault 4)
+        A +1 negation charm (ready) (vault 4)
+        A staff of firebolt [2/2] (vault 4)
+        +1 splint mail [10]<17> (vault 4)
+        A door key (opens vault 4)
+        A cage key (vault 2)
+        A +3 ring of transference (vault 2)
+        A staff of tunneling [2/2] (vault 2)
+        A +0 flail <17> (vault 2)
+        444 gold pieces (3 piles)
+        A caged goblin
+        A caged goblin conjurer
+        A caged monkey
+        A caged goblin
+    Depth 3:
+        +0 banded mail [7]<15>
+        A +0 flail <17>
+        A potion of creeping death
+        A potion of levitation
+        A scroll of aggravate monsters
+        A potion of detect magic
+        A potion of telepathy
+        A scroll of enchanting
+        Some food
+        A staff of poison [2/2] (vault 3)
+        A +1 ring of awareness (vault 3)
+        A staff of lightning [2/2] (vault 3)
+        +0 leather armor [3]<10> (vault 3)
+        +0 plate armor [11]<19> (vault 3)
+        A +0 war hammer <20> (vault 3)
+        A wand of plenty [1] (vault 3)
+        A scroll of identify (vault 1)
+        A scroll of teleportation (vault 1)
+        A scroll of negation (vault 1)
+        A scroll of magic mapping (vault 1)
+        1090 gold pieces (5 piles)
+    Depth 4:
+        A scroll of shattering
+        A potion of invisibility
+        A potion of telepathy
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A staff of tunneling [3/3]
+        A staff of lightning [2/2]
+        A crystal orb (vault 2)
+        A +3 ring of light (vault 2)
+        A +1 guardian charm (ready) (vault 2)
+        A +0 war axe <19> (vault 2)
+        A door key (opens vault 2)
+        1644 gold pieces (6 piles)
+        A potion of confusion (dragon)
+        A door key (monkey) (opens vault 5)
+        An allied ifrit
+    Depth 5:
+        A scroll of identify
+        A scroll of negation
+        A potion of hallucination
+        A scroll of remove curse
+        A scroll of remove curse
+        A +0 dagger <12>
+        A scroll of sanctuary
+        A scroll of remove curse
+        A potion of detect magic
+        A door key (vault 5) (opens vault 3)
+        A +2 ring of stealth (vault 5)
+        +3 chain mail of reprisal [8]<13> (vault 5)
+        A wand of plenty [1] (vault 5)
+        A door key (opens vault 5)
+        3133 gold pieces (10 piles)
+        A shackled ogre
+    Depth 6:
+        A scroll of aggravate monsters
+        A scroll of aggravate monsters
+        A scroll of magic mapping
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        3628 gold pieces (9 piles)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        Some food
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        Some food
+Seed 24:
+    Depth 1:
+        A potion of telepathy
+        A scroll of aggravate monsters
+        A scroll of identify
+        A potion of telepathy
+        A potion of confusion
+        A scroll of aggravate monsters
+        A potion of detect magic
+        A potion of speed
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of poison [2/2] (vault 1)
+        A staff of haste [2/2] (vault 1)
+        A staff of tunneling [3/3] (vault 1)
+        A staff of firebolt [3/3] (vault 1)
+        A staff of conjuration [3/3] (vault 1)
+        A door key (opens vault 1)
+        269 gold pieces (2 piles)
+        A shackled monkey
+    Depth 2:
+        A potion of hallucination
+        A potion of hallucination
+        A potion of incineration
+        A +2 mace of paralysis <16>
+        A potion of speed
+        A scroll of enchanting
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of shattering
+        +2 leather armor of dampening [5]<10> (vault 1)
+        573 gold pieces (3 piles)
+        A shackled ogre
+        A shackled goblin mystic
+    Depth 3:
+        A scroll of identify
+        A scroll of aggravate monsters
+        A potion of descent
+        A scroll of sanctuary
+        A potion of creeping death
+        A scroll of identify
+        A potion of detect magic
+        A scroll of identify
+        A potion of strength
+        A potion of life
+        A mango
+        A staff of firebolt [3/3] (vault 2)
+        A staff of blinking [2/2] (vault 2)
+        A staff of discord [2/2] (vault 2)
+        A staff of tunneling [2/2] (vault 2)
+        A staff of conjuration [2/2] (vault 2)
+        A door key (opens vault 2)
+        1208 gold pieces (5 piles)
+        A scroll of identify (dar blademaster)
+        A shackled goblin mystic
+        A shackled dar blademaster
+    Depth 4:
+        A +3 fire immunity charm (ready)
+        A potion of incineration
+        A potion of hallucination
+        A scroll of protect weapon
+        A potion of darkness
+        A potion of telepathy
+        A potion of incineration
+        A scroll of summon monsters
+        A potion of confusion
+        A potion of detect magic
+        A scroll of enchanting
+        A +3 ring of wisdom (vault 1)
+        A +3 ring of regeneration (vault 1)
+        A +0 flail <17> (vault 1)
+        +0 leather armor [3]<10> (vault 1)
+        A wand of beckoning [4] (vault 1)
+        A wand of teleportation [1] (vault 1)
+        2187 gold pieces (8 piles)
+        A door key (flamedancer) (opens vault 1)
+    Depth 5:
+        A potion of descent
+        A +0 flail <17>
+        A potion of telepathy
+        A scroll of summon monsters
+        A scroll of shattering
+        A potion of strength
+        A potion of strength
+        A potion of life
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A door key (opens vault 3)
+        2249 gold pieces (7 piles)
+        A cage key (vampire [reflective])
+        A caged dar battlemage
+        A caged dar blademaster
+        A shackled dar priestess
+    Depth 6:
+        A potion of darkness
+        A scroll of identify
+        A scroll of teleportation
+        A potion of levitation
+        A potion of strength
+        A potion of life
+        Some food
+        A crystal orb
+        3526 gold pieces (9 piles)
+        An allied ifrit
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        Some food
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+Seed 25:
+    Depth 1:
+        A potion of levitation
+        A scroll of aggravate monsters
+        A scroll of aggravate monsters
+        A scroll of shattering
+        A scroll of sanctuary
+        A potion of incineration
+        A potion of telepathy
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A staff of firebolt [2/2] (vault 4)
+        A +3 ring of regeneration (vault 4)
+        A staff of tunneling [2/2] (vault 4)
+        A +0 broadsword <19> (vault 4)
+        A +0 flail <17> (vault 4)
+        A +0 axe <15> (vault 4)
+        A wand of slowness [2] (vault 4)
+        A staff of poison [4/4] (vault 1)
+        A staff of firebolt [4/4] (vault 1)
+        A +2 ring of stealth (vault 1)
+        A +0 war pike <18> (vault 1)
+        +1 banded mail [8]<15> (vault 1)
+        A +0 war hammer <20> (vault 1)
+        A wand of slowness [4] (vault 1)
+        A door key (opens vault 1)
+        291 gold pieces (2 piles)
+        A door key (monkey) (opens vault 4)
+    Depth 2:
+        A scroll of identify
+        A potion of descent
+        A scroll of shattering
+        A +2 fire immunity charm (ready)
+        A scroll of discord
+        A potion of detect magic
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A +1 rapier of paralysis <15>
+        A potion of levitation
+        A staff of conjuration [3/3]
+        A staff of blinking [5/5]
+        A +3 ring of light (vault 1)
+        A +1 ring of reaping (vault 1)
+        A +2 ring of clairvoyance (vault 1)
+        A wand of invisibility [3] (vault 1)
+        A +0 spear <13> (vault 1)
+        A wand of beckoning [4] (vault 1)
+        A wand of plenty [1] (vault 1)
+        A door key (opens vault 1)
+        705 gold pieces (4 piles)
+    Depth 3:
+        A potion of hallucination
+        A potion of detect magic
+        A potion of darkness
+        A scroll of protect armor
+        A scroll of shattering
+        A scroll of discord
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        Some food
+        A potion of incineration (vault 1)
+        A potion of confusion (vault 1)
+        A potion of caustic gas (vault 1)
+        A potion of levitation (vault 1)
+        A potion of creeping death (vault 1)
+        A potion of descent (vault 1)
+        1407 gold pieces (6 piles)
+    Depth 4:
+        A scroll of teleportation
+        A potion of fire immunity
+        A scroll of sanctuary
+        8 +0 javelins <15>
+        A potion of telepathy
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        A scroll of enchanting
+        A +1 spear of paralysis <13> (vault 1)
+        2206 gold pieces (8 piles)
+    Depth 5:
+        A scroll of sanctuary
+        A scroll of negation
+        A potion of detect magic
+        A potion of speed
+        A potion of speed
+        A potion of strength
+        A potion of life
+        A scroll of enchanting
+        2901 gold pieces (8 piles)
+        A scroll of teleportation (dar priestess)
+        A shackled dar blademaster
+        A shackled dar blademaster
+        A shackled golem
+        A shackled tentacle horror
+        A shackled golem
+        A shackled dar priestess
+    Depth 6:
+        A potion of caustic gas
+        A scroll of sanctuary
+        A scroll of teleportation
+        A potion of fire immunity
+        +0 banded mail [7]<15>
+        A potion of incineration
+        A scroll of identify
+        3785 gold pieces (10 piles)
+        A potion of hallucination (dragon)
+    Depth 7:
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A lumenstone from depth 7
+        A mango
+    Depth 8:
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+        A lumenstone from depth 8
+    Depth 9:
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+        A lumenstone from depth 9
+    Depth 10:
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        A lumenstone from depth 10
+        Some food

--- a/test/update_seed_catalogs.py
+++ b/test/update_seed_catalogs.py
@@ -1,0 +1,33 @@
+import subprocess
+import argparse
+import sys
+
+def create_brogue_seed_catalog_file(output_seed_catalog_file, extra_args, max_level):
+
+    seed_catalog_cmd_args = f'--print-seed-catalog 1 25 {max_level}'
+
+    # Generate the first 25 seeds
+    if extra_args:
+        brogue_command = f'./bin/brogue {extra_args} {seed_catalog_cmd_args} > {output_seed_catalog_file}'
+    else:
+        brogue_command = f'./bin/brogue {seed_catalog_cmd_args} > {output_seed_catalog_file}'
+    print(f"Running {brogue_command}...")
+    brogue_result = subprocess.run(brogue_command, shell=True, capture_output=True, text=True)
+
+    if brogue_result.returncode:
+        print("Seed catalog generation failed. Output:")
+        print(brogue_result.stdout)
+        sys.exit(1)
+
+    print("Seed catalog creation complete.")
+
+def main():
+    parser = argparse.ArgumentParser(description='Brogue Seed Catalog Updater for Brogue Seed Compare Test Runner. Run this script to update the seed catalog files used by the Brogue Seed Compare Test Runner. This should be done after a change to the Brogue source code that changes the dungeon generation. Assumes brogue compiled binary available in ./bin/brogue')
+    parser.parse_args()
+
+    # Create the seed catalog files used in the compare test runner
+    create_brogue_seed_catalog_file('test/seed_catalogs/seed_catalog_brogue.txt', None, 40)
+    create_brogue_seed_catalog_file('test/seed_catalogs/seed_catalog_rapid_brogue.txt', "--variant rapid_brogue", 10)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds a new github action to check the output of seed catalog for each variant and fails if it has changed.
This will detect any unintentional changes to dungeon generation.
If any changes have expected dungeon generation changes, the commits also need to update `test/seed_catalogs`.
This test could apply to `master` but requires the seed catalog crash fix which is only currently in `release`.