### PR TITLE
Refactor auto-targeting and add reflective restriction

### DIFF
--- a/changes/auto-targeting.md
+++ b/changes/auto-targeting.md
@@ -1,0 +1,1 @@
+When using a staff or wand, enemy monsters that always reflect bolts will no longer be auto-targeted.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -746,7 +746,7 @@ void mainInputLoop() {
             }
 
             if (tabKey && !playingBack) { // The tab key cycles the cursor through monsters, items and terrain features.
-                if (nextTargetAfter(&newX, &newY, rogue.cursorLoc.x, rogue.cursorLoc.y, true, true, true, true, false, theEvent.shiftKey)) {
+                if (nextTargetAfter(NULL, &newX, &newY, rogue.cursorLoc.x, rogue.cursorLoc.y, AUTOTARGET_MODE_EXPLORE, theEvent.shiftKey)) {
                     rogue.cursorLoc.x = newX;
                     rogue.cursorLoc.y = newY;
                 }

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -334,6 +334,20 @@ boolean monstersAreTeammates(const creature *monst1, const creature *monst2) {
                  && monst1->leader == monst2->leader)) ? true : false);
 }
 
+/// @brief Checks if a monster always reflects bolts (guardian spirit, mirror totem, stone/winged guardian)
+/// These monsters also always reflect the bolt back at the caster.
+/// @param monst the monster
+/// @return true if the monster always reflect bolts
+boolean monsterAlwaysReflectsBolts(const creature *monst) {
+    if (monst
+        && (monst->info.flags & MONST_REFLECT_4) 
+        && (monst->info.flags & MONST_ALWAYS_USE_ABILITY)) {
+        
+        return true;
+    }
+    return false;
+}
+
 boolean monstersAreEnemies(const creature *monst1, const creature *monst2) {
     if ((monst1->bookkeepingFlags | monst2->bookkeepingFlags) & MB_CAPTIVE) {
         return false;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2814,6 +2814,13 @@ typedef struct archivedMessage {
     unsigned long flags;
 } archivedMessage;
 
+enum autoTargetMode {
+    AUTOTARGET_MODE_NONE,               // don't autotarget
+    AUTOTARGET_MODE_USE_STAFF_OR_WAND, 
+    AUTOTARGET_MODE_THROW,
+    AUTOTARGET_MODE_EXPLORE,            // cycle through anything in the sidebar
+};
+
 extern boolean serverMode;
 extern boolean nonInteractivePlayback;
 extern boolean hasGraphics;
@@ -3121,6 +3128,7 @@ extern "C" {
     boolean monsterWillAttackTarget(const creature *attacker, const creature *defender);
     boolean monstersAreTeammates(const creature *monst1, const creature *monst2);
     boolean monstersAreEnemies(const creature *monst1, const creature *monst2);
+    boolean monsterAlwaysReflectsBolts(const creature *monst);
     void initializeGender(creature *monst);
     boolean stringsMatch(const char *str1, const char *str2);
     void resolvePronounEscapes(char *text, creature *monst);
@@ -3173,8 +3181,7 @@ extern "C" {
     boolean canDirectlySeeMonster(creature *monst);
     void monsterName(char *buf, creature *monst, boolean includeArticle);
     boolean monsterIsInClass(const creature *monst, const short monsterClass);
-    boolean chooseTarget(pos *returnLoc, short maxDistance, boolean stopAtTarget, boolean autoTarget,
-                         boolean targetAllies, const bolt *theBolt, const color *trajectoryColor);
+    boolean chooseTarget(pos *returnLoc, short maxDistance, enum autoTargetMode targetingMode, const item *theItem);
     fixpt strengthModifier(item *theItem);
     fixpt netEnchant(item *theItem);
     short hitProbability(creature *attacker, creature *defender);
@@ -3212,15 +3219,12 @@ extern "C" {
     enum boltEffects boltEffectForItem(item *theItem);
     enum boltType boltForItem(item *theItem);
     boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, boolean reverseBoltDir);
-    boolean nextTargetAfter(short *returnX,
+    boolean nextTargetAfter(const item *theItem,
+                            short *returnX,
                             short *returnY,
                             short targetX,
                             short targetY,
-                            boolean targetEnemies,
-                            boolean targetAllies,
-                            boolean targetItems,
-                            boolean targetTerrain,
-                            boolean requireOpenPath,
+                            enum autoTargetMode targetingMode,
                             boolean reverseDirection);
     boolean moveCursor(boolean *targetConfirmed,
                        boolean *canceled,

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -375,7 +375,7 @@ static void dialogCreateMonster() {
     temporaryMessage(theMessage, REFRESH_SIDEBAR);
 
     // pick a location
-    if (chooseTarget(&selectedPosition, 0, false, true, false, &boltCatalog[BOLT_NONE], &white)) {
+    if (chooseTarget(&selectedPosition, 0, AUTOTARGET_MODE_NONE, NULL)) {
         confirmMessages();
 
         if (!playerCanSeeOrSense(selectedPosition.x, selectedPosition.y)) {


### PR DESCRIPTION
Auto-target selection logic consolidated into canAutoTargetMonster. Now we can add more granular restrictions like not targeting a fire immune monster with firebolt unless it's been negated.

Includes a new auto-targeting restriction, as noted in the change file. 

There are no gameplay changes but I want to build on this with changes that might (e.g. tunneling change #420 ). I applied the changes to release locally and successfully ran the regression tests.