### PR TITLE
Quietus and jelly slaying weapons kill jellies before they split

### DIFF
--- a/changes/jellies-must-die.md
+++ b/changes/jellies-must-die.md
@@ -1,0 +1,1 @@
+Jellies now die without splitting when hit with a slaying or quietus weapon.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1200,11 +1200,11 @@ boolean attack(creature *attacker, creature *defender, boolean lungeAttack) {
             }
         }
 
-        moralAttack(attacker, defender);
-
         if (attacker == &player && rogue.weapon && (rogue.weapon->flags & ITEM_RUNIC)) {
             magicWeaponHit(defender, rogue.weapon, sneakAttack || defenderWasAsleep || defenderWasParalyzed);
         }
+
+        moralAttack(attacker, defender);
 
         if (attacker == &player
             && (defender->bookkeepingFlags & MB_IS_DYING)


### PR DESCRIPTION
Fixes #91 

Jellies will now die without splitting when hit with a jelly slaying weapon or a weapon of quietus that procs.