### PR TITLE
Player can hit an adjacent submerged monster with a staff or wand

### DIFF
--- a/changes/zap-adjacent-submerged.md
+++ b/changes/zap-adjacent-submerged.md
@@ -1,0 +1,2 @@
+A submerged player can now target an adjacent submerged monster with a staff or wand. If a non-adjacent submerged monster is manually targeted, the monster cell highlight color changes to a muted white. 
+The monster details window now informs the player when a submerged monster cannot be targeted with a staff or wand. 

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -4340,18 +4340,26 @@ void monsterDetails(char buf[], creature *monst) {
     upperCase(newText);
     strcat(buf, newText);
 
-    for (theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
-        if (staffOrWandEffectOnMonsterDescription(newText, theItem, monst)) {
-            if (boltEffectForItem(theItem) == BE_DOMINATION) {
-                if (alreadyDisplayedDominationText) {
-                    continue;
-                } else {
-                    alreadyDisplayedDominationText = true;
-                }
-            }
+    // Staff and wand effects 
+    if (rogue.inWater && (monst->bookkeepingFlags & MB_SUBMERGED) && !playerCanTargetSubmergedMonster(monst)) {
+        sprintf(newText, "\n     %s is submerged and cannot be hit by a staff or wand.", capMonstName);
             i = strlen(buf);
             i = encodeMessageColor(buf, i, &itemMessageColor);
             strcat(buf, newText);
+    } else {
+        for (theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+            if (staffOrWandEffectOnMonsterDescription(newText, theItem, monst)) {
+                if (boltEffectForItem(theItem) == BE_DOMINATION) {
+                    if (alreadyDisplayedDominationText) {
+                        continue;
+                    } else {
+                        alreadyDisplayedDominationText = true;
+                    }
+                }
+                i = strlen(buf);
+                i = encodeMessageColor(buf, i, &itemMessageColor);
+                strcat(buf, newText);
+            }
         }
     }
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3170,6 +3170,7 @@ extern "C" {
     boolean monsterIsHidden(const creature *monst, const creature *observer);
     boolean canSeeMonster(creature *monst);
     boolean canDirectlySeeMonster(creature *monst);
+    boolean playerCanTargetSubmergedMonster(creature *monst);
     void monsterName(char *buf, creature *monst, boolean includeArticle);
     boolean monsterIsInClass(const creature *monst, const short monsterClass);
     boolean chooseTarget(pos *returnLoc, short maxDistance, boolean stopAtTarget, boolean autoTarget,


### PR DESCRIPTION
Fixes #578 

- A submerged player can now target an adjacent submerged monster with a staff or wand. 
- If a non-adjacent submerged monster is manually targeted, the monster cell highlight color changes to a muted white. 
- The monster details window now informs the player when a submerged monster cannot be targeted with a staff or wand. 