### PR TITLE
Fix obsidian treated as water

### DIFF
--- a/changes/kraken-obsidian.md
+++ b/changes/kraken-obsidian.md
@@ -1,0 +1,1 @@
+Fixed a bug which treated obsidian as shallow water, allowing a kraken to both traverse it and sieze monsters or the player standing in it. 

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3410,12 +3410,17 @@ boolean spawnDungeonFeature(short x, short y, dungeonFeature *feat, boolean refr
         }
     }
 
-    if (succeeded && (feat->flags & DFF_CLEAR_OTHER_TERRAIN)) {
+    if (succeeded && (feat->flags & (DFF_CLEAR_LOWER_PRIORITY_TERRAIN | DFF_CLEAR_OTHER_TERRAIN))) {
         for (i=0; i<DCOLS; i++) {
             for (j=0; j<DROWS; j++) {
                 if (blockingMap[i][j]) {
                     for (layer = 0; layer < NUMBER_TERRAIN_LAYERS; layer++) {
                         if (layer != feat->layer && layer != GAS) {
+                            if (feat->flags & DFF_CLEAR_LOWER_PRIORITY_TERRAIN) {
+                                if (tileCatalog[pmap[i][j].layers[layer]].drawPriority <= tileCatalog[feat->tile].drawPriority) {
+                                    continue;
+                                }
+                            }
                             pmap[i][j].layers[layer] = (layer == DUNGEON ? FLOOR : NOTHING);
                         }
                     }

--- a/src/brogue/Globals.c
+++ b/src/brogue/Globals.c
@@ -744,7 +744,7 @@ dungeonFeature dungeonFeatureCatalog[NUMBER_DUNGEON_FEATURES] = {
     {PLAIN_FIRE,                SURFACE,    100,    37,     0},
     {EMBERS,                    SURFACE,    0,      0,      0},
     {EMBERS,                    SURFACE,    100,    94,     0},
-    {OBSIDIAN,                  SURFACE,    0,      0,      0},
+    {OBSIDIAN,                  SURFACE,    0,      0,      DFF_CLEAR_LOWER_PRIORITY_TERRAIN},
     {ITEM_FIRE,                 SURFACE,    0,      0,      0,  "", FALLEN_TORCH_FLASH_LIGHT},
     {CREATURE_FIRE,             SURFACE,    0,      0,      0,  "", FALLEN_TORCH_FLASH_LIGHT},
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -1803,6 +1803,7 @@ enum DFFlags {
     DFF_SUPERPRIORITY               = Fl(7),    // Will overwrite terrain of a superior priority.
     DFF_AGGRAVATES_MONSTERS         = Fl(8),    // Will act as though an aggravate monster scroll of effectRadius radius had been read at that point.
     DFF_RESURRECT_ALLY              = Fl(9),    // Will bring back to life your most recently deceased ally.
+    DFF_CLEAR_LOWER_PRIORITY_TERRAIN= Fl(10),   // Erase terrain with a lower priority in the footprint of this DF.
 };
 
 enum boltEffects {


### PR DESCRIPTION
Fixes #372 

The problem was the liquid layer retains SHALLOW_WATER when a tile is turned to obsidian by dragonfire.