### PR TITLE
Simplify button-drawing logic

### DIFF
--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -156,11 +156,11 @@ void setButtonText(brogueButton *button, const char *textWithHotkey, const char 
     strncpy(button->text, textBuf, BUTTON_TEXT_SIZE - 1);
 }
 
-void drawButtonsInState(buttonState *state) {
+void drawButtonsInState(buttonState *state, screenDisplayBuffer *button_dbuf) {
     // Draw the buttons to the button_dbuf:
     for (int i=0; i < state->buttonCount; i++) {
         if (state->buttons[i].flags & B_DRAW) {
-            drawButton(&(state->buttons[i]), BUTTON_NORMAL, &state->button_dbuf);
+            drawButton(&(state->buttons[i]), BUTTON_NORMAL, button_dbuf);
         }
     }
 }
@@ -171,7 +171,8 @@ void initializeButtonState(buttonState *state,
                            short winX,
                            short winY,
                            short winWidth,
-                           short winHeight) {
+                           short winHeight,
+                           screenDisplayBuffer *button_dbuf) {
     // Initialize variables for the state struct:
     state->buttonChosen = state->buttonFocused = state->buttonDepressed = -1;
     state->buttonCount  = buttonCount;
@@ -183,14 +184,14 @@ void initializeButtonState(buttonState *state,
         state->buttons[i] = buttons[i];
     }
     overlayDisplayBuffer(NULL, &state->button_rbuf);
-    clearDisplayBuffer(&state->button_dbuf);
 
-    drawButtonsInState(state);
+    clearDisplayBuffer(button_dbuf);
+    drawButtonsInState(state, button_dbuf);
 
     // Clear the button_rbuf so that it resets only those parts of the screen in which buttons are drawn in the first place:
     for (int i=0; i<COLS; i++) {
         for (int j=0; j<ROWS; j++) {
-            state->button_rbuf.cells[i][j].opacity = (state->button_dbuf.cells[i][j].opacity ? 100 : 0);
+            state->button_rbuf.cells[i][j].opacity = (button_dbuf->cells[i][j].opacity ? 100 : 0);
         }
     }
 }
@@ -203,7 +204,7 @@ void initializeButtonState(buttonState *state,
 // Returns the index of a button if one is chosen.
 // Otherwise, returns -1. That can be if the user canceled (in which case *canceled is true),
 // or, more commonly, if the user's input in this particular split-second round was not decisive.
-short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event) {
+short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event, screenDisplayBuffer *button_dbuf) {
     boolean buttonUsed = false;
 
     // Mouse event:
@@ -216,7 +217,7 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
 
         // Revert the button with old focus, if any.
         if (state->buttonFocused >= 0) {
-            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_NORMAL, &state->button_dbuf);
+            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_NORMAL, button_dbuf);
             state->buttonFocused = -1;
         }
 
@@ -242,11 +243,11 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
 
         if (state->buttonDepressed >= 0) {
             if (state->buttonDepressed == state->buttonFocused) {
-                drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_PRESSED, &state->button_dbuf);
+                drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_PRESSED, button_dbuf);
             }
         } else if (state->buttonFocused >= 0) {
             // If no button is depressed, then update the appearance of the button with the new focus, if any.
-            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_HOVER, &state->button_dbuf);
+            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_HOVER, button_dbuf);
         }
 
         // Mouseup:
@@ -257,7 +258,7 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
             } else {
                 // Otherwise, no button is depressed. If one was previously depressed, redraw it.
                 if (state->buttonDepressed >= 0) {
-                    drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_NORMAL, &state->button_dbuf);
+                    drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_NORMAL, button_dbuf);
                 } else if (!(x >= state->winX && x < state->winX + state->winWidth
                              && y >= state->winY && y < state->winY + state->winHeight)) {
                     // Clicking outside of a button means canceling.
@@ -268,7 +269,7 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
 
                 if (state->buttonFocused >= 0) {
                     // Buttons don't hover-highlight when one is depressed, so we have to fix that when the mouse is up.
-                    drawButton(&(state->buttons[state->buttonFocused]), BUTTON_HOVER, &state->button_dbuf);
+                    drawButton(&(state->buttons[state->buttonFocused]), BUTTON_HOVER, button_dbuf);
                 }
                 state->buttonDepressed = -1;
             }
