### PR TITLE
Fix discordant allies negating other discordant allies

### DIFF
--- a/changes/discordant-pixie
+++ b/changes/discordant-pixie
@@ -1,0 +1,1 @@
+Discordant allies that cast negation will no longer target other discordant allies for the sole purpose of negating the discordant status. They will still target discordant allies if negation will also have a harmful effect like removing haste.

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -2609,6 +2609,7 @@ static boolean specificallyValidBoltTarget(creature *caster, creature *target, e
                 }
                 if (monstersAreTeammates(caster, target)
                     && target->status[STATUS_DISCORDANT]
+                    && !caster->status[STATUS_DISCORDANT]
                     && !(target->info.flags & MONST_DIES_IF_NEGATED)) {
                     // Dispel discord from allies unless it would destroy them.
                     return true;


### PR DESCRIPTION
Fixes #438 

Negation for the sole purpose of removing discord is a positive effect and is a bug.