### PR TITLE
Move letters off the grid to make text more readable

### DIFF
--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -115,6 +115,9 @@ void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDis
             if (dbuf) {
                 // Only buffers can have opacity set.
                 dbuf->cells[button->x + i][button->y].opacity = opacity;
+                dbuf->cells[button->x + i][button->y].textInfo = (CellTextInfo) { .mode = 1, .firstColumn = button->x };
+            } else {
+                displayBuffer.cells[button->x + i][button->y].textInfo = (CellTextInfo) { .mode = 1, .firstColumn = button->x };
             }
         }
     }

--- a/src/brogue/Buttons.c
+++ b/src/brogue/Buttons.c
@@ -77,6 +77,12 @@ void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDis
 
     short symbolNumber = 0;
 
+    CellTextInfo buttonTextInfo = (CellTextInfo) {
+        .mode = 2,
+        .firstColumn = button->x,
+        .lastColumn = button->x + width - 1,
+    };
+
     for (int i = 0, textLoc = 0; i < width && i + button->x < COLS; i++, textLoc++) {
         while (button->text[textLoc] == COLOR_ESCAPE) {
             textLoc = decodeMessageColor(button->text, textLoc, &fColorBase);
@@ -115,9 +121,9 @@ void drawButton(brogueButton *button, enum buttonDrawStates highlight, screenDis
             if (dbuf) {
                 // Only buffers can have opacity set.
                 dbuf->cells[button->x + i][button->y].opacity = opacity;
-                dbuf->cells[button->x + i][button->y].textInfo = (CellTextInfo) { .mode = 1, .firstColumn = button->x };
+                dbuf->cells[button->x + i][button->y].textInfo = buttonTextInfo;
             } else {
-                displayBuffer.cells[button->x + i][button->y].textInfo = (CellTextInfo) { .mode = 1, .firstColumn = button->x };
+                displayBuffer.cells[button->x + i][button->y].textInfo = buttonTextInfo;
             }
         }
     }

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -1814,9 +1814,9 @@ void plotCharWithColorAndTextInfo(enum displayGlyph inputChar, windowpos loc, co
     target->backColorComponents[0] = backRed;
     target->backColorComponents[1] = backGreen;
     target->backColorComponents[2] = backBlue;
-    if (textInfo.mode != 0) {
-        target->textInfo = textInfo;
-    }
+    // if (textInfo.mode != 0 || inputChar != ' ') {
+    target->textInfo = textInfo;
+    // }
 
     restoreRNG;
 }
@@ -1846,9 +1846,8 @@ void plotCharToBufferWithTextInfo(enum displayGlyph inputChar, windowpos loc, co
     cell->backColorComponents[1] = backColor->green + rand_range(0, backColor->greenRand) + rand_range(0, backColor->rand);
     cell->backColorComponents[2] = backColor->blue + rand_range(0, backColor->blueRand) + rand_range(0, backColor->rand);
     cell->character = inputChar;
-    if (textInfo.mode != 0) {
-        cell->textInfo = textInfo;
-    }
+    
+    cell->textInfo = textInfo;
     restoreRNG;
 }
 
@@ -1877,6 +1876,7 @@ void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *f
     cell->backColorComponents[1] = backColor->green + rand_range(0, backColor->greenRand) + rand_range(0, backColor->rand);
     cell->backColorComponents[2] = backColor->blue + rand_range(0, backColor->blueRand) + rand_range(0, backColor->rand);
     cell->character = inputChar;
+    cell->textInfo = (CellTextInfo) { .mode = 0 };
     restoreRNG;
 }
 
