### PR TITLE
Use a dialog window when saving a game or recording

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -2739,15 +2739,22 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
 boolean getInputTextString(char *inputText,
                            const char *prompt,
                            short maxLength,
-                           const char *defaultEntry,
+                           char *defaultEntry,
                            const char *promptSuffix,
                            short textEntryType,
                            boolean useDialogBox) {
-    short charNum, i, x, y;
+    short charNum, i, x, y, promptSuffixLen, defaultEntrylengthOverflow;
     char keystroke, suffix[100];
     const short textEntryBounds[TEXT_INPUT_TYPES][2] = {{' ', '~'}, {' ', '~'}, {'0', '9'}};
     screenDisplayBuffer dbuf;
     screenDisplayBuffer rbuf;
+
+    // handle defaultEntry values exceeding maxLength
+    promptSuffixLen = strlen(promptSuffix);
+    defaultEntrylengthOverflow = strlen(defaultEntry) + promptSuffixLen - maxLength;
+    if(defaultEntrylengthOverflow > 0) {
+        defaultEntry[strlen(defaultEntry) - defaultEntrylengthOverflow] = '\0';
+    }
 
     // x and y mark the origin for text entry.
     if (useDialogBox) {
@@ -2807,8 +2814,8 @@ boolean getInputTextString(char *inputText,
 
             inputText[charNum] = keystroke;
             plotCharWithColor(keystroke, (windowpos){ x + charNum, y }, &white, &black);
-            printString(suffix, charNum + x + 1, y, &gray, &black, 0);
-            if (charNum < maxLength) {
+            if (charNum < maxLength - promptSuffixLen) {
+                printString(suffix, charNum + x + 1, y, &gray, &black, 0);
                 charNum++;
             }
         }

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1199,6 +1199,7 @@ void saveGameNoPrompt() {
     rogue.gameExitStatusCode = EXIT_STATUS_SUCCESS;
     rogue.recording = false;
 }
+#define MAX_TEXT_INPUT_FILENAME_LENGTH (COLS - 12) // max length including the suffix
 
 void saveGame() {
     char filePathWithoutSuffix[BROGUE_FILENAME_MAX - sizeof(GAME_SUFFIX)], filePath[BROGUE_FILENAME_MAX], defaultPath[BROGUE_FILENAME_MAX];
@@ -1212,11 +1213,10 @@ void saveGame() {
     getAvailableFilePath(filePathWithoutSuffix, defaultPath, GAME_SUFFIX);
     filePath[0] = '\0';
 
-    deleteMessages();
     do {
         askAgain = false;
         if (getInputTextString(filePathWithoutSuffix, "Save game as (<esc> to cancel): ",
-                               BROGUE_FILENAME_MAX - strlen(GAME_SUFFIX), filePathWithoutSuffix, GAME_SUFFIX, TEXT_INPUT_FILENAME, false)) {
+                               MAX_TEXT_INPUT_FILENAME_LENGTH, filePathWithoutSuffix, GAME_SUFFIX, TEXT_INPUT_FILENAME, true)) {
             snprintf(filePath, BROGUE_FILENAME_MAX, "%s%s", filePathWithoutSuffix, GAME_SUFFIX);
             if (!fileExists(filePath) || confirm("File of that name already exists. Overwrite?", true)) {
                 remove(filePath);
@@ -1232,7 +1232,6 @@ void saveGame() {
             }
         }
     } while (askAgain);
-    displayRecentMessages();
 }
 
 void saveRecordingNoPrompt(char *filePath) {
@@ -1260,11 +1259,10 @@ void saveRecording(char *filePathWithoutSuffix) {
     getAvailableFilePath(filePathWithoutSuffix, defaultPath, RECORDING_SUFFIX);
     filePath[0] = '\0';
 
-    deleteMessages();
     do {
         askAgain = false;
         if (getInputTextString(filePathWithoutSuffix, "Save recording as (<esc> to cancel): ",
-                               BROGUE_FILENAME_MAX - strlen(RECORDING_SUFFIX), filePathWithoutSuffix, RECORDING_SUFFIX, TEXT_INPUT_FILENAME, false)) {
+                               MAX_TEXT_INPUT_FILENAME_LENGTH, filePathWithoutSuffix, RECORDING_SUFFIX, TEXT_INPUT_FILENAME, true)) {
 
             snprintf(filePath, BROGUE_FILENAME_MAX, "%s%s", filePathWithoutSuffix, RECORDING_SUFFIX);
             if (!fileExists(filePath) || confirm("File of that name already exists. Overwrite?", true)) {
@@ -1283,7 +1281,6 @@ void saveRecording(char *filePathWithoutSuffix) {
             rogue.recording = false;
         }
     } while (askAgain);
-    deleteMessages();
 }
 
 static void copyFile(char *fromFilePath, char *toFilePath, unsigned long fromFileLength) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2974,7 +2974,7 @@ extern "C" {
     boolean getInputTextString(char *inputText,
                                const char *prompt,
                                short maxLength,
-                               const char *defaultEntry,
+                               char *defaultEntry,
                                const char *promptSuffix,
                                short textEntryType,
                                boolean useDialogBox);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1323,11 +1323,12 @@ void victory(boolean superVictory) {
     rogue.playbackMode = false;
     rogue.playbackMode = isPlayback;
 
+    displayMoreSign();
+
     if (serverMode) {
-        // There's no save recording prompt, so let the player see achievements.
-        displayMoreSign();
         saveRecordingNoPrompt(recordingFilename);
     } else {
+        blackOutScreen();
         saveRecording(recordingFilename);
         printHighScores(qualified);
     }


### PR DESCRIPTION
Previously, file save operations used the message pane, which is a dungeon UI component. However, when the player wins or dies, the dungeon UI is no longer visible, so the location of the message pane and any related message management is no longer relevant. 

This change updates the UI so that game save and recording save operations use a centered dialog. The dialog title displays the prompt and the filename is entered on the line below, which accommodates much long file names. This is especially nice for the long filenames generated by debug builds but is also generally useful since the filename now includes a variant identifier and version number and can also include the mode name (e.g. wizard). I added some long filename handling so the initially generated filename is truncated to fit in the available space and  the max length is enforced when typing, with no off-screen overflow.