### PR TITLE
Fixed strength potion not curing weakness immediately

### DIFF
--- a/changes/strength-potion-not-immediate.md
+++ b/changes/strength-potion-not-immediate.md
@@ -1,0 +1,1 @@
+Drinking a strength potion now causes weakness to be removed from a character immediately, in the middle of the turn in which it was ingested (as well as at the end of the turn).

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -7157,6 +7157,8 @@ void drinkPotion(item *theItem) {
             if (player.status[STATUS_WEAKENED]) {
                 player.status[STATUS_WEAKENED] = 1;
             }
+            //Needed to make potion have immediate effect
+            player.weaknessAmount = 0;
             updateEncumbrance();
             messageWithColor("newfound strength surges through your body.", &advancementMessageColor, 0);
             createFlare(player.loc.x, player.loc.y, POTION_STRENGTH_LIGHT);


### PR DESCRIPTION
This fixes bug [#366](https://github.com/tmewett/BrogueCE/issues/366).

This removes the player's weakened status as soon as the potion is drunk.  It's done again at the end of the turn as well, but I don't see how that would cause a problem.  

It's possible that the better way to do this is to make another generic function like applyInstantTileEffectsToCreature (but for potions), but I don't know of any other potions that need an effect like this to happen immediately.  If there are, it might make sense to put them into something like applyInstantPotionEffectsToPlayer (which I'd be happy to try to tackle if that's the correct thing to do in this case).

(This is my first bug fix in C, my first attempt at using github.)
