### PR TITLE
Prevent spear and whip attacks around corners

### DIFF
--- a/changes/prevent-spear-attacks-around-corners.md
+++ b/changes/prevent-spear-attacks-around-corners.md
@@ -1,0 +1,1 @@
+Prevent monsters with a spear or whip attack from attacking around corners

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -582,6 +582,13 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
     }
     pos originLoc = attacker->loc;
     pos targetLoc = posNeighborInDirection(attacker->loc, dir);
+
+    // The neighboring position in the attack direction must not be diagonally blocked.
+    // Generally speaking, the attacker must be able to move one tile in the attack direction.
+    if (diagonalBlocked(originLoc.x, originLoc.y, targetLoc.x, targetLoc.y, attacker == &player)) {
+        return false;
+    }
+
     pos strikeLoc;
     getImpactLoc(&strikeLoc, originLoc, targetLoc, 5, false, &boltCatalog[BOLT_WHIP]);
 
@@ -628,6 +635,13 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
             return false;
         }
     } else if (!(attacker->info.abilityFlags & MA_ATTACKS_PENETRATE)) {
+        return false;
+    }
+
+    // The neighboring position in the attack direction must not be diagonally blocked
+    // Generally speaking, the attacker must be able to move one tile in the attack direction.
+    pos neighborLoc = posNeighborInDirection(attacker->loc, dir);
+    if (diagonalBlocked(attacker->loc.x, attacker->loc.y, neighborLoc.x, neighborLoc.y, attacker == &player)) {
         return false;
     }
 


### PR DESCRIPTION
Fixes #103 

I find the move/attack logic to be mind-bendingly complex and I won't say how long I spent on this one. Anyway, it turns out that spear/whip attacks were being treated differently for discordant monsters vs. hunting monsters vs. allies.

This fix adds a check on the neighboring tile in the direction of attack. The attacker must generally be able move to the tile. In the screenshot below, the player can attack the goblin but goblin cannot attack the player. Before the fix, if the goblin was discordant it would happily attack the player. Also, if the player was instead an enemy monster and the goblin was an ally, previously the goblin would happily attack.


![image](https://github.com/tmewett/BrogueCE/assets/71573970/a8055c7f-3063-4371-a8f1-8cb7a9052780)