@@ -2020,6 +2020,8 @@ void overlayDisplayBuffer(const screenDisplayBuffer *overBuf) {
                 enum displayGlyph character;
                 backColor = colorFromComponents(overBuf->cells[i][j].backColorComponents);
 
+                CellTextInfo displayTextInfo = displayBuffer.cells[i][j].textInfo;
+
                 // character and fore color:
                 if (overBuf->cells[i][j].character == ' ') { // Blank cells in the overbuf take the character from the screen.
                     character = displayBuffer.cells[i][j].character;
@@ -2028,13 +2030,17 @@ void overlayDisplayBuffer(const screenDisplayBuffer *overBuf) {
                 } else {
                     character = overBuf->cells[i][j].character;
                     foreColor = colorFromComponents(overBuf->cells[i][j].foreColorComponents);
+                    displayTextInfo = overBuf->cells[i][j].textInfo;
+                }
+                if (overBuf->cells[i][j].opacity > 90) {
+                    displayTextInfo = overBuf->cells[i][j].textInfo;
                 }
 
                 // back color:
                 tempColor = colorFromComponents(displayBuffer.cells[i][j].backColorComponents);
                 applyColorAverage(&backColor, &tempColor, 100 - overBuf->cells[i][j].opacity);
 
-                plotCharWithColorAndTextInfo(character, (windowpos){ i, j }, &foreColor, &backColor, overBuf->cells[i][j].textInfo);
+                plotCharWithColorAndTextInfo(character, (windowpos){ i, j }, &foreColor, &backColor, displayTextInfo);
             }
         }
     }

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -890,14 +890,23 @@ void mainBrogueJunction() {
     initializeLaunchArguments(&rogue.nextGame, rogue.nextGamePath, &rogue.nextGameSeed);
 
     do {
+        // In between menus and games, zero out the textinfo.
+        for (int x = 0; x < COLS; x++) {
+            for (int y = 0; y < ROWS; y++) {
+                displayBuffer.cells[x][y].textInfo = (CellTextInfo) { .mode = 0 };
+            }
+        }
         rogue.gameHasEnded = false;
         rogue.playbackFastForward = false;
         rogue.playbackMode = false;
         switch (rogue.nextGame) {
-            case NG_NOTHING:
+            case NG_NOTHING: {
                 // Run the main menu to get a decision out of the player.
+                const SavedDisplayBuffer rbuf = saveDisplayBuffer();
                 titleMenu();
+                restoreDisplayBuffer(&rbuf);
                 break;
+            }
             case NG_GAME_VARIANT:
                 rogue.nextGame = NG_NOTHING;
                 initializeGameVariant();

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1283,12 +1283,18 @@ enum dungeonLayers {
     NUMBER_TERRAIN_LAYERS
 };
 
+typedef struct CellTextInfo {
+    int mode;
+    int startColumn;
+} CellTextInfo;
+
 // keeps track of graphics so we only redraw if the cell has changed:
 typedef struct cellDisplayBuffer {
     enum displayGlyph character;
     char foreColorComponents[3];
     char backColorComponents[3];
     char opacity;
+    CellTextInfo textInfo;
 } cellDisplayBuffer;
 
 typedef struct screenDisplayBuffer {
@@ -2884,7 +2890,8 @@ extern "C" {
     void plotChar(enum displayGlyph inputChar,
                   short xLoc, short yLoc,
                   short backRed, short backGreen, short backBlue,
-                  short foreRed, short foreGreen, short foreBlue);
+                  short foreRed, short foreGreen, short foreBlue,
+                  CellTextInfo textInfo);
 
     typedef struct PauseBehavior {
         /// If `interuptForMouseMove` is true, then the pause function will return `true`
@@ -2956,6 +2963,7 @@ extern "C" {
     void hiliteCell(short x, short y, const color *hiliteColor, short hiliteStrength, boolean distinctColors);
     void colorMultiplierFromDungeonLight(short x, short y, color *editColor);
     void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *cellForeColor, const color *cellBackColor);
+    void plotCharWithColorAndTextInfo(enum displayGlyph inputChar, windowpos loc, const color *cellForeColor, const color *cellBackColor, CellTextInfo textInfo);
     void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *foreColor, const color *backColor, screenDisplayBuffer *dbuf);
     void plotForegroundChar(enum displayGlyph inputChar, short x, short y, const color *foreColor, boolean affectedByLighting);
     void commitDraws(void);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2993,6 +2993,7 @@ extern "C" {
     void colorFlash(const color *theColor, unsigned long reqTerrainFlags, unsigned long reqTileFlags, short frames, short maxRadius, short x, short y);
     // Prints the specified formatted string to the screen, starting at the coordinates (x, y).
     void printString(const char *theString, short x, short y, const color *foreColor, const color* backColor, screenDisplayBuffer *dbuf);
+    void printStringWithTextMode(const char *theString, short x, short y, const color *foreColor, const color* backColor, int textMode, screenDisplayBuffer *dbuf);
     // The same as `printString`, but centers the text when performing letter spacing adjustments.
     void printStringCentered(const char *theString, short x, short y, const color *foreColor, const color* backColor, screenDisplayBuffer *dbuf);
     short wrapText(char *to, const char *sourceText, short width);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2942,7 +2942,7 @@ extern "C" {
                                           short x, short y, short width,
                                           boolean includeButtons);
     void funkyFade(screenDisplayBuffer *displayBuf, const color *colorStart, const color *colorEnd, short stepCount, short x, short y, boolean invert);
-    void displayCenteredAlert(char *message);
+    void displayCenteredAlert(const char *message);
     void flashMessage(char *message, short x, short y, int time, const color *fColor, const color *bColor);
     void flashTemporaryAlert(char *message, int time);
     void highlightScreenCell(short x, short y, const color *highlightColor, short strength);
@@ -2991,7 +2991,10 @@ extern "C" {
     void flashForeground(short *x, short *y, const color **flashColor, short *flashStrength, short count, short frames);
     void flashCell(const color *theColor, short frames, short x, short y);
     void colorFlash(const color *theColor, unsigned long reqTerrainFlags, unsigned long reqTileFlags, short frames, short maxRadius, short x, short y);
+    // Prints the specified formatted string to the screen, starting at the coordinates (x, y).
     void printString(const char *theString, short x, short y, const color *foreColor, const color* backColor, screenDisplayBuffer *dbuf);
+    // The same as `printString`, but centers the text when performing letter spacing adjustments.
+    void printStringCentered(const char *theString, short x, short y, const color *foreColor, const color* backColor, screenDisplayBuffer *dbuf);
     short wrapText(char *to, const char *sourceText, short width);
     short printStringWithWrapping(const char *theString, short x, short y, short width, const color *foreColor,
                                   const color *backColor, screenDisplayBuffer *dbuf);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1284,8 +1284,12 @@ enum dungeonLayers {
 };
 
 typedef struct CellTextInfo {
-    int mode;
-    int startColumn;
+    /// 0 : Normal terminal output
+    /// 1 : Left-aligned text [startColumn must be set]
+    /// 2 : Middle-aligned text [startColumn and endColumn must be set]
+    int8_t mode;
+    int8_t firstColumn; // first column (x coordinate) of text (inclusive)
+    int8_t lastColumn; // last column (x coordinate) of text (inclusive)
 } CellTextInfo;
 
 // keeps track of graphics so we only redraw if the cell has changed:
@@ -2965,6 +2969,7 @@ extern "C" {
     void plotCharWithColor(enum displayGlyph inputChar, windowpos loc, const color *cellForeColor, const color *cellBackColor);
     void plotCharWithColorAndTextInfo(enum displayGlyph inputChar, windowpos loc, const color *cellForeColor, const color *cellBackColor, CellTextInfo textInfo);
     void plotCharToBuffer(enum displayGlyph inputChar, windowpos loc, const color *foreColor, const color *backColor, screenDisplayBuffer *dbuf);
+    void plotCharToBufferWithTextInfo(enum displayGlyph inputChar, windowpos loc, const color *foreColor, const color *backColor, CellTextInfo textInfo, screenDisplayBuffer *dbuf);
     void plotForegroundChar(enum displayGlyph inputChar, short x, short y, const color *foreColor, boolean affectedByLighting);
     void commitDraws(void);
     void dumpLevelToScreen(void);

--- a/src/platform/null-platform.c
+++ b/src/platform/null-platform.c
@@ -15,7 +15,8 @@ static void null_nextKeyOrMouseEvent(rogueEvent *returnEvent, boolean textInput,
 static void null_plotChar(enum displayGlyph ch,
               short xLoc, short yLoc,
               short foreRed, short foreGreen, short foreBlue,
-              short backRed, short backGreen, short backBlue) {
+              short backRed, short backGreen, short backBlue,
+              CellTextInfo textInfo) {
     return;
 }
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -58,7 +58,8 @@ struct brogueConsole {
         enum displayGlyph inputChar,
         short x, short y,
         short foreRed, short foreGreen, short foreBlue,
-        short backRed, short backGreen, short backBlue
+        short backRed, short backGreen, short backBlue,
+        CellTextInfo textInfo
     );
 
     void (*remap)(const char *, const char *);

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -224,8 +224,9 @@ boolean isEnvironmentGlyph(enum displayGlyph glyph) {
 void plotChar(enum displayGlyph inputChar,
               short xLoc, short yLoc,
               short foreRed, short foreGreen, short foreBlue,
-              short backRed, short backGreen, short backBlue) {
-    currentConsole.plotChar(inputChar, xLoc, yLoc, foreRed, foreGreen, foreBlue, backRed, backGreen, backBlue);
+              short backRed, short backGreen, short backBlue,
+              CellTextInfo textInfo) {
+    currentConsole.plotChar(inputChar, xLoc, yLoc, foreRed, foreGreen, foreBlue, backRed, backGreen, backBlue, textInfo);
 }
 
 boolean shiftKeyIsDown() {

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -390,11 +390,12 @@ static void _plotChar(
     enum displayGlyph inputChar,
     short x, short y,
     short foreRed, short foreGreen, short foreBlue,
-    short backRed, short backGreen, short backBlue
+    short backRed, short backGreen, short backBlue,
+    CellTextInfo textInfo
 ) {
     updateTile(y, x, fontIndex(inputChar),
         foreRed, foreGreen, foreBlue,
-        backRed, backGreen, backBlue);
+        backRed, backGreen, backBlue, textInfo);
 }
 
 

--- a/src/platform/tiles.c
+++ b/src/platform/tiles.c
@@ -696,9 +696,10 @@ void updateScreen() {
                     }
 
                     int textMode = tile->textInfo.mode;
+                    int charIndex = tile->charIndex;
 
-                    int tileRow    = tile->charIndex / 16;
-                    int tileColumn = tile->charIndex % 16;
+                    int tileRow    = charIndex / 16;
+                    int tileColumn = charIndex % 16;
 
                     if (tileEmpty[tileRow][tileColumn]
                             && !(tileRow == 21 && tileColumn == 1)) {  // wall top (procedural)
@@ -721,8 +722,27 @@ void updateScreen() {
                         // If it's text, then we want to compress the letters
                         // so the spacing between consecutive letters is more
                         // natural and readable.
-                        dest.x -= outputWidth * (x - tile->textInfo.startColumn) / 5 / COLS;
+                        dest.x -= outputWidth * (x - tile->textInfo.firstColumn) / 5 / COLS;
                     }
+                    if (textMode == 2) {
+                        int offsetForLetter = outputWidth * (x - tile->textInfo.firstColumn) / 5 / COLS;
+                        int offsetForEnd = outputWidth * (tile->textInfo.lastColumn - tile->textInfo.firstColumn) / 5 / COLS;
+                        // `offsetForLetter` is zero for the first letter, and increases for each
+                        // subsequent letter in the line.
+                        dest.x -= offsetForLetter;
+                        // `offsetForEnd` is a constant for all text in the same contiguous span.
+                        // By adding half its value back, we shift the text over so that the first
+                        // letter and the last letter in the span are shifted equally for kerning,
+                        // so that spacing on both sides is uniform.
+                        dest.x += offsetForEnd / 2;
+                    }
+
+                    // int diff = abs(tile->foreRed - tile->backRed) + abs(tile->foreGreen - tile->backGreen) + abs(tile->foreBlue - tile->backBlue);
+                    // if (diff < 100) {
+                    //     tile->foreRed = 100;
+                    //     tile->foreGreen = 100;
+                    //     tile->foreBlue = 100;
+                    // }
 
                     // blend the foreground
                     if (SDL_SetTextureColorMod(Textures[step],

--- a/src/platform/tiles.h
+++ b/src/platform/tiles.h
@@ -2,12 +2,14 @@
 #define __TILES_H__
 
 #include <SDL.h>
+#include "Rogue.h"
 
 void initTiles(void);
 void resizeWindow(int width, int height);
 void updateTile(int row, int column, short charIndex,
     short foreRed, short foreGreen, short foreBlue,
-    short backRed, short backGreen, short backBlue);
+    short backRed, short backGreen, short backBlue,
+    CellTextInfo textInfo);
 void updateScreen(void);
 SDL_Surface *captureScreen(void);
 


### PR DESCRIPTION
This PR augments the `cellDisplayBuffer` struct with a new field, `CellTextInfo textInfo` that tracks information about the text qualities of the cell. When drawing text to the screen, `textInfo.textMode` is set to a non-zero value:

- 0: Not text
- 1: Left-aligned text
- 2: Centered text

The platform can read this information, and adjust the placement of letters to make text more readable:

<table>
<tr>
<td><b>Before</b></td><td><b>After</b></td>
</tr>
<tr>
<td>
<img width="1341" alt="Screenshot 2024-01-20 at 7 10 09 PM" src="https://github.com/tmewett/BrogueCE/assets/6179181/a0d78d1d-4aca-461e-a551-a79d9020a1f4">
</td>
<td>
<img width="1341" alt="Screenshot 2024-01-20 at 7 08 48 PM" src="https://github.com/tmewett/BrogueCE/assets/6179181/fdcdf1cd-9581-4fec-9f1d-1c808ce346ca">
</td>
</tr>
</table>

As shown in the screenshot above, most interfaces and log messages now make use of this fancier text-printing info.

I _think_ I've ironed out all of the bugs, but it's possible that there's still some screens which display incorrectly.

---

Platforms must be modified to accept the extra `CellTextInfo` parameter in their `plotChar` implementation - though it can simply be ignored if the platform doesn't want to or can't support moving the letters around. The actual display logic change is pretty small - see `tiles.c` for what the platform actually does to make use of this new metadata.