### PR TITLE
Add negation, shattering and tunneling effects, if any, to monster details

### DIFF
--- a/changes/monster-details.md
+++ b/changes/monster-details.md
@@ -1,0 +1,1 @@
+The monster details window now includes information about the effect of negation if the player has a known means to negate the monster. Also, if the player has a known means to destroy a monster via tunneling or shattering, that information is now displayed.

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -1676,6 +1676,59 @@ const feat featTable[FEAT_COUNT] = {
     {"Untempted",       "Ascend without picking up gold.", true},
 };
 
+const monsterBehavior monsterBehaviorCatalog[32] = {
+    {"is invisible",                    true},          // MONST_INVISIBLE
+    {"is an inanimate object",          false},         // MONST_INANIMATE
+    {"cannot move",                     false},         // MONST_IMMOBILE
+    {"",                                false},         // MONST_CARRY_ITEM_100
+    {"",                                false},         // MONST_CARRY_ITEM_25
+    {"",                                false},         // MONST_ALWAYS_HUNTING
+    {"flees at low health",             false},         // MONST_FLEES_NEAR_DEATH
+    {"",                                false},         // MONST_ATTACKABLE_THRU_WALLS
+    {"corrodes weapons when hit",       true},          // MONST_DEFEND_DEGRADE_WEAPON
+    {"is immune to weapon damage",      true},          // MONST_IMMUNE_TO_WEAPONS
+    {"flies",                           true},          // MONST_FLIES
+    {"moves erratically",               true},          // MONST_FLITS
+    {"is immune to fire",               true},          // MONST_IMMUNE_TO_FIRE
+    {"",                                false},         // MONST_CAST_SPELLS_SLOWLY
+    {"cannot be entangled",             false},         // MONST_IMMUNE_TO_WEBS
+    {"can reflect magic spells",        true},          // MONST_REFLECT_4
+    {"never sleeps",                    false},         // MONST_NEVER_SLEEPS
+    {"burns unceasingly",               true},          // MONST_FIERY
+    {"is invulnerable",                 false},         // MONST_INVULNERABLE
+    {"is at home in water",             false},         // MONST_IMMUNE_TO_WATER
+    {"cannot venture onto dry land",    false},         // MONST_RESTRICTED_TO_LIQUID
+    {"submerges",                       false},         // MONST_SUBMERGES
+    {"keeps $HISHER distance",          true},          // MONST_MAINTAINS_DISTANCE
+    {"",                                false},         // MONST_WILL_NOT_USE_STAIRS
+    {"is animated purely by magic",     false},         // MONST_DIES_IF_NEGATED
+    {"",                                false},         // MONST_MALE
+    {"",                                false},         // MONST_FEMALE
+    {"",                                false},         // MONST_NOT_LISTED_IN_SIDEBAR
+    {"moves only when activated",       false},         // MONST_GETS_TURN_ON_ACTIVATION
+};
+
+const monsterAbility monsterAbilityCatalog[32] = {
+    {"can induce hallucinations",                   true},  // MA_HIT_HALLUCINATE
+    {"can steal items",                             true},  // MA_HIT_STEAL_FLEE
+    {"lights enemies on fire when $HESHE hits",     true},  // MA_HIT_BURN
+    {"can possess $HISHER summoned allies",         true},  // MA_ENTER_SUMMONS
+    {"corrodes armor when $HESHE hits",             true},  // MA_HIT_DEGRADE_ARMOR
+    {"can summon allies",                           true},  // MA_CAST_SUMMON
+    {"immobilizes $HISHER prey",                    true},  // MA_SEIZES
+    {"injects poison when $HESHE hits",             true},  // MA_POISONS
+    {"",                                            true},  // MA_DF_ON_DEATH
+    {"divides in two when struck",                  true},  // MA_CLONE_SELF_ON_DEFEND
+    {"dies when $HESHE attacks",                    true},  // MA_KAMIKAZE
+    {"recovers health when $HESHE inflicts damage", true},  // MA_TRANSFERENCE
+    {"saps strength when $HESHE inflicts damage",   true},  // MA_CAUSE_WEAKNESS
+    {"attacks up to two opponents in a line",       false}, // MA_ATTACKS_PENETRATE
+    {"attacks all adjacent opponents at once",      false}, // MA_ATTACKS_ALL_ADJACENT
+    {"attacks with a whip",                         false}, // MA_ATTACKS_EXTEND
+    {"pushes opponents backward when $HESHE hits",  false}, // MA_ATTACKS_STAGGER
+    {"avoids attacking in corridors in a group",    true},  // MA_AVOID_CORRIDORS
+};
+
 const char monsterBehaviorFlagDescriptions[32][COLS] = {
     "is invisible",                             // MONST_INVISIBLE
     "is an inanimate object",                   // MONST_INANIMATE
@@ -1749,3 +1802,33 @@ const char monsterBookkeepingFlagDescriptions[32][COLS] = {
     "is anchored to reality by $HISHER summoner",// MB_BOUND_TO_LEADER
     "is marked for demonic sacrifice",          // MB_MARKED_FOR_SACRIFICE
 };
+
+const statusEffect statusEffectCatalog[NUMBER_OF_STATUS_EFFECTS] = {
+    {"Searching",       false, 0}, // STATUS_SEARCHING
+    {"Donning Armor",   false, 0}, // STATUS_DONNING
+    {"Weakened: -",     false, 0}, // STATUS_WEAKENED
+    {"Telepathic",      true,  1}, // STATUS_TELEPATHIC
+    {"Hallucinating",   true,  0}, // STATUS_HALLUCINATING
+    {"Levitating",      true,  1}, // STATUS_LEVITATING
+    {"Slowed",          true,  0}, // STATUS_SLOWED
+    {"Hasted",          true,  0}, // STATUS_HASTED
+    {"Confused",        true,  0}, // STATUS_CONFUSED
+    {"Burning",         false, 0}, // STATUS_BURNING
+    {"Paralyzed",       false, 0}, // STATUS_PARALYZED
+    {"Poisoned",        false, 0}, // STATUS_POISONED
+    {"Stuck",           false, 0}, // STATUS_STUCK
+    {"Nauseous",        false, 0}, // STATUS_NAUSEOUS
+    {"Discordant",      true,  0}, // STATUS_DISCORDANT
+    {"Immune to Fire",  true,  1}, // STATUS_IMMUNE_TO_FIRE
+    {"",                false, 0}, // STATUS_EXPLOSION_IMMUNITY,
+    {"",                false, 0}, // STATUS_NUTRITION,
+    {"",                false, 0}, // STATUS_ENTERS_LEVEL_IN,
+    {"",                false, 0}, // STATUS_ENRAGED,
+    {"Frightened",      true,  0}, // STATUS_MAGICAL_FEAR
+    {"Entranced",       true,  0}, // STATUS_ENTRANCED
+    {"Darkened",        true,  0}, // STATUS_DARKNESS
+    {"Lifespan",        false, 0}, // STATUS_LIFESPAN_REMAINING
+    {"Shielded",        true,  0}, // STATUS_SHIELDED
+    {"Invisible",       true,  0}, // STATUS_INVISIBLE
+    {"",                false, 0}, // STATUS_AGGRAVATING,
+}; 

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -1692,7 +1692,7 @@ const monsterBehavior monsterBehaviorCatalog[32] = {
     {"is immune to fire",               true},          // MONST_IMMUNE_TO_FIRE
     {"",                                false},         // MONST_CAST_SPELLS_SLOWLY
     {"cannot be entangled",             false},         // MONST_IMMUNE_TO_WEBS
-    {"can reflect magic spells",        true},          // MONST_REFLECT_4
+    {"can reflect magic spells",        true},          // MONST_REFLECT_50
     {"never sleeps",                    false},         // MONST_NEVER_SLEEPS
     {"burns unceasingly",               true},          // MONST_FIERY
     {"is invulnerable",                 false},         // MONST_INVULNERABLE
@@ -1830,5 +1830,4 @@ const statusEffect statusEffectCatalog[NUMBER_OF_STATUS_EFFECTS] = {
     {"Lifespan",        false, 0}, // STATUS_LIFESPAN_REMAINING
     {"Shielded",        true,  0}, // STATUS_SHIELDED
     {"Invisible",       true,  0}, // STATUS_INVISIBLE
-    {"",                false, 0}, // STATUS_AGGRAVATING,
-}; 
+};

--- a/src/brogue/Globals.h
+++ b/src/brogue/Globals.h
@@ -97,7 +97,7 @@ extern const monsterWords monsterText[NUMBER_MONSTER_KINDS];
 extern const hordeType *hordeCatalog;
 extern const mutation mutationCatalog[NUMBER_MUTATORS];
 extern const monsterClass monsterClassCatalog[MONSTER_CLASS_COUNT];
-
+extern const statusEffect statusEffectCatalog[NUMBER_OF_STATUS_EFFECTS];
 extern const feat featTable[FEAT_COUNT];
 
 extern char itemTitles[NUMBER_ITEM_TITLES][30];

--- a/src/brogue/GlobalsBase.h
+++ b/src/brogue/GlobalsBase.h
@@ -124,6 +124,8 @@ extern const color rainbow;
 
 extern const char monsterBehaviorFlagDescriptions[32][COLS];
 extern const char monsterAbilityFlagDescriptions[32][COLS];
+extern const monsterBehavior monsterBehaviorCatalog[32];
+extern const monsterAbility monsterAbilityCatalog[32];
 extern const char monsterBookkeepingFlagDescriptions[32][COLS];
 
 extern const windowpos WINDOW_POSITION_DUNGEON_TOP_LEFT;

--- a/src/brogue/GlobalsBase.h
+++ b/src/brogue/GlobalsBase.h
@@ -122,8 +122,6 @@ extern const color darkPink;
 extern const color tanColor;
 extern const color rainbow;
 
-extern const char monsterBehaviorFlagDescriptions[32][COLS];
-extern const char monsterAbilityFlagDescriptions[32][COLS];
 extern const monsterBehavior monsterBehaviorCatalog[32];
 extern const monsterAbility monsterAbilityCatalog[32];
 extern const char monsterBookkeepingFlagDescriptions[32][COLS];

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4453,34 +4453,6 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
         "    (Shrieking)     ",
         "   (Caterwauling)   ",
     };
