### PR TITLE
Improve and refactor auto-targeting when throwing something or using a staff or wand

### DIFF
--- a/changes/auto-targeting.md
+++ b/changes/auto-targeting.md
@@ -1,0 +1,4 @@
+- When using a staff or wand, enemies that always reflect bolts (stone/winged guardian, mirror totem) will no longer be auto-targeted.
+- When hallucinating but not telepathic, auto-targeting behavior has changed in two ways. First, an initial target will no longer be selected when using a staff or wand whose kind isn't known. Second, the tab key will have no effect. The previous behavoir leaked information about which creatures are allies.
+ - When using a staff or wand, the tab key will now only select additional targets (if any) when an initial target was selected.
+ - A known staff of tunneling will now auto-target turrets and sentinels.

--- a/changes/auto-targeting.md
+++ b/changes/auto-targeting.md
@@ -1,4 +1,12 @@
-- When using a staff or wand, enemies that always reflect bolts (stone/winged guardian, mirror totem) will no longer be auto-targeted.
+- When using a staff or wand, enemies that always reflect bolts (stone/winged guardian, non-negated mirror totem) will no longer be auto-targeted.
 - When hallucinating but not telepathic, auto-targeting behavior has changed in two ways. First, an initial target will no longer be selected when using a staff or wand whose kind isn't known. Second, the tab key will have no effect. The previous behavoir leaked information about which creatures are allies.