@@ -287,20 +288,20 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
                     if (state->buttons[i].flags & B_DRAW) {
                         // Restore the depressed and focused buttons.
                         if (state->buttonDepressed >= 0) {
-                            drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_NORMAL, &state->button_dbuf);
+                            drawButton(&(state->buttons[state->buttonDepressed]), BUTTON_NORMAL, button_dbuf);
                         }
                         if (state->buttonFocused >= 0) {
-                            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_NORMAL, &state->button_dbuf);
+                            drawButton(&(state->buttons[state->buttonFocused]), BUTTON_NORMAL, button_dbuf);
                         }
 
                         // If the button likes to flash when keypressed:
                         if (state->buttons[i].flags & B_KEYPRESS_HIGHLIGHT) {
                             // Depress the chosen button.
-                            drawButton(&(state->buttons[i]), BUTTON_PRESSED, &state->button_dbuf);
+                            drawButton(&(state->buttons[i]), BUTTON_PRESSED, button_dbuf);
 
                             // Update the display.
                             overlayDisplayBuffer(&state->button_rbuf, NULL);
-                            overlayDisplayBuffer(&state->button_dbuf, NULL);
+                            overlayDisplayBuffer(button_dbuf, NULL);
 
                             if (!rogue.playbackMode || rogue.playbackPaused) {
                                 // Wait for a little; then we're done.
@@ -351,21 +352,22 @@ short buttonInputLoop(brogueButton *buttons,
     boolean canceled;
     rogueEvent theEvent;
     buttonState state = {0};
+    screenDisplayBuffer button_dbuf;
 
     assureCosmeticRNG;
 
     canceled = false;
-    initializeButtonState(&state, buttons, buttonCount, winX, winY, winWidth, winHeight);
+    initializeButtonState(&state, buttons, buttonCount, winX, winY, winWidth, winHeight, &button_dbuf);
 
     do {
         // Update the display.
-        overlayDisplayBuffer(&state.button_dbuf, NULL);
+        overlayDisplayBuffer(&button_dbuf, NULL);
 
         // Get input.
         nextBrogueEvent(&theEvent, true, false, false);
 
         // Process the input.
-        button = processButtonInput(&state, &canceled, &theEvent);
+        button = processButtonInput(&state, &canceled, &theEvent, &button_dbuf);
 
         // Revert the display.
         overlayDisplayBuffer(&state.button_rbuf, NULL);

--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -294,10 +294,10 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
 
                             if (!rogue.playbackMode || rogue.playbackPaused) {
                                 // Wait for a little; then we're done.
-                                pauseBrogue(50);
+                                pauseBrogue(50, PAUSE_BEHAVIOR_DEFAULT);
                             } else {
                                 // Wait long enough for the viewer to see what was selected.
-                                pauseAnimation(1000);
+                                pauseAnimation(1000, PAUSE_BEHAVIOR_DEFAULT);
                             }
 
                             // Revert the display to its appearance before the button-press.

--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -191,14 +191,6 @@ void initializeButtonState(buttonState *state,
     }
 }
 
-void maskOutBufferAlpha(screenDisplayBuffer *rbuf, const screenDisplayBuffer *dbuf) {
-    for (int i=0; i<COLS; i++) {
-        for (int j=0; j<ROWS; j++) {
-            rbuf->cells[i][j].opacity = (dbuf->cells[i][j].opacity ? 100 : 0);
-        }
-    }
-}
-
 // Processes one round of user input, and updates `state` accordingly.
 // If a button is pressed, draws to the screen and briefly pauses, but then
 // immediately reverts the screen state to beforce `processButtonInput` was caled.
@@ -251,9 +243,7 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
                 buttonUsed = true;
             } else {
                 // Otherwise, no button is depressed. If one was previously depressed, redraw it.
-                if (state->buttonDepressed >= 0) {
-                    // ...
-                } else if (!(x >= state->winX && x < state->winX + state->winWidth
+                if (state->buttonDepressed < 0 && !(x >= state->winX && x < state->winX + state->winWidth
                              && y >= state->winY && y < state->winY + state->winHeight)) {
                     // Clicking outside of a button means canceling.
                     if (canceled) {

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -430,7 +430,7 @@ static short actionMenu(short x, boolean playingBack) {
 
 #define MAX_MENU_BUTTON_COUNT 5
 
-static void initializeMenuButtons(buttonState *state, screenDisplayBuffer *button_dbuf, brogueButton buttons[5]) {
+static void initializeMenuButtons(buttonState *state, screenDisplayBuffer *button_dbuf, screenDisplayBuffer *button_rbuf, brogueButton buttons[5]) {
     short i, x, buttonCount;
     char goldTextEscape[MAX_MENU_BUTTON_COUNT] = "";
     char whiteTextEscape[MAX_MENU_BUTTON_COUNT] = "";
@@ -521,20 +521,21 @@ static void initializeMenuButtons(buttonState *state, screenDisplayBuffer *butto
                           ROWS - 1,
                           COLS - mapToWindowX(0),
                           1,
-                          button_dbuf);
+                          button_dbuf,
+                          button_rbuf);
 
     for (i=0; i < 5; i++) {
-        drawButton(&(state->buttons[i]), BUTTON_NORMAL, &state->button_rbuf);
+        drawButton(&(state->buttons[i]), BUTTON_NORMAL, button_rbuf);
     }
     for (i=0; i<COLS; i++) { // So the buttons stay (but are dimmed and desaturated) when inactive.
-        tempColor = colorFromComponents(state->button_rbuf.cells[i][ROWS - 1].backColorComponents);
+        tempColor = colorFromComponents(button_rbuf->cells[i][ROWS - 1].backColorComponents);
         desaturate(&tempColor, 60);
         applyColorAverage(&tempColor, &black, 50);
-        storeColorComponents(state->button_rbuf.cells[i][ROWS - 1].backColorComponents, &tempColor);
-        tempColor = colorFromComponents(state->button_rbuf.cells[i][ROWS - 1].foreColorComponents);
+        storeColorComponents(button_rbuf->cells[i][ROWS - 1].backColorComponents, &tempColor);
+        tempColor = colorFromComponents(button_rbuf->cells[i][ROWS - 1].foreColorComponents);
         desaturate(&tempColor, 60);
         applyColorAverage(&tempColor, &black, 50);
-        storeColorComponents(state->button_rbuf.cells[i][ROWS - 1].foreColorComponents, &tempColor);
+        storeColorComponents(button_rbuf->cells[i][ROWS - 1].foreColorComponents, &tempColor);
     }
 }
 
@@ -556,6 +557,7 @@ void mainInputLoop() {
     brogueButton buttons[5] = {{{0}}};
     buttonState state;
     screenDisplayBuffer button_dbuf;
+    screenDisplayBuffer button_rbuf;
     short buttonInput;
     short backupCost;
 
@@ -566,7 +568,7 @@ void mainInputLoop() {
     rogue.cursorPathIntensity = (rogue.cursorMode ? 50 : 20);
 
     // Initialize buttons.
-    initializeMenuButtons(&state, &button_dbuf, buttons);
+    initializeMenuButtons(&state, &button_dbuf, &button_rbuf, buttons);
 
     playingBack = rogue.playbackMode;
     rogue.playbackMode = false;
@@ -700,7 +702,7 @@ void mainInputLoop() {
 
             // Get the input!
             rogue.playbackMode = playingBack;
-            doEvent = moveCursor(&targetConfirmed, &canceled, &tabKey, &rogue.cursorLoc, &theEvent, &state, &button_dbuf, !textDisplayed, rogue.cursorMode, true);
+            doEvent = moveCursor(&targetConfirmed, &canceled, &tabKey, &rogue.cursorLoc, &theEvent, &state, &button_dbuf, &button_rbuf, !textDisplayed, rogue.cursorMode, true);
             rogue.playbackMode = false;
 
             if (state.buttonChosen == 3) { // Actions menu button.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -3371,7 +3371,7 @@ void displayMessageArchive() {
     height = min(length, MESSAGE_ARCHIVE_VIEW_LINES);
     offset = height;
 
-    copyDisplayBuffer(&rbuf, &displayBuffer);
+    overlayDisplayBuffer(NULL, &rbuf);
 
     animateMessageArchive(true, messageBuffer, length, offset, height, &rbuf);
     offset = scrollMessageArchive(messageBuffer, length, offset, height, &rbuf);

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -434,7 +434,6 @@ static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
     short i, x, buttonCount;
     char goldTextEscape[MAX_MENU_BUTTON_COUNT] = "";
     char whiteTextEscape[MAX_MENU_BUTTON_COUNT] = "";
-    color tempColor;
 
     encodeMessageColor(goldTextEscape, 0, KEYBOARD_LABELS ? &yellow : &white);
     encodeMessageColor(whiteTextEscape, 0, &white);
@@ -514,8 +513,6 @@ static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
         x += strLenWithoutEscapes(buttons[i].text) + 2; // Gap between buttons.
     }
 
-    // overlayDisplayBuffer(NULL, button_rbuf);
-    // clearDisplayBuffer(button_dbuf);
     initializeButtonState(state,
                           buttons,
                           5,
@@ -523,22 +520,6 @@ static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
                           ROWS - 1,
                           COLS - mapToWindowX(0),
                           1);
-    // drawButtonsInState(state, button_dbuf);
-    // maskOutBufferAlpha(button_rbuf, button_dbuf);
-
-    // for (i=0; i < 5; i++) {
-    //     drawButton(&(state->buttons[i]), BUTTON_NORMAL, button_rbuf);
-    // }
-    // for (i=0; i<COLS; i++) { // So the buttons stay (but are dimmed and desaturated) when inactive.
-    //     tempColor = colorFromComponents(button_rbuf->cells[i][ROWS - 1].backColorComponents);
-    //     desaturate(&tempColor, 60);
-    //     applyColorAverage(&tempColor, &black, 50);
-    //     storeColorComponents(button_rbuf->cells[i][ROWS - 1].backColorComponents, &tempColor);
-    //     tempColor = colorFromComponents(button_rbuf->cells[i][ROWS - 1].foreColorComponents);
-    //     desaturate(&tempColor, 60);
-    //     applyColorAverage(&tempColor, &black, 50);
-    //     storeColorComponents(button_rbuf->cells[i][ROWS - 1].foreColorComponents, &tempColor);
-    // }
 }
 
 
@@ -1982,12 +1963,16 @@ color colorFromComponents(char rgb[3]) {
 
 // draws overBuf over the current display with per-cell pseudotransparency as specified in overBuf.
 // If previousBuf is not null, it gets filled with the preexisting display for reversion purposes.
+// 
+// If `overBuf` is null, then nothing is drawn to the screen. This can be used to save
+// `previousBuf` without drawing anything new.
 void overlayDisplayBuffer(screenDisplayBuffer *overBuf, screenDisplayBuffer *previousBuf) {
     if (previousBuf) {
         copyDisplayBuffer(previousBuf, &displayBuffer);
     }
 
     if (overBuf == NULL) {
+        // If `overBuf` is NULL, then save `previousBuf` but draw nothing.
         return;
     }
 

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -523,17 +523,17 @@ static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
                           1);
 
     for (i=0; i < 5; i++) {
-        drawButton(&(state->buttons[i]), BUTTON_NORMAL, &state->rbuf);
+        drawButton(&(state->buttons[i]), BUTTON_NORMAL, &state->button_rbuf);
     }
     for (i=0; i<COLS; i++) { // So the buttons stay (but are dimmed and desaturated) when inactive.
-        tempColor = colorFromComponents(state->rbuf.cells[i][ROWS - 1].backColorComponents);
+        tempColor = colorFromComponents(state->button_rbuf.cells[i][ROWS - 1].backColorComponents);
         desaturate(&tempColor, 60);
         applyColorAverage(&tempColor, &black, 50);
-        storeColorComponents(state->rbuf.cells[i][ROWS - 1].backColorComponents, &tempColor);
-        tempColor = colorFromComponents(state->rbuf.cells[i][ROWS - 1].foreColorComponents);
+        storeColorComponents(state->button_rbuf.cells[i][ROWS - 1].backColorComponents, &tempColor);
+        tempColor = colorFromComponents(state->button_rbuf.cells[i][ROWS - 1].foreColorComponents);
         desaturate(&tempColor, 60);
         applyColorAverage(&tempColor, &black, 50);
-        storeColorComponents(state->rbuf.cells[i][ROWS - 1].foreColorComponents, &tempColor);
+        storeColorComponents(state->button_rbuf.cells[i][ROWS - 1].foreColorComponents, &tempColor);
     }
 }
 
@@ -1979,18 +1979,19 @@ color colorFromComponents(char rgb[3]) {
 // draws overBuf over the current display with per-cell pseudotransparency as specified in overBuf.
 // If previousBuf is not null, it gets filled with the preexisting display for reversion purposes.
 void overlayDisplayBuffer(screenDisplayBuffer *overBuf, screenDisplayBuffer *previousBuf) {
-    short i, j;
-    color foreColor, backColor, tempColor;
-    enum displayGlyph character;
-
     if (previousBuf) {
         copyDisplayBuffer(previousBuf, &displayBuffer);
     }
 
-    for (i=0; i<COLS; i++) {
-        for (j=0; j<ROWS; j++) {
+    if (overBuf == NULL) {
+        return;
+    }
 
+    for (int i=0; i<COLS; i++) {
+        for (int j=0; j<ROWS; j++) {
             if (overBuf->cells[i][j].opacity != 0) {
+                color foreColor, backColor, tempColor;
+                enum displayGlyph character;
                 backColor = colorFromComponents(overBuf->cells[i][j].backColorComponents);
 
                 // character and fore color:

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -430,7 +430,7 @@ static short actionMenu(short x, boolean playingBack) {
 
 #define MAX_MENU_BUTTON_COUNT 5
 
-static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
+static void initializeMenuButtons(buttonState *state, screenDisplayBuffer *button_dbuf, brogueButton buttons[5]) {
     short i, x, buttonCount;
     char goldTextEscape[MAX_MENU_BUTTON_COUNT] = "";
     char whiteTextEscape[MAX_MENU_BUTTON_COUNT] = "";
@@ -520,7 +520,8 @@ static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
                           mapToWindowX(0),
                           ROWS - 1,
                           COLS - mapToWindowX(0),
-                          1);
+                          1,
+                          button_dbuf);
 
     for (i=0; i < 5; i++) {
         drawButton(&(state->buttons[i]), BUTTON_NORMAL, &state->button_rbuf);
@@ -554,6 +555,7 @@ void mainInputLoop() {
     short **costMap, **playerPathingMap, **cursorSnapMap;
     brogueButton buttons[5] = {{{0}}};
     buttonState state;
+    screenDisplayBuffer button_dbuf;
     short buttonInput;
     short backupCost;
 
@@ -564,7 +566,7 @@ void mainInputLoop() {
     rogue.cursorPathIntensity = (rogue.cursorMode ? 50 : 20);
 
     // Initialize buttons.
-    initializeMenuButtons(&state, buttons);
+    initializeMenuButtons(&state, &button_dbuf, buttons);
 
     playingBack = rogue.playbackMode;
     rogue.playbackMode = false;
@@ -698,7 +700,7 @@ void mainInputLoop() {
 
             // Get the input!
             rogue.playbackMode = playingBack;
-            doEvent = moveCursor(&targetConfirmed, &canceled, &tabKey, &rogue.cursorLoc, &theEvent, &state, !textDisplayed, rogue.cursorMode, true);
+            doEvent = moveCursor(&targetConfirmed, &canceled, &tabKey, &rogue.cursorLoc, &theEvent, &state, &button_dbuf, !textDisplayed, rogue.cursorMode, true);
             rogue.playbackMode = false;
 
             if (state.buttonChosen == 3) { // Actions menu button.
@@ -811,7 +813,7 @@ void mainInputLoop() {
                 if (!rogue.playbackMode) {
                     // Playback mode is off, user must have taken control
                     // Redraw buttons to reflect that
-                    initializeMenuButtons(&state, buttons);
+                    initializeMenuButtons(&state, &button_dbuf, buttons);
                 }
 #endif
                 playingBack = rogue.playbackMode;

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -514,15 +514,17 @@ static void initializeMenuButtons(buttonState *state, screenDisplayBuffer *butto
         x += strLenWithoutEscapes(buttons[i].text) + 2; // Gap between buttons.
     }
 
+    overlayDisplayBuffer(NULL, button_rbuf);
+    clearDisplayBuffer(button_dbuf);
     initializeButtonState(state,
                           buttons,
                           5,
                           mapToWindowX(0),
                           ROWS - 1,
                           COLS - mapToWindowX(0),
-                          1,
-                          button_dbuf,
-                          button_rbuf);
+                          1);
+    drawButtonsInState(state, button_dbuf);
+    maskOutBufferAlpha(button_rbuf, button_dbuf);
 
     for (i=0; i < 5; i++) {
         drawButton(&(state->buttons[i]), BUTTON_NORMAL, button_rbuf);

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -430,7 +430,7 @@ static short actionMenu(short x, boolean playingBack) {
 
 #define MAX_MENU_BUTTON_COUNT 5
 
-static void initializeMenuButtons(buttonState *state, screenDisplayBuffer *button_dbuf, screenDisplayBuffer *button_rbuf, brogueButton buttons[5]) {
+static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
     short i, x, buttonCount;
     char goldTextEscape[MAX_MENU_BUTTON_COUNT] = "";
     char whiteTextEscape[MAX_MENU_BUTTON_COUNT] = "";
@@ -514,8 +514,8 @@ static void initializeMenuButtons(buttonState *state, screenDisplayBuffer *butto
         x += strLenWithoutEscapes(buttons[i].text) + 2; // Gap between buttons.
     }
 
-    overlayDisplayBuffer(NULL, button_rbuf);
-    clearDisplayBuffer(button_dbuf);
+    // overlayDisplayBuffer(NULL, button_rbuf);
+    // clearDisplayBuffer(button_dbuf);
     initializeButtonState(state,
                           buttons,
                           5,
@@ -523,22 +523,22 @@ static void initializeMenuButtons(buttonState *state, screenDisplayBuffer *butto
                           ROWS - 1,
                           COLS - mapToWindowX(0),
                           1);
-    drawButtonsInState(state, button_dbuf);
-    maskOutBufferAlpha(button_rbuf, button_dbuf);
+    // drawButtonsInState(state, button_dbuf);
+    // maskOutBufferAlpha(button_rbuf, button_dbuf);
 
-    for (i=0; i < 5; i++) {
-        drawButton(&(state->buttons[i]), BUTTON_NORMAL, button_rbuf);
-    }
-    for (i=0; i<COLS; i++) { // So the buttons stay (but are dimmed and desaturated) when inactive.
-        tempColor = colorFromComponents(button_rbuf->cells[i][ROWS - 1].backColorComponents);
-        desaturate(&tempColor, 60);
-        applyColorAverage(&tempColor, &black, 50);
-        storeColorComponents(button_rbuf->cells[i][ROWS - 1].backColorComponents, &tempColor);
-        tempColor = colorFromComponents(button_rbuf->cells[i][ROWS - 1].foreColorComponents);
-        desaturate(&tempColor, 60);
-        applyColorAverage(&tempColor, &black, 50);
-        storeColorComponents(button_rbuf->cells[i][ROWS - 1].foreColorComponents, &tempColor);
-    }
+    // for (i=0; i < 5; i++) {
+    //     drawButton(&(state->buttons[i]), BUTTON_NORMAL, button_rbuf);
+    // }
+    // for (i=0; i<COLS; i++) { // So the buttons stay (but are dimmed and desaturated) when inactive.
+    //     tempColor = colorFromComponents(button_rbuf->cells[i][ROWS - 1].backColorComponents);
+    //     desaturate(&tempColor, 60);
+    //     applyColorAverage(&tempColor, &black, 50);
+    //     storeColorComponents(button_rbuf->cells[i][ROWS - 1].backColorComponents, &tempColor);
+    //     tempColor = colorFromComponents(button_rbuf->cells[i][ROWS - 1].foreColorComponents);
+    //     desaturate(&tempColor, 60);
+    //     applyColorAverage(&tempColor, &black, 50);
+    //     storeColorComponents(button_rbuf->cells[i][ROWS - 1].foreColorComponents, &tempColor);
+    // }
 }
 
 
@@ -558,8 +558,6 @@ void mainInputLoop() {
     short **costMap, **playerPathingMap, **cursorSnapMap;
     brogueButton buttons[5] = {{{0}}};
     buttonState state;
-    screenDisplayBuffer button_dbuf;
-    screenDisplayBuffer button_rbuf;
     short buttonInput;
     short backupCost;
 
@@ -570,7 +568,7 @@ void mainInputLoop() {
     rogue.cursorPathIntensity = (rogue.cursorMode ? 50 : 20);
 
     // Initialize buttons.
-    initializeMenuButtons(&state, &button_dbuf, &button_rbuf, buttons);
+    initializeMenuButtons(&state, buttons);
 
     playingBack = rogue.playbackMode;
     rogue.playbackMode = false;
@@ -704,7 +702,7 @@ void mainInputLoop() {
 
             // Get the input!
             rogue.playbackMode = playingBack;
-            doEvent = moveCursor(&targetConfirmed, &canceled, &tabKey, &rogue.cursorLoc, &theEvent, &state, &button_dbuf, &button_rbuf, !textDisplayed, rogue.cursorMode, true);
+            doEvent = moveCursor(&targetConfirmed, &canceled, &tabKey, &rogue.cursorLoc, &theEvent, &state, !textDisplayed, rogue.cursorMode, true);
             rogue.playbackMode = false;
 
             if (state.buttonChosen == 3) { // Actions menu button.
@@ -817,7 +815,7 @@ void mainInputLoop() {
                 if (!rogue.playbackMode) {
                     // Playback mode is off, user must have taken control
                     // Redraw buttons to reflect that
-                    initializeMenuButtons(&state, &button_dbuf, buttons);
+                    initializeMenuButtons(&state, buttons);
                 }
 #endif
                 playingBack = rogue.playbackMode;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5233,8 +5233,6 @@ boolean moveCursor(boolean *targetConfirmed,
                    pos *targetLoc,
                    rogueEvent *event,
                    buttonState *state,
-                   screenDisplayBuffer *button_dbuf,
-                   screenDisplayBuffer *button_rbuf,
                    boolean colorsDance,
                    boolean keysMoveCursor,
                    boolean targetCanLeaveMap) {
@@ -5260,23 +5258,26 @@ boolean moveCursor(boolean *targetConfirmed,
         //assureCosmeticRNG;
 
         if (state) { // Also running a button loop.
+            screenDisplayBuffer dbuf;
+            clearDisplayBuffer(&dbuf);
+            drawButtonsInState(state, &dbuf);
 
+            screenDisplayBuffer rbuf;
             // Update the display.
-            overlayDisplayBuffer(button_dbuf, NULL);
+            overlayDisplayBuffer(&dbuf, &rbuf);
 
             // Get input.
             nextBrogueEvent(&theEvent, false, colorsDance, true);
 
             // Process the input.
-            buttonInput = processButtonInput(state, NULL, &theEvent, button_dbuf, button_rbuf);
+            buttonInput = processButtonInput(state, NULL, &theEvent);
 
             if (buttonInput != -1) {
                 state->buttonDepressed = state->buttonFocused = -1;
-                drawButtonsInState(state, button_dbuf);
             }
 
             // Revert the display.
-            overlayDisplayBuffer(button_rbuf, NULL);
+            overlayDisplayBuffer(&rbuf, NULL);
 
         } else { // No buttons to worry about.
             nextBrogueEvent(&theEvent, false, colorsDance, true);
@@ -5578,7 +5579,7 @@ boolean chooseTarget(pos *returnLoc,
         }
 
         oldTargetLoc = targetLoc;
-        moveCursor(&targetConfirmed, &canceled, &tabKey, &targetLoc, &event, NULL, NULL, NULL, false, true, false);
+        moveCursor(&targetConfirmed, &canceled, &tabKey, &targetLoc, &event, NULL, false, true, false);
         if (event.eventType == RIGHT_MOUSE_UP) { // Right mouse cancels.
             canceled = true;
         }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5260,7 +5260,7 @@ boolean moveCursor(boolean *targetConfirmed,
         if (state) { // Also running a button loop.
 
             // Update the display.
-            overlayDisplayBuffer(&state->dbuf, NULL);
+            overlayDisplayBuffer(&state->button_dbuf, NULL);
 
             // Get input.
             nextBrogueEvent(&theEvent, false, colorsDance, true);
@@ -5274,7 +5274,7 @@ boolean moveCursor(boolean *targetConfirmed,
             }
 
             // Revert the display.
-            overlayDisplayBuffer(&state->rbuf, NULL);
+            overlayDisplayBuffer(&state->button_rbuf, NULL);
 
         } else { // No buttons to worry about.
             nextBrogueEvent(&theEvent, false, colorsDance, true);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5233,6 +5233,7 @@ boolean moveCursor(boolean *targetConfirmed,
                    pos *targetLoc,
                    rogueEvent *event,
                    buttonState *state,
+                   screenDisplayBuffer *button_dbuf,
                    boolean colorsDance,
                    boolean keysMoveCursor,
                    boolean targetCanLeaveMap) {
@@ -5260,17 +5261,17 @@ boolean moveCursor(boolean *targetConfirmed,
         if (state) { // Also running a button loop.
 
             // Update the display.
-            overlayDisplayBuffer(&state->button_dbuf, NULL);
+            overlayDisplayBuffer(button_dbuf, NULL);
 
             // Get input.
             nextBrogueEvent(&theEvent, false, colorsDance, true);
 
             // Process the input.
-            buttonInput = processButtonInput(state, NULL, &theEvent);
+            buttonInput = processButtonInput(state, NULL, &theEvent, button_dbuf);
 
             if (buttonInput != -1) {
                 state->buttonDepressed = state->buttonFocused = -1;
-                drawButtonsInState(state);
+                drawButtonsInState(state, button_dbuf);
             }
 
             // Revert the display.
@@ -5576,7 +5577,7 @@ boolean chooseTarget(pos *returnLoc,
         }
 
         oldTargetLoc = targetLoc;
-        moveCursor(&targetConfirmed, &canceled, &tabKey, &targetLoc, &event, NULL, false, true, false);
+        moveCursor(&targetConfirmed, &canceled, &tabKey, &targetLoc, &event, NULL, NULL, false, true, false);
         if (event.eventType == RIGHT_MOUSE_UP) { // Right mouse cancels.
             canceled = true;
         }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4954,7 +4954,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
             }
         }
         if (!fastForward && (boltInView || rogue.playbackOmniscience)) {
-            fastForward = rogue.playbackFastForward || pauseAnimation(16);
+            fastForward = rogue.playbackFastForward || pauseAnimation(16, PAUSE_BEHAVIOR_DEFAULT);
         }
 
         if (theBolt->boltEffect == BE_BLINKING) {
@@ -5097,7 +5097,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
                 }
 
                 if (!fastForward && boltInView) {
-                    fastForward = rogue.playbackFastForward || pauseAnimation(16);
+                    fastForward = rogue.playbackFastForward || pauseAnimation(16, PAUSE_BEHAVIOR_DEFAULT);
                 }
             }
         } else if (theBolt->flags & BF_DISPLAY_CHAR_ALONG_LENGTH) {
@@ -6019,7 +6019,7 @@ static void throwItem(item *theItem, creature *thrower, pos targetLoc, short max
             plotCharWithColor(theItem->displayChar, mapToWindow((pos){ x, y }), &foreColor, &backColor);
 
             if (!fastForward) {
-                fastForward = rogue.playbackFastForward || pauseAnimation(25);
+                fastForward = rogue.playbackFastForward || pauseAnimation(25, PAUSE_BEHAVIOR_DEFAULT);
             }
 
             refreshDungeonCell((pos){ x, y });

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5234,6 +5234,7 @@ boolean moveCursor(boolean *targetConfirmed,
                    rogueEvent *event,
                    buttonState *state,
                    screenDisplayBuffer *button_dbuf,
+                   screenDisplayBuffer *button_rbuf,
                    boolean colorsDance,
                    boolean keysMoveCursor,
                    boolean targetCanLeaveMap) {
@@ -5267,7 +5268,7 @@ boolean moveCursor(boolean *targetConfirmed,
             nextBrogueEvent(&theEvent, false, colorsDance, true);
 
             // Process the input.
-            buttonInput = processButtonInput(state, NULL, &theEvent, button_dbuf);
+            buttonInput = processButtonInput(state, NULL, &theEvent, button_dbuf, button_rbuf);
 
             if (buttonInput != -1) {
                 state->buttonDepressed = state->buttonFocused = -1;
@@ -5275,7 +5276,7 @@ boolean moveCursor(boolean *targetConfirmed,
             }
 
             // Revert the display.
-            overlayDisplayBuffer(&state->button_rbuf, NULL);
+            overlayDisplayBuffer(button_rbuf, NULL);
 
         } else { // No buttons to worry about.
             nextBrogueEvent(&theEvent, false, colorsDance, true);
@@ -5577,7 +5578,7 @@ boolean chooseTarget(pos *returnLoc,
         }
 
         oldTargetLoc = targetLoc;
-        moveCursor(&targetConfirmed, &canceled, &tabKey, &targetLoc, &event, NULL, NULL, false, true, false);
+        moveCursor(&targetConfirmed, &canceled, &tabKey, &targetLoc, &event, NULL, NULL, NULL, false, true, false);
         if (event.eventType == RIGHT_MOUSE_UP) { // Right mouse cancels.
             canceled = true;
         }

--- a/src/brogue/Light.c
+++ b/src/brogue/Light.c
@@ -395,7 +395,7 @@ void animateFlares(flare **flares, short count) {
         demoteVisibility();
         updateFieldOfViewDisplay(false, true);
         if (!fastForward && (inView || rogue.playbackOmniscience) && atLeastOneFlareStillActive) {
-            fastForward = pauseAnimation(10);
+            fastForward = pauseAnimation(10, PAUSE_BEHAVIOR_DEFAULT);
         }
         recordOldLights();
         restoreLighting(lights);

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -590,7 +590,7 @@ static void titleMenu() {
 
                     // Process the flyout menu input as needed
                     if (isFlyoutActive()) {
-                        flyoutIndex = processButtonInput(&flyoutMenu, NULL, &theEvent, &flyoutMenu_button_dbuf, &flyoutMenu_button_rbuf);
+                        flyoutIndex = processButtonInput(&flyoutMenu, NULL, &theEvent);
                         if (flyoutIndex != -1 && (theEvent.eventType == MOUSE_UP || theEvent.eventType == KEYSTROKE)) {
                             rogue.nextGame = flyoutButtons[flyoutIndex].command;
                         }
@@ -602,7 +602,7 @@ static void titleMenu() {
                     }
 
                     // Process the main menu input
-                    mainIndex = processButtonInput(&mainMenu, NULL, &theEvent, &mainMenu_button_dbuf, &mainMenu_button_rbuf);
+                    mainIndex = processButtonInput(&mainMenu, NULL, &theEvent);
                     if (theEvent.eventType == MOUSE_UP || theEvent.eventType == KEYSTROKE) {
                         if (mainIndex != - 1 && rogue.nextGame != mainButtons[mainIndex].command) {
                             rogue.nextGame = mainButtons[mainIndex].command;

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -494,7 +494,7 @@ static void redrawMainMenuButtons(buttonState *menu) {
         //darken the main menu buttons not selected
         for (int i = 0; i < MAIN_MENU_BUTTON_COUNT; i++) {
             drawState = (menu->buttons[i].command == rogue.nextGame) ? BUTTON_NORMAL : BUTTON_PRESSED;
-            drawButton(&(menu->buttons[i]), drawState, &menu->dbuf);
+            drawButton(&(menu->buttons[i]), drawState, &menu->button_dbuf);
         }
     }
 }
@@ -554,18 +554,18 @@ static void titleMenu() {
         do {
             if (isApplicationActive()) {
                 // Revert the display.
-                overlayDisplayBuffer(&mainMenu.rbuf, NULL);
+                overlayDisplayBuffer(&mainMenu.button_rbuf, NULL);
 
                 // Update the display.
                 updateMenuFlames(colors, colorSources, flames);
                 drawMenuFlames(flames, mask);
                 overlayDisplayBuffer(&mainShadowBuf, NULL);
-                overlayDisplayBuffer(&mainMenu.dbuf, NULL);
+                overlayDisplayBuffer(&mainMenu.button_dbuf, NULL);
 
                 //Show flyout if selected
                 if (isFlyoutActive()) {
                     overlayDisplayBuffer(&flyoutShadowBuf, NULL);
-                    overlayDisplayBuffer(&flyoutMenu.dbuf, NULL);
+                    overlayDisplayBuffer(&flyoutMenu.button_dbuf, NULL);
                 }
                 // Pause briefly.
                 if (pauseBrogue(MENU_FLAME_UPDATE_DELAY)) {

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -403,7 +403,7 @@ static void chooseGameVariant() {
 
     brogueButton buttons[2];
     screenDisplayBuffer rbuf;
-    copyDisplayBuffer(&rbuf, &displayBuffer);
+    overlayDisplayBuffer(NULL, &rbuf);
     initializeMainMenuButton(&(buttons[0]), "  %sR%sapid Brogue     ", 'r', 'R', NG_NOTHING);
     initializeMainMenuButton(&(buttons[1]), "     %sB%srogue        ", 'b', 'B', NG_NOTHING);
     gameVariantChoice = printTextBox(textBuf, 20, 7, 45, &white, &black, &rbuf, buttons, 2);
@@ -443,7 +443,7 @@ static void chooseGameMode() {
 
     brogueButton buttons[3];
     screenDisplayBuffer rbuf;
-    copyDisplayBuffer(&rbuf, &displayBuffer);
+    overlayDisplayBuffer(NULL, &rbuf);
     initializeMainMenuButton(&(buttons[0]), "      %sW%sizard       ", 'w', 'W', NG_NOTHING);
     initializeMainMenuButton(&(buttons[1]), "       %sE%sasy        ", 'e', 'E', NG_NOTHING);
     initializeMainMenuButton(&(buttons[2]), "      %sN%sormal       ", 'n', 'N', NG_NOTHING);
@@ -691,7 +691,7 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
 
     suffixLength = strlen(suffix);
     files = listFiles(&count, &membuf);
-    copyDisplayBuffer(&rbuf, &displayBuffer);
+    overlayDisplayBuffer(NULL, &rbuf);
     maxPathLength = strLenWithoutEscapes(prompt);
 
     // First, we want to filter the list by stripping out any filenames that do not end with suffix.

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -317,6 +317,9 @@ static void stackButtons(brogueButton *buttons, short buttonCount, windowpos sta
 /// @param buttonCount The number of buttons in the array
 /// @param shadowBuf The display buffer object for the background/shadow
 static void initializeMenu(buttonState *menu, screenDisplayBuffer *button_dbuf, screenDisplayBuffer *button_rbuf, brogueButton *buttons, short buttonCount, screenDisplayBuffer *shadowBuf) {
+    // copies the current display to a reversion buffer. draws the buttons on the button state display buffer.
+    overlayDisplayBuffer(NULL, button_rbuf);
+    
     memset((void *) menu, 0, sizeof( buttonState ));
     short minX, maxX, minY, maxY;
     minX = COLS;
@@ -334,13 +337,16 @@ static void initializeMenu(buttonState *menu, screenDisplayBuffer *button_dbuf, 
     short width = maxX - minX;
     short height = maxY - minY;
 
-    clearDisplayBuffer(shadowBuf);
-    // copies the current display to a reversion buffer. draws the buttons on the button state display buffer.
-    initializeButtonState(menu, buttons, buttonCount, minX, minY, width, height, button_dbuf, button_rbuf);
+    initializeButtonState(menu, buttons, buttonCount, minX, minY, width, height);
+
+    clearDisplayBuffer(button_dbuf);
+    drawButtonsInState(menu, button_dbuf);
+    maskOutBufferAlpha(button_rbuf, button_dbuf);
 
     // Draws a rectangular shaded area of the specified color and opacity to a buffer. Position x, y is the upper/left.
     // The shading effect outside the rectangle decreases with distance.
     // Warning: shading of neighboring rectangles stacks
+    clearDisplayBuffer(shadowBuf);
     rectangularShading(minX, minY, width, height + 1, &black, INTERFACE_OPACITY, shadowBuf);
 }
 

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -2098,7 +2098,7 @@ boolean useStairs(short stairDirection) {
 
     if (stairDirection == 1) {
         if (rogue.depthLevel < gameConst->deepestLevel) {
-            //copyDisplayBuffer(fromBuf, displayBuffer);
+            //overlayDisplayBuffer(NULL, fromBuf);
             rogue.cursorLoc = INVALID_POS;
             rogue.depthLevel++;
             message("You descend.", 0);
@@ -2106,7 +2106,7 @@ boolean useStairs(short stairDirection) {
             if (rogue.depthLevel > rogue.deepestLevel) {
                 rogue.deepestLevel = rogue.depthLevel;
             }
-            //copyDisplayBuffer(toBuf, displayBuffer);
+            //overlayDisplayBuffer(NULL, toBuf);
             //irisFadeBetweenBuffers(fromBuf, toBuf, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), 20, false);
         } else if (numberOfMatchingPackItems(AMULET, 0, 0, false)) {
             victory(true);
@@ -2123,10 +2123,10 @@ boolean useStairs(short stairDirection) {
             if (rogue.depthLevel == 0) {
                 victory(false);
             } else {
-                //copyDisplayBuffer(fromBuf, displayBuffer);
+                //overlayDisplayBuffer(NULL, fromBuf);
                 message("You ascend.", 0);
                 startLevel(rogue.depthLevel + 1, stairDirection);
-                //copyDisplayBuffer(toBuf, displayBuffer);
+                //overlayDisplayBuffer(NULL, toBuf);
                 //irisFadeBetweenBuffers(fromBuf, toBuf, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), 20, true);
             }
             succeeded = true;

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -696,7 +696,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
             attack(attacker, hitList[i], false);
         }
         if (visualEffect) {
-            pauseAnimation(16);
+            pauseAnimation(16, PAUSE_BEHAVIOR_DEFAULT);
             for (i = 0; i < range; i++) {
                 const pos targetLoc = (pos) {
                     attacker->loc.x + (1 + i) * nbDirs[dir][0],
@@ -1509,7 +1509,7 @@ void travelRoute(pos path[1000], short steps) {
                 if (!playerMoves(dir)) {
                     rogue.disturbed = true;
                 }
-                if (pauseAnimation(25)) {
+                if (pauseAnimation(25, PAUSE_BEHAVIOR_DEFAULT)) {
                     rogue.disturbed = true;
                 }
                 break;
@@ -1544,7 +1544,7 @@ static void travelMap(short **distanceMap) {
                 if (!playerMoves(dir)) {
                     rogue.disturbed = true;
                 }
-                if (pauseAnimation(500)) {
+                if (pauseAnimation(500, PAUSE_BEHAVIOR_DEFAULT)) {
                     rogue.disturbed = true;
                 }
                 currentX = newX;
@@ -1938,7 +1938,8 @@ boolean explore(short frameDelay) {
             rogue.disturbed = true;
         } else {
             madeProgress = true;
-            if (pauseAnimation(frameDelay)) {
+            if (pauseAnimation(frameDelay, PAUSE_BEHAVIOR_DEFAULT)) {
+                
                 rogue.disturbed = true;
                 rogue.autoPlayingLevel = false;
             }
@@ -1992,7 +1993,7 @@ boolean startFighting(enum directions dir, boolean tillDeath) {
         if (!playerMoves(dir)) {
             break;
         }
-        if (pauseAnimation(1)) {
+        if (pauseAnimation(1, PAUSE_BEHAVIOR_DEFAULT)) {
             break;
         }
     } while (!rogue.disturbed && !rogue.gameHasEnded && (tillDeath || player.currentHP > expectedDamage)

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -777,7 +777,7 @@ static void seek(unsigned long seekTarget, enum recordingSeekModes seekMode) {
             printProgressBar((COLS - 20) / 2, ROWS / 2, "[     Loading...   ]",
                              rogue.playerTurnNumber - startTurnNumber,
                              targetTurnNumber - startTurnNumber, &darkPurple, false);
-            while (pauseBrogue(0)) { // pauseBrogue(0) is necessary to flush the display to the window in SDL
+            while (pauseBrogue(0, PAUSE_BEHAVIOR_DEFAULT)) { // pauseBrogue(0) is necessary to flush the display to the window in SDL
                 if (rogue.gameHasEnded) {
                     return;
                 }
@@ -1374,7 +1374,7 @@ boolean loadSavedGame() {
             if (recordingLocation / progressBarInterval != previousRecordingLocation / progressBarInterval && !rogue.playbackOOS) {
                 rogue.playbackFastForward = false; // so that pauseBrogue looks for inputs
                 printProgressBar((COLS - 20) / 2, ROWS / 2, "[     Loading...   ]", recordingLocation, lengthOfPlaybackFile, &darkPurple, false);
-                while (pauseBrogue(0)) { // pauseBrogue(0) is necessary to flush the display to the window in SDL, as well as look for inputs
+                while (pauseBrogue(0, PAUSE_BEHAVIOR_DEFAULT)) { // pauseBrogue(0) is necessary to flush the display to the window in SDL, as well as look for inputs
                     rogue.creaturesWillFlashThisTurn = false; // prevent monster flashes from showing up on screen
                     nextBrogueEvent(&theEvent, true, false, true);
                     if (rogue.gameHasEnded || theEvent.eventType == KEYSTROKE && theEvent.param1 == ESCAPE_KEY) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2885,7 +2885,16 @@ extern "C" {
                   short xLoc, short yLoc,
                   short backRed, short backGreen, short backBlue,
                   short foreRed, short foreGreen, short foreBlue);
-    boolean pauseForMilliseconds(short milliseconds);
+
+    typedef struct PauseBehavior {
+        /// If `interuptForMouseMove` is true, then the pause function will return `true`
+        /// if a mouse move occurs during the pause.
+        /// Otherwise, mouse movements will be ignored.
+        boolean interuptForMouseMove;
+    } PauseBehavior;
+#define PAUSE_BEHAVIOR_DEFAULT ((PauseBehavior) { .interuptForMouseMove = false })
+
+    boolean pauseForMilliseconds(short milliseconds, PauseBehavior behavior);
     boolean isApplicationActive(void);
     void nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance);
     void notifyEvent(short eventId, int data1, int data2, const char *str1, const char *str2);
@@ -2974,8 +2983,8 @@ extern "C" {
                                const char *promptSuffix,
                                short textEntryType,
                                boolean useDialogBox);
-    boolean pauseBrogue(short milliseconds);
-    boolean pauseAnimation(short milliseconds);
+    boolean pauseBrogue(short milliseconds, PauseBehavior behavior);
+    boolean pauseAnimation(short milliseconds, PauseBehavior behavior);
     void nextBrogueEvent(rogueEvent *returnEvent, boolean textInput, boolean colorsDance, boolean realInputEvenInPlayback);
     void executeMouseClick(rogueEvent *theEvent);
     void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKey);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2785,9 +2785,6 @@ typedef struct buttonState {
     short winY;
     short winWidth;
     short winHeight;
-
-    // Graphical buffers:
-    screenDisplayBuffer button_rbuf; // Reversion screen state.
 } buttonState;
 
 enum messageFlags {
@@ -3218,6 +3215,7 @@ extern "C" {
                        rogueEvent *event,
                        buttonState *state,
                        screenDisplayBuffer *button_dbuf,
+                       screenDisplayBuffer *button_rbuf,
                        boolean colorsDance,
                        boolean keysMoveCursor,
                        boolean targetCanLeaveMap);
@@ -3443,8 +3441,9 @@ extern "C" {
                                short winY,
                                short winWidth,
                                short winHeight,
-                               screenDisplayBuffer *button_dbuf);
-    short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event, screenDisplayBuffer *button_dbuf);
+                               screenDisplayBuffer *button_dbuf,
+                               screenDisplayBuffer *button_rbuf);
+    short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event, screenDisplayBuffer *button_dbuf, screenDisplayBuffer *button_rbuf);
     short smoothHiliteGradient(const short currentXValue, const short maxXValue);
     void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDisplayBuffer* dbuf);
     short buttonInputLoop(brogueButton *buttons,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2787,8 +2787,8 @@ typedef struct buttonState {
     short winHeight;
 
     // Graphical buffers:
-    screenDisplayBuffer dbuf; // Where buttons are drawn.
-    screenDisplayBuffer rbuf; // Reversion screen state.
+    screenDisplayBuffer button_dbuf; // Where buttons are drawn.
+    screenDisplayBuffer button_rbuf; // Reversion screen state.
 } buttonState;
 
 enum messageFlags {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3214,8 +3214,6 @@ extern "C" {
                        pos *targetLoc,
                        rogueEvent *event,
                        buttonState *state,
-                       screenDisplayBuffer *button_dbuf,
-                       screenDisplayBuffer *button_rbuf,
                        boolean colorsDance,
                        boolean keysMoveCursor,
                        boolean targetCanLeaveMap);
@@ -3442,7 +3440,7 @@ extern "C" {
                                short winWidth,
                                short winHeight);
     void maskOutBufferAlpha(screenDisplayBuffer *rbuf, const screenDisplayBuffer *dbuf);
-    short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event, screenDisplayBuffer *button_dbuf, screenDisplayBuffer *button_rbuf);
+    short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event);
     short smoothHiliteGradient(const short currentXValue, const short maxXValue);
     void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDisplayBuffer* dbuf);
     short buttonInputLoop(brogueButton *buttons,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3440,9 +3440,8 @@ extern "C" {
                                short winX,
                                short winY,
                                short winWidth,
-                               short winHeight,
-                               screenDisplayBuffer *button_dbuf,
-                               screenDisplayBuffer *button_rbuf);
+                               short winHeight);
+    void maskOutBufferAlpha(screenDisplayBuffer *rbuf, const screenDisplayBuffer *dbuf);
     short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event, screenDisplayBuffer *button_dbuf, screenDisplayBuffer *button_rbuf);
     short smoothHiliteGradient(const short currentXValue, const short maxXValue);
     void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDisplayBuffer* dbuf);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2787,7 +2787,6 @@ typedef struct buttonState {
     short winHeight;
 
     // Graphical buffers:
-    screenDisplayBuffer button_dbuf; // Where buttons are drawn.
     screenDisplayBuffer button_rbuf; // Reversion screen state.
 } buttonState;
 
@@ -3218,6 +3217,7 @@ extern "C" {
                        pos *targetLoc,
                        rogueEvent *event,
                        buttonState *state,
+                       screenDisplayBuffer *button_dbuf,
                        boolean colorsDance,
                        boolean keysMoveCursor,
                        boolean targetCanLeaveMap);
@@ -3435,15 +3435,16 @@ extern "C" {
     int printSeedCatalog(uint64_t startingSeed, uint64_t numberOfSeedsToScan, unsigned int scanThroughDepth, boolean isCsvFormat, char *errorMessage);
 
     void initializeButton(brogueButton *button);
-    void drawButtonsInState(buttonState *state);
+    void drawButtonsInState(buttonState *state, screenDisplayBuffer *button_dbuf);
     void initializeButtonState(buttonState *state,
                                brogueButton *buttons,
                                short buttonCount,
                                short winX,
                                short winY,
                                short winWidth,
-                               short winHeight);
-    short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event);
+                               short winHeight,
+                               screenDisplayBuffer *button_dbuf);
+    short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event, screenDisplayBuffer *button_dbuf);
     short smoothHiliteGradient(const short currentXValue, const short maxXValue);
     void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDisplayBuffer* dbuf);
     short buttonInputLoop(brogueButton *buttons,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3448,7 +3448,6 @@ extern "C" {
                                short winY,
                                short winWidth,
                                short winHeight);
-    void maskOutBufferAlpha(screenDisplayBuffer *rbuf, const screenDisplayBuffer *dbuf);
     short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *event);
     short smoothHiliteGradient(const short currentXValue, const short maxXValue);
     void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDisplayBuffer* dbuf);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1112,7 +1112,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     if (rogue.quit) {
         blackOutScreen();
     } else {
-        copyDisplayBuffer(&dbuf, &displayBuffer);
+        overlayDisplayBuffer(NULL, &dbuf);
         funkyFade(&dbuf, &black, 0, 120, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
     }
 
@@ -1214,7 +1214,7 @@ void victory(boolean superVictory) {
     //
     if (superVictory) {
         message(    "Light streams through the portal, and you are teleported out of the dungeon.", 0);
-        copyDisplayBuffer(&dbuf, &displayBuffer);
+        overlayDisplayBuffer(NULL, &dbuf);
         funkyFade(&dbuf, &superVictoryColor, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
         displayMoreSign();
         printString("Congratulations; you have transcended the Dungeons of Doom!                 ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
@@ -1224,7 +1224,7 @@ void victory(boolean superVictory) {
         strcpy(displayedMessage[0], "You retire in splendor, forever renowned for your remarkable triumph.     ");
     } else {
         message(    "You are bathed in sunlight as you throw open the heavy doors.", 0);
-        copyDisplayBuffer(&dbuf, &displayBuffer);
+        overlayDisplayBuffer(NULL, &dbuf);
         funkyFade(&dbuf, &white, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
         displayMoreSign();
         printString("Congratulations; you have escaped from the Dungeons of Doom!     ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -126,7 +126,7 @@ static void screen_update_benchmark() {
                 plotCharWithColor(theChar, (windowpos){ i, j }, &sparklesauce, &sparklesauce);
             }
         }
-        pauseBrogue(1);
+        pauseBrogue(1, PAUSE_BEHAVIOR_DEFAULT);
     }
     printf("\n\nBenchmark took a total of %lu seconds.\n", ((unsigned long) time(NULL)) - initialTime);
 }

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -2117,7 +2117,7 @@ void autoRest() {
             recordKeystroke(REST_KEY, false, false);
             rogue.justRested = true;
             playerTurnEnded();
-            if (dangerChanged(danger) || pauseAnimation(1)) {
+            if (dangerChanged(danger) || pauseAnimation(1, PAUSE_BEHAVIOR_DEFAULT)) {
                 rogue.disturbed = true;
             }
         }
@@ -2126,7 +2126,7 @@ void autoRest() {
             recordKeystroke(REST_KEY, false, false);
             rogue.justRested = true;
             playerTurnEnded();
-            if (dangerChanged(danger) || pauseAnimation(1)) {
+            if (dangerChanged(danger) || pauseAnimation(1, PAUSE_BEHAVIOR_DEFAULT)) {
                 rogue.disturbed = true;
             }
         }
@@ -2416,7 +2416,7 @@ void playerTurnEnded() {
                 monstersApproachStairs();
 
                 if (player.ticksUntilTurn > 100 && !fastForward) {
-                    fastForward = rogue.playbackFastForward || pauseAnimation(25);
+                    fastForward = rogue.playbackFastForward || pauseAnimation(25, PAUSE_BEHAVIOR_DEFAULT);
                 }
 
                 // Rolling waypoint refresh:
@@ -2540,7 +2540,7 @@ void playerTurnEnded() {
 
         if (player.status[STATUS_PARALYZED]) {
             if (!fastForward) {
-                fastForward = rogue.playbackFastForward || pauseAnimation(25);
+                fastForward = rogue.playbackFastForward || pauseAnimation(25, PAUSE_BEHAVIOR_DEFAULT);
             }
         }
 

--- a/src/platform/null-platform.c
+++ b/src/platform/null-platform.c
@@ -4,7 +4,7 @@ static void null_gameLoop() {
     exit(rogueMain());
 }
 
-static boolean null_pauseForMilliseconds(short milliseconds) {
+static boolean null_pauseForMilliseconds(short milliseconds, PauseBehavior behavior) {
     return false;
 }
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -42,7 +42,7 @@ struct brogueConsole {
     Pause the game, returning a boolean specifying whether an input event
     is available for receiving with nextKeyOrMouseEvent.
     */
-    boolean (*pauseForMilliseconds)(short milliseconds);
+    boolean (*pauseForMilliseconds)(short milliseconds, PauseBehavior behavior);
 
     /*
     Block until an event is available and then update returnEvent with

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -239,8 +239,8 @@ void nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInput, boolean col
     currentConsole.nextKeyOrMouseEvent(returnEvent, textInput, colorsDance);
 }
 
-boolean pauseForMilliseconds(short milliseconds) {
-    return currentConsole.pauseForMilliseconds(milliseconds);
+boolean pauseForMilliseconds(short milliseconds, PauseBehavior behavior) {
+    return currentConsole.pauseForMilliseconds(milliseconds, behavior);
 }
 
 void notifyEvent(short eventId, int data1, int data2, const char *str1, const char *str2) {

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -297,18 +297,18 @@ static void _delayUpTo(short ms) {
     lastDelayTime = SDL_GetTicks();
 }
 
-static boolean _pauseForMilliseconds(short ms) {
+static boolean _pauseForMilliseconds(short ms, PauseBehavior behavior) {
     updateScreen();
     _delayUpTo(ms);
 
     if (lastEvent.eventType != EVENT_ERROR
-        && lastEvent.eventType != MOUSE_ENTERED_CELL) {
+        && (lastEvent.eventType != MOUSE_ENTERED_CELL || behavior.interuptForMouseMove)) {
         return true; // SDL already gave us an interrupting event to process
     }
 
     return pollBrogueEvent(&lastEvent, false) // ask SDL for a new event if one is available
         && lastEvent.eventType != EVENT_ERROR // and check if it is interrupting
-        && lastEvent.eventType != MOUSE_ENTERED_CELL;
+        && (lastEvent.eventType != MOUSE_ENTERED_CELL || behavior.interuptForMouseMove);
 }
 
 


### PR DESCRIPTION
This is a refactor of the way that buttons are drawn and some button-related events are handled. The main idea is to remove `dbuf` and `rbuf` from the `buttonState` struct, and instead just re-render the buttons whenever they need to be added to the screen.

This gets rid of a lot of low-level logic for highlighting/unhighlighting buttons, and makes the behavior of saving/restoring the screen clearer, because it becomes more local, i.e. now you'll see this logic explicitly:

```C
// All in one block of code:

screenDisplayBuffer rbuf;
overlayDisplayBuffer(..., &rbuf); // save the original screen

// draw stuff & wait for input 
...

// Restore the screen to how it was before this block executed:
overlayDisplayBuffer(&rbuf, NULL);
```

effectively this is what was happening before, but figuring out the details required traveling through several layers of button-handling logic. In particular, it bothered me that the "initialize button state" function _also_ drew to the button buffer. This doesn't need to happen anymore.

---

I accidentally found and fixed an input handling bug on the main menu: because of the animated flame background, there are a lot of `pause(...)` loops on the title screen.

The `pause(...)` family of functions return `true` if there are new input events to handle. However, in order to avoid cancelling auto-explore, the SDL backend treats mouse-move events as not having happened. This means that you don't get "hovered" styling for buttons in the main menu, because it can't see any mouse movement events during the flame animation!

Therefore, all pausing functions now take a `PauseBehavior` which allows the caller to decide whether they want to treat mouse movement events as interruptions or not. Almost every existing call uses the old behavior.

**This affects platform implementations** because their pause function must now read the provided `PauseBehavior` argument. However, supporting this should be largely trivial (i.e. I already fixed the SDL platform in about 2 lines of code).