-    const char statusStrings[NUMBER_OF_STATUS_EFFECTS][COLS] = {
-        "Searching",
-        "Donning Armor",
-        "Weakened: -",
-        "Telepathic",
-        "Hallucinating",
-        "Levitating",
-        "Slowed",
-        "Hasted",
-        "Confused",
-        "Burning",
-        "Paralyzed",
-        "Poisoned",
-        "Stuck",
-        "Nauseous",
-        "Discordant",
-        "Immune to Fire",
-        "", // STATUS_EXPLOSION_IMMUNITY,
-        "", // STATUS_NUTRITION,
-        "", // STATUS_ENTERS_LEVEL_IN,
-        "", // STATUS_ENRAGED,
-        "Frightened",
-        "Entranced",
-        "Darkened",
-        "Lifespan",
-        "Shielded",
-        "Invisible",
-    };
 
     if (y >= ROWS - 1) {
         return ROWS - 1;
@@ -4603,7 +4575,7 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
 
         for (i=0; i<NUMBER_OF_STATUS_EFFECTS; i++) {
             if (i == STATUS_WEAKENED && monst->status[i] > 0) {
-                sprintf(buf, "%s%i", statusStrings[STATUS_WEAKENED], monst->weaknessAmount);
+                sprintf(buf, "%s%i", statusEffectCatalog[STATUS_WEAKENED].name, monst->weaknessAmount);
                 printProgressBar(0, y++, buf, monst->status[i], monst->maxStatus[i], &redBar, dim);
             } else if (i == STATUS_LEVITATING && monst->status[i] > 0) {
                 printProgressBar(0, y++, (monst == &player ? "Levitating" : "Flying"), monst->status[i], monst->maxStatus[i], &redBar, dim);
@@ -4624,8 +4596,8 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
                             monst->poisonAmount);
                     printProgressBar(0, y++, buf2, monst->status[i], monst->maxStatus[i], &redBar, dim);
                 }
-            } else if (statusStrings[i][0] && monst->status[i] > 0) {
-                printProgressBar(0, y++, statusStrings[i], monst->status[i], monst->maxStatus[i], &redBar, dim);
+            } else if (statusEffectCatalog[i].name[0] && monst->status[i] > 0) {
+                printProgressBar(0, y++, statusEffectCatalog[i].name, monst->status[i], monst->maxStatus[i], &redBar, dim);
             }
         }
         if (posEq(monst->targetCorpseLoc, monst->loc)) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3714,71 +3714,9 @@ boolean negate(creature *monst) {
         combatMessage(buf, messageColorFromVictim(monst));
         negated = true;
     } else if (!(monst->info.flags & MONST_INVULNERABLE)) {
-        // works on inanimates
-        if (monst->status[STATUS_IMMUNE_TO_FIRE]) {
-            monst->status[STATUS_IMMUNE_TO_FIRE] = 0;
+        if (canNegateCreatureStatusEffects(monst)) {
             negated = true;
-        }
-        if (monst->status[STATUS_SLOWED]) {
-            monst->status[STATUS_SLOWED] = 0;
-            negated = true;
-        }
-        if (monst->status[STATUS_HASTED]) {
-            monst->status[STATUS_HASTED] = 0;
-            negated = true;
-        }
-        if (monst->status[STATUS_CONFUSED]) {
-            monst->status[STATUS_CONFUSED] = 0;
-            negated = true;
-        }
-        if (monst->status[STATUS_ENTRANCED]) {
-            monst->status[STATUS_ENTRANCED] = 0;
-            negated = true;
-        }
-        if (monst->status[STATUS_DISCORDANT]) {
-            monst->status[STATUS_DISCORDANT] = 0;
-            negated = true;
-        }
-        if (monst->status[STATUS_SHIELDED]) {
-            monst->status[STATUS_SHIELDED] = 0;
-            negated = true;
-        }
-        if (monst->status[STATUS_INVISIBLE]) {
-            monst->status[STATUS_INVISIBLE] = 0;
-            negated = true;
-        }
-        if (monst == &player) {
-            if (monst->status[STATUS_TELEPATHIC] > 1 ) {
-                monst->status[STATUS_TELEPATHIC] = 1;
-                negated = true;
-            }
-            if (monst->status[STATUS_MAGICAL_FEAR] > 1 ) {
-                monst->status[STATUS_MAGICAL_FEAR] = 1;
-                negated = true;
-            }
-            if (monst->status[STATUS_LEVITATING] > 1 ) {
-                monst->status[STATUS_LEVITATING] = 1;
-                negated = true;
-            }
-            if (monst->status[STATUS_DARKNESS]) {
-                monst->status[STATUS_DARKNESS] = 0;
-                updateMinersLightRadius();
-                updateVision(true);
-                negated = true;
-            }
-        } else {
-            if (monst->status[STATUS_TELEPATHIC] > 0 ) {
-                monst->status[STATUS_TELEPATHIC] = 0;
-                negated = true;
-            }
-            if (monst->status[STATUS_MAGICAL_FEAR] > 0 ) {
-                monst->status[STATUS_MAGICAL_FEAR] = 0;
-                negated = true;
-            }
-            if (monst->status[STATUS_LEVITATING] > 0 ) {
-                monst->status[STATUS_LEVITATING] = 0;
-                negated = true;
-            }
+            negateCreatureStatusEffects(monst);
         }
         if (monst->info.flags & MONST_IMMUNE_TO_FIRE) {
             monst->info.flags &= ~MONST_IMMUNE_TO_FIRE;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2001,6 +2001,12 @@ enum statusEffects {
     NUMBER_OF_STATUS_EFFECTS,
 };
 
+typedef struct statusEffect {
+    char name[COLS];
+    boolean isNegatable;
+    int playerNegatedValue;
+} statusEffect;
+
 enum hordeFlags {
     HORDE_DIES_ON_LEADER_DEATH      = Fl(0),    // if the leader dies, the horde will die instead of electing new leader
     HORDE_IS_SUMMONED               = Fl(1),    // minions summoned when any creature is the same species as the leader and casts summon
@@ -2074,6 +2080,12 @@ enum monsterBehaviorFlags {
     MONST_NEVER_MUTATED             = (MONST_INVISIBLE | MONST_INANIMATE | MONST_IMMOBILE | MONST_INVULNERABLE),
 };
 
+typedef struct monsterBehavior {
+    char description[COLS];
+    boolean isNegatable;
+} monsterBehavior;
+
+
 enum monsterAbilityFlags {
     MA_HIT_HALLUCINATE              = Fl(0),    // monster can hit to cause hallucinations
     MA_HIT_STEAL_FLEE               = Fl(1),    // monster can steal an item and then run away
@@ -2103,6 +2115,11 @@ enum monsterAbilityFlags {
     MA_NEVER_VORPAL_ENEMY           = (MA_KAMIKAZE),
     MA_NEVER_MUTATED                = (MA_KAMIKAZE),
 };
+
+typedef struct monsterAbility {
+    char description[COLS];
+    boolean isNegatable;
+} monsterAbility;
 
 enum monsterBookkeepingFlags {
     MB_WAS_VISIBLE              = Fl(0),    // monster was visible to player last turn
@@ -3127,6 +3144,10 @@ extern "C" {
     void prependCreature(creatureList *list, creature *add);
     boolean removeCreature(creatureList *list, creature *remove);
     creature *firstCreature(creatureList *list);
+
+    boolean canNegateCreatureStatusEffect(creature *monst, enum statusEffects theStatus, boolean negate);
+    boolean canNegateCreatureStatusEffects(creature *monst, boolean negate);
+    boolean monsterIsNegatable(creature *monst);
 
     boolean monsterWillAttackTarget(const creature *attacker, const creature *defender);
     boolean monstersAreTeammates(const creature *monst1, const creature *monst2);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3145,8 +3145,8 @@ extern "C" {
     boolean removeCreature(creatureList *list, creature *remove);
     creature *firstCreature(creatureList *list);
 
-    boolean canNegateCreatureStatusEffect(creature *monst, enum statusEffects theStatus, boolean negate);
-    boolean canNegateCreatureStatusEffects(creature *monst, boolean negate);
+    boolean canNegateCreatureStatusEffects(creature *monst);
+    void negateCreatureStatusEffects(creature *monst);
     boolean monsterIsNegatable(creature *monst);
 
     boolean monsterWillAttackTarget(const creature *attacker, const creature *defender);


### PR DESCRIPTION
Related to #664.

If the monster has both negatable and non-negatable traits and the player has the means to negate the monster, the non-negatable traits are listed first. The negatable traits are shown next, along with the list of item kinds that can negate the monster.

If the monster is destroyed by negation, shattering, or tunneling and the player has a known item of that type, that fact is displayed in the details screen.