### PR TITLE
Save run history and add game stats screen

### DIFF
--- a/changes/game-stats.md
+++ b/changes/game-stats.md
@@ -1,0 +1,1 @@
+Players can now view summary statistics of games played by selecting the "Game Stats" option from the "View" menu. Statistics are collected only for games played since the menu option became available.

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -379,6 +379,19 @@ typedef struct rogueHighScoresEntry {
     char description[DCOLS];
 } rogueHighScoresEntry;
 
+typedef struct rogueRun {
+    uint64_t seed;
+    long dateNumber;
+    char result[DCOLS];
+    char killedBy[DCOLS];
+    int gold;
+    int lumenstones;
+    int score;
+    int turns;
+    int deepestLevel;
+    struct rogueRun *nextRun;
+} rogueRun;
+
 typedef struct fileEntry {
     char *path;
     struct tm date;
@@ -2301,6 +2314,7 @@ enum NGCommands {
     NG_OPEN_GAME,
     NG_VIEW_RECORDING,
     NG_HIGH_SCORES,
+    NG_GAME_STATS,
     NG_QUIT,
 };
 
@@ -2911,6 +2925,9 @@ extern "C" {
     boolean shiftKeyIsDown(void);
     short getHighScoresList(rogueHighScoresEntry returnList[HIGH_SCORES_COUNT]);
     boolean saveHighScore(rogueHighScoresEntry theEntry);
+    void saveRunHistory(char *result, char *killedBy, int score, int lumenstones);
+    void saveResetRun(void);
+    rogueRun *loadRunHistory(void);
     fileEntry *listFiles(short *fileCount, char **dynamicMemoryBuffer);
     void initializeLaunchArguments(enum NGCommands *command, char *path, uint64_t *seed);
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1186,6 +1186,10 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
     }
 
+    if (!rogue.playbackMode && !rogue.easyMode && !rogue.wizard) {
+        saveRunHistory(rogue.quit ? "Quit" : "Died", rogue.quit ? "-" : killedBy, (int) theEntry.score, numGems);
+    }
+
     rogue.gameHasEnded = true;
     rogue.gameExitStatusCode = EXIT_STATUS_SUCCESS;
 }
@@ -1346,6 +1350,10 @@ void victory(boolean superVictory) {
         }
     } else {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
+    }
+
+    if (!rogue.playbackMode && !rogue.easyMode && !rogue.wizard) {
+        saveRunHistory(victoryVerb, "-", (int) theEntry.score, gemCount);
     }
 
     rogue.gameHasEnded = true;


### PR DESCRIPTION
Saves run history to a file and adds a new menu option for viewing game statistics.
![image](https://github.com/tmewett/BrogueCE/assets/71573970/98753a5d-ad9d-45b2-9fda-cb1367a4565c)

The player can reset their "Recent" stats at any time.
![image](https://github.com/tmewett/BrogueCE/assets/71573970/14634f22-d276-4354-b1f4-e68d9099543a)