- - When using a staff or wand, the tab key will now only select additional targets (if any) when an initial target was selected.
- - A known staff of tunneling will now auto-target turrets and sentinels.
+ - When using a staff or wand, the tab key will now cycle through additional targets (if any) only if an initial target was selected.
+ - When using a known staff of tunneling, turrets and sentinels will now be auto-targeted.
+ - If a wand or staff of unknown kind has been magic detected, auto-targeting will now target enemies or allies accordingly.
+ - Monsters that are immune to fire are no longer auto-targeted when using a firebolt staff or throwing an incendiary dart or known potion of incineration.
+ - Monsters that are immune to weapon damage are no longer auto-targeted when throwing a dart or javelin, or using a staff of conjuration.
+ - When using a known wand of domination, monsters at full health will not longer be auto-targeted.
+ - When using a known wand of negation, monsters that will not be affected will no longer be auto-targeted.
+ - When using a known wand of beckoning, monsters that are adjacent to the player will no longer be auto-targeted.
+ - When using a known staff of healing, non-reflective allies at full health will no longer be auto-targeted.
+ - When throwing a known potion of confusion or caustic gas, unaffected enemies will no longer be auto-targeted.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -527,7 +527,7 @@ static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
 // This is basically the main loop for the game.
 void mainInputLoop() {
     pos oldTargetLoc = { 0, 0 };
-    short steps, oldRNG, dir, newX, newY;
+    short steps, oldRNG, dir;
     pos path[1000];
     creature *monst;
     item *theItem;
@@ -734,9 +734,9 @@ void mainInputLoop() {
             }
 
             if (tabKey && !playingBack) { // The tab key cycles the cursor through monsters, items and terrain features.
-                if (nextTargetAfter(&newX, &newY, rogue.cursorLoc.x, rogue.cursorLoc.y, true, true, true, true, false, theEvent.shiftKey)) {
-                    rogue.cursorLoc.x = newX;
-                    rogue.cursorLoc.y = newY;
+                pos newLoc;
+                if (nextTargetAfter(NULL, &newLoc, rogue.cursorLoc, AUTOTARGET_MODE_EXPLORE, theEvent.shiftKey)) {
+                    rogue.cursorLoc = newLoc;
                 }
             }
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5530,16 +5530,6 @@ static pos pullMouseClickDuringPlayback(void) {
     };
 }
 
-// Returns whether monst is targetable with thrown items, staves, wands, etc.
-// i.e. would the player ever select it?
-static boolean creatureIsTargetable(creature *monst) {
-    return monst != NULL
-        && canSeeMonster(monst)
-        && monst->depth == rogue.depthLevel
-        && !(monst->bookkeepingFlags & MB_IS_DYING)
-        && openPathBetween(player.loc, monst->loc);
-}
-
 /// @brief Allows the player to interactively choose a target location for actions that require a straight line from
 /// the player to the target (e.g. throwing an item or using a staff/wand). The best path to the target is determined
 /// and highlighted. If possible, an inital target is chosen automatically. The player can cycle through additional

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -1629,7 +1629,7 @@ static short awarenessDistance(creature *observer, creature *target) {
     // and wander toward the last location that we saw the player.
     perceivedDistance = (rogue.scentTurnNumber - scentMap[observer->loc.x][observer->loc.y]); // this value is double the apparent distance
     if ((target == &player && (pmapAt(observer->loc)->flags & IN_FIELD_OF_VIEW))
-        || (target != &player && openPathBetween(observer->loc.x, observer->loc.y, target->loc.x, target->loc.y))) {
+        || (target != &player && openPathBetween(observer->loc, target->loc))) {
 
         perceivedDistance = min(perceivedDistance, scentDistance(observer->loc.x, observer->loc.y, target->loc.x, target->loc.y));
     }
@@ -1746,7 +1746,7 @@ void updateMonsterState(creature *monst) {
         if (monsterFleesFrom(monst, monst2)
             && distanceBetween((pos){x, y}, monst2->loc) < closestFearedEnemy
             && traversiblePathBetween(monst2, x, y)
-            && openPathBetween(x, y, monst2->loc.x, monst2->loc.y)) {
+            && openPathBetween((pos){x, y}, monst2->loc)) {
 
             closestFearedEnemy = distanceBetween((pos){x, y}, monst2->loc);
         }
@@ -2030,16 +2030,11 @@ boolean specifiedPathBetween(short x1, short y1, short x2, short y2,
     return true; // should never get here
 }
 
-boolean openPathBetween(short x1, short y1, short x2, short y2) {
-    pos startLoc = (pos){ .x = x1, .y = y1 };
-    pos targetLoc = (pos){ .x = x2, .y = y2 };
+boolean openPathBetween(const pos startLoc, const pos targetLoc) {
 
     pos returnLoc;
     getImpactLoc(&returnLoc, startLoc, targetLoc, DCOLS, false, &boltCatalog[BOLT_NONE]);
-    if (returnLoc.x == targetLoc.x && returnLoc.y == targetLoc.y) {
-        return true;
-    }
-    return false;
+    return posEq(returnLoc,targetLoc);
 }
 
 // will return the player if the player is at (p.x, p.y).
@@ -2489,7 +2484,7 @@ static boolean generallyValidBoltTarget(creature *caster, creature *target) {
         // No bolt will affect a submerged creature. Can't shoot at invisible creatures unless it's in gas.
         return false;
     }
-    return openPathBetween(caster->loc.x, caster->loc.y, target->loc.x, target->loc.y);
+    return openPathBetween(caster->loc, target->loc);
 }
 
 static boolean targetEligibleForCombatBuff(creature *caster, creature *target) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3144,7 +3144,7 @@ extern "C" {
     boolean specifiedPathBetween(short x1, short y1, short x2, short y2,
                                  unsigned long blockingTerrain, unsigned long blockingFlags);
     boolean traversiblePathBetween(creature *monst, short x2, short y2);
-    boolean openPathBetween(short x1, short y1, short x2, short y2);
+    boolean openPathBetween(const pos startLoc, const pos targetLoc);
     creature *monsterAtLoc(pos p);
     creature *dormantMonsterAtLoc(pos p);
     pos perimeterCoords(short n);
@@ -3181,8 +3181,7 @@ extern "C" {
     boolean canDirectlySeeMonster(creature *monst);
     void monsterName(char *buf, creature *monst, boolean includeArticle);
     boolean monsterIsInClass(const creature *monst, const short monsterClass);
-    boolean chooseTarget(pos *returnLoc, short maxDistance, boolean stopAtTarget, boolean autoTarget,
-                         boolean targetAllies, const bolt *theBolt, const color *trajectoryColor);
+    boolean chooseTarget(pos *returnLoc, short maxDistance, enum autoTargetMode targetingMode, const item *theItem);
     fixpt strengthModifier(item *theItem);
     fixpt netEnchant(item *theItem);
     short hitProbability(creature *attacker, creature *defender);
@@ -3220,15 +3219,10 @@ extern "C" {
     enum boltEffects boltEffectForItem(item *theItem);
     enum boltType boltForItem(item *theItem);
     boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, boolean reverseBoltDir);
-    boolean nextTargetAfter(short *returnX,
-                            short *returnY,
-                            short targetX,
-                            short targetY,
-                            boolean targetEnemies,
-                            boolean targetAllies,
-                            boolean targetItems,
-                            boolean targetTerrain,
-                            boolean requireOpenPath,
+    boolean nextTargetAfter(const item *theItem,
+                            pos *returnLoc,
+                            pos targetLoc,
+                            enum autoTargetMode targetingMode,
                             boolean reverseDirection);
     boolean moveCursor(boolean *targetConfirmed,
                        boolean *canceled,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2793,6 +2793,13 @@ enum messageFlags {
     FOLDABLE                      = Fl(2),
 };
 
+enum autoTargetMode {
+    AUTOTARGET_MODE_NONE,               // don't autotarget
+    AUTOTARGET_MODE_USE_STAFF_OR_WAND, 
+    AUTOTARGET_MODE_THROW,
+    AUTOTARGET_MODE_EXPLORE,            // cycle through anything in the sidebar
+};
+
 typedef struct archivedMessage {
     char message[COLS*2];
     unsigned char count;          // how many times this message appears

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -376,7 +376,7 @@ static void dialogCreateMonster() {
     temporaryMessage(theMessage, REFRESH_SIDEBAR);
 
     // pick a location
-    if (chooseTarget(&selectedPosition, 0, false, true, false, &boltCatalog[BOLT_NONE], &white)) {
+    if (chooseTarget(&selectedPosition, 0, AUTOTARGET_MODE_NONE, NULL)) {
         confirmMessages();
 
         if (!playerCanSeeOrSense(selectedPosition.x, selectedPosition.y)) {


### PR DESCRIPTION
Replaces PR #658 
Fixes #420 

Centralizes the player auto-targeting logic and makes many behavior modifications, as described in the changes file. I tried to implement improvements that I think make sense, but let me know if I should back out any of them.

These changes should have no effect on replays because I think only the final selected target is recorded, not the candidate targets and I don't think the method of target selection (auto vs. manual) is relevant.