### PR TITLE
Refactor screen save&restore logic

### DIFF
--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -273,14 +273,11 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
                             // Depress the chosen button.
 
                             // Update the display.
-                            screenDisplayBuffer rbuf;
+                            const SavedDisplayBuffer rbuf = saveDisplayBuffer();
                             screenDisplayBuffer dbuf;
                             clearDisplayBuffer(&dbuf);
                             drawButtonsInState(state, &dbuf);
-                            overlayDisplayBuffer(&dbuf, &rbuf);
-
-                            // overlayDisplayBuffer(button_rbuf, NULL);
-                            // overlayDisplayBuffer(button_dbuf, NULL);
+                            overlayDisplayBuffer(&dbuf);
 
                             if (!rogue.playbackMode || rogue.playbackPaused) {
                                 // Wait for a little; then we're done.
@@ -291,7 +288,7 @@ short processButtonInput(buttonState *state, boolean *canceled, rogueEvent *even
                             }
 
                             // Revert the display to its appearance before the button-press.
-                            overlayDisplayBuffer(&rbuf, NULL);
+                            restoreDisplayBuffer(&rbuf);
                         }
                     }
 
@@ -346,9 +343,9 @@ short buttonInputLoop(brogueButton *buttons,
         clearDisplayBuffer(&dbuf);
         drawButtonsInState(&state, &dbuf);
 
-        screenDisplayBuffer rbuf;
+        const SavedDisplayBuffer rbuf = saveDisplayBuffer();
         // Update the display.
-        overlayDisplayBuffer(&dbuf, &rbuf);
+        overlayDisplayBuffer(&dbuf);
 
         // Get input.
         nextBrogueEvent(&theEvent, true, false, false);
@@ -357,15 +354,13 @@ short buttonInputLoop(brogueButton *buttons,
         button = processButtonInput(&state, &canceled, &theEvent);
 
         // Revert the display.
-        overlayDisplayBuffer(&rbuf, NULL);
+        restoreDisplayBuffer(&rbuf);
 
     } while (button == -1 && !canceled);
 
     if (returnEvent) {
         *returnEvent = theEvent;
     }
-
-    //overlayDisplayBuffer(dbuf, NULL); // hangs around
 
     restoreRNG;
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2702,8 +2702,6 @@ char displayInventory(unsigned short categoryMask,
     rogueEvent theEvent;
     boolean magicDetected, repeatDisplay;
     short highlightItemLine, itemSpaceRemaining;
-    screenDisplayBuffer dbuf;
-    screenDisplayBuffer rbuf;
     brogueButton buttons[50] = {{{0}}};
     short actionKey = -1;
     color darkItemColor;
@@ -2719,6 +2717,9 @@ char displayInventory(unsigned short categoryMask,
     assureCosmeticRNG;
 
     clearCursorPath();
+
+    
+    screenDisplayBuffer dbuf;
     clearDisplayBuffer(&dbuf);
 
     whiteColorEscapeSequence[0] = '\0';
@@ -2930,14 +2931,15 @@ char displayInventory(unsigned short categoryMask,
     buttons[itemNumber + extraLineCount + 1].hotkey[0] = NUMPAD_2;
     buttons[itemNumber + extraLineCount + 1].hotkey[1] = DOWN_ARROW;
 
-    overlayDisplayBuffer(&dbuf, &rbuf);
+    const SavedDisplayBuffer rbuf = saveDisplayBuffer();
+    overlayDisplayBuffer(&dbuf);
 
     do {
         repeatDisplay = false;
 
         // Do the button loop.
         highlightItemLine = -1;
-        overlayDisplayBuffer(&rbuf, NULL);   // Remove the inventory display while the buttons are active,
+        restoreDisplayBuffer(&rbuf);   // Remove the inventory display while the buttons are active,
                                             // since they look the same and we don't want their opacities to stack.
 
         highlightItemLine = buttonInputLoop(buttons,
@@ -2970,7 +2972,7 @@ char displayInventory(unsigned short categoryMask,
             do {
                 // Yes. Highlight the selected item. Do this by changing the button color and re-displaying it.
 
-                overlayDisplayBuffer(&dbuf, NULL);
+                overlayDisplayBuffer(&dbuf);
 
                 //buttons[highlightItemLine].buttonColor = interfaceBoxColor;
                 drawButton(&(buttons[highlightItemLine]), BUTTON_PRESSED, NULL);
@@ -2980,15 +2982,15 @@ char displayInventory(unsigned short categoryMask,
                     // Display an information window about the item.
                     actionKey = printCarriedItemDetails(theItem, max(2, mapToWindowX(DCOLS - maxLength - 42)), mapToWindowY(2), 40, includeButtons);
 
-                    overlayDisplayBuffer(&rbuf, NULL); // remove the item info window
+                    restoreDisplayBuffer(&rbuf); // remove the item info window
 
                     if (actionKey == -1) {
                         repeatDisplay = true;
-                        overlayDisplayBuffer(&dbuf, NULL); // redisplay the inventory
+                        overlayDisplayBuffer(&dbuf); // redisplay the inventory
                     } else {
                         restoreRNG;
                         repeatDisplay = false;
-                        overlayDisplayBuffer(&rbuf, NULL); // restore the original screen
+                        restoreDisplayBuffer(&rbuf); // restore the original screen
                     }
 
                     switch (actionKey) {
@@ -3042,7 +3044,7 @@ char displayInventory(unsigned short categoryMask,
         }
     } while (repeatDisplay); // so you can get info on multiple items sequentially
 
-    overlayDisplayBuffer(&rbuf, NULL); // restore the original screen
+    restoreDisplayBuffer(&rbuf); // restore the original screen
 
     restoreRNG;
     return theKey;
@@ -5262,9 +5264,9 @@ boolean moveCursor(boolean *targetConfirmed,
             clearDisplayBuffer(&dbuf);
             drawButtonsInState(state, &dbuf);
 
-            screenDisplayBuffer rbuf;
+            const SavedDisplayBuffer rbuf = saveDisplayBuffer();
             // Update the display.
-            overlayDisplayBuffer(&dbuf, &rbuf);
+            overlayDisplayBuffer(&dbuf);
 
             // Get input.
             nextBrogueEvent(&theEvent, false, colorsDance, true);
@@ -5277,7 +5279,7 @@ boolean moveCursor(boolean *targetConfirmed,
             }
 
             // Revert the display.
-            overlayDisplayBuffer(&rbuf, NULL);
+            restoreDisplayBuffer(&rbuf);
 
         } else { // No buttons to worry about.
             nextBrogueEvent(&theEvent, false, colorsDance, true);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2978,7 +2978,7 @@ char displayInventory(unsigned short categoryMask,
 
                 if (theEvent.shiftKey || theEvent.controlKey || waitForAcknowledge) {
                     // Display an information window about the item.
-                    actionKey = printCarriedItemDetails(theItem, max(2, mapToWindowX(DCOLS - maxLength - 42)), mapToWindowY(2), 40, includeButtons, NULL);
+                    actionKey = printCarriedItemDetails(theItem, max(2, mapToWindowX(DCOLS - maxLength - 42)), mapToWindowY(2), 40, includeButtons);
 
                     overlayDisplayBuffer(&rbuf, NULL); // remove the item info window
 

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -401,11 +401,12 @@ static void chooseGameVariant() {
     append(textBuf, "Die faster and more often in this quarter-length version of the classic game!\n\n", TEXT_MAX_LENGTH);
 
     brogueButton buttons[2];
-    screenDisplayBuffer rbuf;
-    overlayDisplayBuffer(NULL, &rbuf);
     initializeMainMenuButton(&(buttons[0]), "  %sR%sapid Brogue     ", 'r', 'R', NG_NOTHING);
     initializeMainMenuButton(&(buttons[1]), "     %sB%srogue        ", 'b', 'B', NG_NOTHING);
-    gameVariantChoice = printTextBox(textBuf, 20, 7, 45, &white, &black, &rbuf, buttons, 2);
+    
+    screenDisplayBuffer rbuf;
+    overlayDisplayBuffer(NULL, &rbuf);
+    gameVariantChoice = printTextBox(textBuf, 20, 7, 45, &white, &black, buttons, 2);
     overlayDisplayBuffer(&rbuf, NULL);
 
     if (gameVariantChoice == 1) {
@@ -441,12 +442,12 @@ static void chooseGameMode() {
                     "(Your score is not saved.)", TEXT_MAX_LENGTH);
 
     brogueButton buttons[3];
-    screenDisplayBuffer rbuf;
-    overlayDisplayBuffer(NULL, &rbuf);
     initializeMainMenuButton(&(buttons[0]), "      %sW%sizard       ", 'w', 'W', NG_NOTHING);
     initializeMainMenuButton(&(buttons[1]), "       %sE%sasy        ", 'e', 'E', NG_NOTHING);
     initializeMainMenuButton(&(buttons[2]), "      %sN%sormal       ", 'n', 'N', NG_NOTHING);
-    gameMode = printTextBox(textBuf, 10, 5, 66, &white, &black, &rbuf, buttons, 3);
+    screenDisplayBuffer rbuf;
+    overlayDisplayBuffer(NULL, &rbuf);
+    gameMode = printTextBox(textBuf, 10, 5, 66, &white, &black, buttons, 3);
     overlayDisplayBuffer(&rbuf, NULL);
     if (gameMode == 0) {
         rogue.wizard = true;
@@ -634,14 +635,15 @@ int quitImmediately() {
 }
 
 void dialogAlert(char *message) {
-    screenDisplayBuffer rbuf;
 
     brogueButton OKButton;
     initializeButton(&OKButton);
     strcpy(OKButton.text, "     OK     ");
     OKButton.hotkey[0] = RETURN_KEY;
     OKButton.hotkey[1] = ACKNOWLEDGE_KEY;
-    printTextBox(message, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, &rbuf, &OKButton, 1);
+    screenDisplayBuffer rbuf;
+    overlayDisplayBuffer(NULL, &rbuf);
+    printTextBox(message, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, &OKButton, 1);
     overlayDisplayBuffer(&rbuf, NULL);
 }
 

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -404,10 +404,9 @@ static void chooseGameVariant() {
     initializeMainMenuButton(&(buttons[0]), "  %sR%sapid Brogue     ", 'r', 'R', NG_NOTHING);
     initializeMainMenuButton(&(buttons[1]), "     %sB%srogue        ", 'b', 'B', NG_NOTHING);
     
-    screenDisplayBuffer rbuf;
-    overlayDisplayBuffer(NULL, &rbuf);
+    const SavedDisplayBuffer rbuf = saveDisplayBuffer();
     gameVariantChoice = printTextBox(textBuf, 20, 7, 45, &white, &black, buttons, 2);
-    overlayDisplayBuffer(&rbuf, NULL);
+    restoreDisplayBuffer(&rbuf);
 
     if (gameVariantChoice == 1) {
         gameVariant = VARIANT_BROGUE;
@@ -445,10 +444,9 @@ static void chooseGameMode() {
     initializeMainMenuButton(&(buttons[0]), "      %sW%sizard       ", 'w', 'W', NG_NOTHING);
     initializeMainMenuButton(&(buttons[1]), "       %sE%sasy        ", 'e', 'E', NG_NOTHING);
     initializeMainMenuButton(&(buttons[2]), "      %sN%sormal       ", 'n', 'N', NG_NOTHING);
-    screenDisplayBuffer rbuf;
-    overlayDisplayBuffer(NULL, &rbuf);
+    const SavedDisplayBuffer rbuf = saveDisplayBuffer();
     gameMode = printTextBox(textBuf, 10, 5, 66, &white, &black, buttons, 3);
-    overlayDisplayBuffer(&rbuf, NULL);
+    restoreDisplayBuffer(&rbuf);
     if (gameMode == 0) {
         rogue.wizard = true;
         rogue.easyMode = false;
@@ -555,21 +553,21 @@ static void titleMenu() {
                 // Update the display.
                 updateMenuFlames(colors, colorSources, flames);
                 drawMenuFlames(flames, mask);
-                overlayDisplayBuffer(&mainShadowBuf, NULL);
+                overlayDisplayBuffer(&mainShadowBuf);
 
                 // Draw the main menu buttons
                 screenDisplayBuffer dbuf;
                 clearDisplayBuffer(&dbuf);
                 redrawMainMenuButtons(&mainMenu, &dbuf);
-                overlayDisplayBuffer(&dbuf, NULL);
+                overlayDisplayBuffer(&dbuf);
 
                 //Show flyout if selected
                 if (isFlyoutActive()) {
-                    overlayDisplayBuffer(&flyoutShadowBuf, NULL);
+                    overlayDisplayBuffer(&flyoutShadowBuf);
                     screenDisplayBuffer flyout_dbuf;
                     clearDisplayBuffer(&flyout_dbuf);
                     drawButtonsInState(&flyoutMenu, &flyout_dbuf);
-                    overlayDisplayBuffer(&flyout_dbuf, NULL);
+                    overlayDisplayBuffer(&flyout_dbuf);
                     mainMenu.buttonDepressed = -1;
                     mainMenu.buttonFocused = -1;
                 }
@@ -641,10 +639,9 @@ void dialogAlert(char *message) {
     strcpy(OKButton.text, "     OK     ");
     OKButton.hotkey[0] = RETURN_KEY;
     OKButton.hotkey[1] = ACKNOWLEDGE_KEY;
-    screenDisplayBuffer rbuf;
-    overlayDisplayBuffer(NULL, &rbuf);
+    const SavedDisplayBuffer rbuf = saveDisplayBuffer();
     printTextBox(message, COLS/3, ROWS/3, COLS/3, &white, &interfaceBoxColor, &OKButton, 1);
-    overlayDisplayBuffer(&rbuf, NULL);
+    restoreDisplayBuffer(&rbuf);
 }
 
 static boolean stringsExactlyMatch(const char *string1, const char *string2) {
@@ -691,14 +688,14 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
     fileEntry *files;
     boolean retval = false, again;
     screenDisplayBuffer dbuf;
-    screenDisplayBuffer rbuf;
+    
     const color *dialogColor = &interfaceBoxColor;
     char *membuf;
     char fileDate [11];
 
     suffixLength = strlen(suffix);
     files = listFiles(&count, &membuf);
-    overlayDisplayBuffer(NULL, &rbuf);
+    const SavedDisplayBuffer rbuf = saveDisplayBuffer();
     maxPathLength = strLenWithoutEscapes(prompt);
 
     // First, we want to filter the list by stripping out any filenames that do not end with suffix.
@@ -808,7 +805,7 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
             clearDisplayBuffer(&dbuf);
             printString(prompt, x, y - 1, &itemMessageColor, dialogColor, &dbuf);
             rectangularShading(x - 1, y - 1, width + 1, height + 1, dialogColor, INTERFACE_OPACITY, &dbuf);
-            overlayDisplayBuffer(&dbuf, NULL);
+            overlayDisplayBuffer(&dbuf);
 
 //          for (j=0; j<min(count - currentPageStart, FILES_ON_PAGE_MAX); j++) {
 //              strftime(fileDate, sizeof(fileDate), DATE_FORMAT, &files[currentPageStart+j].date);
@@ -830,7 +827,7 @@ boolean dialogChooseFile(char *path, const char *suffix, const char *prompt) {
 //              printf("\n   (button name)Sanity check AFTER: %s", buttons[j].text);
 //          }
 
-            overlayDisplayBuffer(&rbuf, NULL);
+            restoreDisplayBuffer(&rbuf);
 
             if (i < min(count - currentPageStart, FILES_ON_PAGE_MAX)) {
                 if (i >= 0) {

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -2099,7 +2099,6 @@ boolean useStairs(short stairDirection) {
 
     if (stairDirection == 1) {
         if (rogue.depthLevel < gameConst->deepestLevel) {
-            //overlayDisplayBuffer(NULL, fromBuf);
             rogue.cursorLoc = INVALID_POS;
             rogue.depthLevel++;
             message("You descend.", 0);
@@ -2124,10 +2123,8 @@ boolean useStairs(short stairDirection) {
             if (rogue.depthLevel == 0) {
                 victory(false);
             } else {
-                //overlayDisplayBuffer(NULL, fromBuf);
                 message("You ascend.", 0);
                 startLevel(rogue.depthLevel + 1, stairDirection);
-                //overlayDisplayBuffer(NULL, toBuf);
                 //irisFadeBetweenBuffers(fromBuf, toBuf, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), 20, true);
             }
             succeeded = true;

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -316,15 +316,14 @@ static void playbackPanic() {
         confirmMessages();
         message("Playback is out of sync.", 0);
 
-        screenDisplayBuffer rbuf;
-        overlayDisplayBuffer(NULL, &rbuf);
+        const SavedDisplayBuffer rbuf = saveDisplayBuffer();
         printTextBox(OOS_APOLOGY, 0, 0, 0, &white, &black, NULL, 0);
 
         rogue.playbackMode = false;
         displayMoreSign();
         rogue.playbackMode = true;
 
-        overlayDisplayBuffer(&rbuf, NULL);
+        restoreDisplayBuffer(&rbuf);
 
         if (nonInteractivePlayback) {
             rogue.gameHasEnded = true;
@@ -332,7 +331,7 @@ static void playbackPanic() {
         rogue.gameExitStatusCode = EXIT_STATUS_FAILURE_RECORDING_OOS;
 
         printf("Playback panic at location %li! Turn number %li.\n", recordingLocation - 1, rogue.playerTurnNumber);
-        overlayDisplayBuffer(&rbuf, NULL);
+        restoreDisplayBuffer(&rbuf);
 
         mainInputLoop();
     }
@@ -440,15 +439,14 @@ void displayAnnotation() {
         if (!rogue.playbackFastForward) {
             refreshSideBar(-1, -1, false);
 
-            screenDisplayBuffer rbuf;
-            overlayDisplayBuffer(NULL, &rbuf);
+            const SavedDisplayBuffer rbuf = saveDisplayBuffer();
             printTextBox(rogue.nextAnnotation, player.loc.x, 0, 0, &black, &white, NULL, 0);
 
             rogue.playbackMode = false;
             displayMoreSign();
             rogue.playbackMode = true;
 
-            overlayDisplayBuffer(&rbuf, NULL);
+            restoreDisplayBuffer(&rbuf);
         }
 
         loadNextAnnotation();
@@ -641,7 +639,6 @@ static boolean unpause() {
 static void printPlaybackHelpScreen() {
     short i, j;
     screenDisplayBuffer dbuf;
-    screenDisplayBuffer rbuf;
     char helpText[PLAYBACK_HELP_LINE_COUNT][80] = {
         "Commands:",
         "",
@@ -685,12 +682,14 @@ static void printPlaybackHelpScreen() {
             dbuf.cells[i][j].opacity = (i < STAT_BAR_WIDTH ? 0 : INTERFACE_OPACITY);
         }
     }
-    overlayDisplayBuffer(&dbuf, &rbuf);
+
+    const SavedDisplayBuffer rbuf = saveDisplayBuffer();
+    overlayDisplayBuffer(&dbuf);
 
     rogue.playbackMode = false;
     waitForAcknowledgment();
     rogue.playbackMode = true;
-    overlayDisplayBuffer(&rbuf, NULL);
+    restoreDisplayBuffer(&rbuf);
 }
 
 static void resetPlayback() {
@@ -767,7 +766,7 @@ static void seek(unsigned long seekTarget, enum recordingSeekModes seekMode) {
     if (useProgressBar) {
         clearDisplayBuffer(&dbuf);
         rectangularShading((COLS - 20) / 2, ROWS / 2, 20, 1, &black, INTERFACE_OPACITY, &dbuf);
-        overlayDisplayBuffer(&dbuf, NULL);
+        overlayDisplayBuffer(&dbuf);
         commitDraws();
     }
     rogue.playbackFastForward = true;
@@ -1358,7 +1357,7 @@ boolean loadSavedGame() {
         clearDisplayBuffer(&dbuf);
         rectangularShading((COLS - 20) / 2, ROWS / 2, 20, 1, &black, INTERFACE_OPACITY, &dbuf);
         rogue.playbackFastForward = false;
-        overlayDisplayBuffer(&dbuf, NULL);
+        overlayDisplayBuffer(&dbuf);
         rogue.playbackFastForward = true;
 
         while (recordingLocation < lengthOfPlaybackFile

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -303,7 +303,6 @@ If this is a different computer from the one on which the recording was saved, t
 might succeed on the original computer."
 
 static void playbackPanic() {
-    screenDisplayBuffer rbuf;
 
     if (!rogue.playbackOOS) {
         rogue.playbackFastForward = false;
@@ -317,7 +316,9 @@ static void playbackPanic() {
         confirmMessages();
         message("Playback is out of sync.", 0);
 
-        printTextBox(OOS_APOLOGY, 0, 0, 0, &white, &black, &rbuf, NULL, 0);
+        screenDisplayBuffer rbuf;
+        overlayDisplayBuffer(NULL, &rbuf);
+        printTextBox(OOS_APOLOGY, 0, 0, 0, &white, &black, NULL, 0);
 
         rogue.playbackMode = false;
         displayMoreSign();
@@ -433,15 +434,15 @@ static void loadNextAnnotation() {
 }
 
 void displayAnnotation() {
-    screenDisplayBuffer rbuf;
-
     if (rogue.playbackMode
         && rogue.playerTurnNumber == rogue.nextAnnotationTurn) {
 
         if (!rogue.playbackFastForward) {
             refreshSideBar(-1, -1, false);
 
-            printTextBox(rogue.nextAnnotation, player.loc.x, 0, 0, &black, &white, &rbuf, NULL, 0);
+            screenDisplayBuffer rbuf;
+            overlayDisplayBuffer(NULL, &rbuf);
+            printTextBox(rogue.nextAnnotation, player.loc.x, 0, 0, &black, &white, NULL, 0);
 
             rogue.playbackMode = false;
             displayMoreSign();

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2965,8 +2965,16 @@ extern "C" {
     void colorOverDungeon(const color *color);
     void copyDisplayBuffer(screenDisplayBuffer *toBuf, screenDisplayBuffer *fromBuf);
     void clearDisplayBuffer(screenDisplayBuffer *dbuf);
-    color colorFromComponents(char rgb[3]);
-    void overlayDisplayBuffer(screenDisplayBuffer *overBuf, screenDisplayBuffer *previousBuf);
+    color colorFromComponents(const char rgb[3]);
+    // A `SavedDisplayBuffer` holds a previous version of the screen. It can be
+    // Obtain one by calling `saveDisplayBuffer()` and restore it to the screen
+    // by calling `restoreDisplayBuffer()`.
+    typedef struct SavedDisplayBuffer {
+        screenDisplayBuffer savedScreen;
+    } SavedDisplayBuffer;
+    SavedDisplayBuffer saveDisplayBuffer(void);
+    void restoreDisplayBuffer(const SavedDisplayBuffer *savedBuf);
+    void overlayDisplayBuffer(const screenDisplayBuffer *overBuf);
     void flashForeground(short *x, short *y, const color **flashColor, short *flashStrength, short count, short frames);
     void flashCell(const color *theColor, short frames, short x, short y);
     void colorFlash(const color *theColor, unsigned long reqTerrainFlags, unsigned long reqTileFlags, short frames, short maxRadius, short x, short y);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2923,15 +2923,13 @@ extern "C" {
                             const color *backColor, short opacity, screenDisplayBuffer *dbuf);
     short printTextBox(char *textBuf, short x, short y, short width,
                        const color *foreColor, const color *backColor,
-                       screenDisplayBuffer *rbuf,
                        brogueButton *buttons, short buttonCount);
     void setButtonText(brogueButton *button, const char *textWithHotkey, const char *textWithoutHotkey);
-    void printMonsterDetails(creature *monst, screenDisplayBuffer* rbuf);
-    void printFloorItemDetails(item *theItem, screenDisplayBuffer* rbuf);
+    void printMonsterDetails(creature *monst);
+    void printFloorItemDetails(item *theItem);
     unsigned long printCarriedItemDetails(item *theItem,
                                           short x, short y, short width,
-                                          boolean includeButtons,
-                                          screenDisplayBuffer* rbuf);
+                                          boolean includeButtons);
     void funkyFade(screenDisplayBuffer *displayBuf, const color *colorStart, const color *colorEnd, short stepCount, short x, short y, boolean invert);
     void displayCenteredAlert(char *message);
     void flashMessage(char *message, short x, short y, int time, const color *fColor, const color *bColor);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1025,7 +1025,6 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     short i, y;
     char buf[200], highScoreText[200], buf2[200];
     rogueHighScoresEntry theEntry;
-    screenDisplayBuffer dbuf;
     boolean playback;
     rogueEvent theEvent;
     item *theItem;
@@ -1112,7 +1111,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     if (rogue.quit) {
         blackOutScreen();
     } else {
-        overlayDisplayBuffer(NULL, &dbuf);
+        screenDisplayBuffer dbuf = displayBuffer;
         funkyFade(&dbuf, &black, 0, 120, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
     }
 
@@ -1198,7 +1197,7 @@ void victory(boolean superVictory) {
     unsigned long totalValue = 0;
     rogueHighScoresEntry theEntry;
     boolean qualified, isPlayback;
-    screenDisplayBuffer dbuf;
+    
     char recordingFilename[BROGUE_FILENAME_MAX] = {0};
 
     rogue.gameInProgress = false;
@@ -1214,7 +1213,7 @@ void victory(boolean superVictory) {
     //
     if (superVictory) {
         message(    "Light streams through the portal, and you are teleported out of the dungeon.", 0);
-        overlayDisplayBuffer(NULL, &dbuf);
+        screenDisplayBuffer dbuf = displayBuffer;
         funkyFade(&dbuf, &superVictoryColor, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
         displayMoreSign();
         printString("Congratulations; you have transcended the Dungeons of Doom!                 ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
@@ -1224,15 +1223,17 @@ void victory(boolean superVictory) {
         strcpy(displayedMessage[0], "You retire in splendor, forever renowned for your remarkable triumph.     ");
     } else {
         message(    "You are bathed in sunlight as you throw open the heavy doors.", 0);
-        overlayDisplayBuffer(NULL, &dbuf);
+        screenDisplayBuffer dbuf = displayBuffer;
         funkyFade(&dbuf, &white, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
         displayMoreSign();
         printString("Congratulations; you have escaped from the Dungeons of Doom!     ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
         displayMoreSign();
-        clearDisplayBuffer(&dbuf);
         deleteMessages();
         strcpy(displayedMessage[0], "You sell your treasures and live out your days in fame and glory.");
     }
+
+    screenDisplayBuffer dbuf;
+    clearDisplayBuffer(&dbuf);
 
     //
     // Second screen - Show inventory and item's value

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -44,7 +44,6 @@ static short dialogSelectEntryFromList(
 
     short x=0, y=0, width=0, height=0;
     screenDisplayBuffer dbuf;
-    screenDisplayBuffer rbuf;
     short i, selectedButton, len, maxLen;
     char buttonText[COLS];
 
@@ -78,11 +77,12 @@ static short dialogSelectEntryFromList(
     //Dialog background
     rectangularShading(x - 1, y - 1, width + 1, height + 1, &interfaceBoxColor, INTERFACE_OPACITY, &dbuf);
     //Display the title/background and save the prior display state
-    overlayDisplayBuffer(&dbuf, &rbuf);
+    const SavedDisplayBuffer rbuf = saveDisplayBuffer();
+    overlayDisplayBuffer(&dbuf);
     //Display the buttons and wait for user selection
     selectedButton = buttonInputLoop(buttons, buttonCount, x, y, width, height, NULL);
     //Revert the display state
-    overlayDisplayBuffer(&rbuf, NULL);
+    restoreDisplayBuffer(&rbuf);
 
     return selectedButton;
 }


### PR DESCRIPTION
This PR is only refactoring; it should not cause any visible changes.

---

A common pattern in the Brogue codebase is to do the following:

```c
screenDisplayBuffer dbuf;
screenDisplayBuffer rbuf;

clearDisplayBuffer(&dbuf);
fillBufferWithSomeKindOfGraphics(&dbuf); // some arbitrary logic

overlayDisplayBuffer(&dbuf, &rbuf);

// ... wait for events or something ...

overlayDisplayBuffer(&rbuf, NULL); // put the screen back
```

The second argument to `overlayDisplayBuffer` is used to store the old screen, so that drawn graphics can be reverted later. This is convenient, but it makes `dbuf` and `rbuf` usage look very similar, since they're both just `screenDisplayBuffer`s.

We can make the distinction clearer by introducing new functions:

```c
// A `SavedDisplayBuffer` holds a previous version of the screen. It can be
// Obtain one by calling `saveDisplayBuffer()` and restore it to the screen
// by calling `restoreDisplayBuffer()`.
typedef struct SavedDisplayBuffer {
  screenDisplayBuffer savedScreen;
} SavedDisplayBuffer;
SavedDisplayBuffer saveDisplayBuffer(void);
void restoreDisplayBuffer(const SavedDisplayBuffer *savedBuf);

// Now, `overlayDisplayBuffer` does not have a second reset pattern:
void overlayDisplayBuffer(const screenDisplayBuffer *overBuf);
```

The common pattern at the top can now be spelled as:

```c
const SavedDisplayBuffer rbuf = saveDisplayBuffer();

screenDisplayBuffer dbuf;
clearDisplayBuffer(&dbuf);
fillBufferWithSomeKindOfGraphics(&dbuf); // some arbitrary logic

overlayDisplayBuffer(&dbuf);

// ... wait for events or something ...

restoreDisplayBuffer(&rbuf); // put the screen back
```

in particular, with a few exceptions, `saveDisplayBuffer()` is now always called in the same function that calls `restoreDisplayBuffer`, on the same variable. This makes it relatively easy to ensure that the screen is always getting restored when we mean it to, and less code-tracing across multiple functions is needed.

---

From this change, the number of calls of `overlayDisplayBuffer` drops from 60 to 23. So we see that actually many of its calls were *solely* for saving/restoring the state of the screen, mixed in with calls that actually draw new graphics to the screen.