### PR TITLE
Vision, aggression, attack rewrite

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1762,9 +1762,12 @@ void buildHitList(creature **hitList, const creature *attacker, creature *defend
             newestY = y + cDirs[newDir][1];
             if (coordinatesAreInMap(newestX, newestY) && (pmap[newestX][newestY].flags & (HAS_MONSTER | HAS_PLAYER))) {
                 defender = monsterAtLoc((pos){ newestX, newestY });
+/*
                 if (defender
                     && monsterWillAttackTarget(attacker, defender)
                     && (!cellHasTerrainFlag(defender->loc, T_OBSTRUCTS_PASSABILITY) || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
+*/
+                if (ableAndWillingToAttack(attacker, defender, notSeeInvis, 1)) {
 
                     hitList[i] = defender;
                 }

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1733,47 +1733,41 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
     }
 }
 
-void buildHitList(creature **hitList, const creature *attacker, creature *defender, const boolean sweep) {
-    short i, x, y, newX, newY, newestX, newestY;
-    enum directions dir, newDir;
+enum directions posDirectionToNeighborPos(
+        const pos *source,
+        const pos *target,
+        enum directions otherwise ) {
 
-    x = attacker->loc.x;
-    y = attacker->loc.y;
-    newX = defender->loc.x;
-    newY = defender->loc.y;
-
-    dir = NO_DIRECTION;
-    for (i = 0; i < DIRECTION_COUNT; i++) {
-        if (nbDirs[i][0] == newX - x
-            && nbDirs[i][1] == newY - y) {
+    enum directions dir = otherwise;
+    const pos p = (pos) {
+        target->x - source->x,
+        target->y - source->y
+    };
+    for (short i = 0; i < DIRECTION_COUNT; i++) {
+        if (nbDirs[i][0] == p.x && nbDirs[i][1] == p.y) {
 
             dir = i;
             break;
         }
     }
+    return dir;
+}
 
-    if (sweep) {
-        if (dir == NO_DIRECTION) {
-            dir = UP; // Just pick one.
-        }
-        for (i=0; i<8; i++) {
-            newDir = (dir + i) % DIRECTION_COUNT;
-            newestX = x + cDirs[newDir][0];
-            newestY = y + cDirs[newDir][1];
-            if (coordinatesAreInMap(newestX, newestY) && (pmap[newestX][newestY].flags & (HAS_MONSTER | HAS_PLAYER))) {
-                defender = monsterAtLoc((pos){ newestX, newestY });
-/*
-                if (defender
-                    && monsterWillAttackTarget(attacker, defender)
-                    && (!cellHasTerrainFlag(defender->loc, T_OBSTRUCTS_PASSABILITY) || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
-*/
-                if (ableAndWillingToAttack(attacker, defender, notSeeInvis, 1)) {
+void buildHitList(creature **hitList, const creature *attacker, creature *defender, const boolean sweep) {
 
-                    hitList[i] = defender;
-                }
-            }
-        }
-    } else {
+    if (!sweep) {
         hitList[0] = defender;
+        return;
+    }
+
+    enum directions bumpDir = posDirectionToNeighborPos( &attacker->loc, &defender->loc, UP );
+
+    for (short i=0, dir=bumpDir; i < DIRECTION_COUNT; i++, dir++) {
+        dir %= DIRECTION_COUNT;
+        const pos p = posNeighborInDirection( attacker->loc, dir );
+        defender = monsterAtLoc(p);
+        if (ableAndWillingToAttack(attacker, defender, dir == bumpDir, 1)) {
+            hitList[i] = defender;
+        }
     }
 }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3534,11 +3534,7 @@ void getImpactLoc(pos *returnLoc, const pos originLoc, const pos targetLoc,
     n = min(n, maxDistance);
     for (i=0; i<n; i++) {
         monst = monsterAtLoc(coords[i]);
-/*
-        if (monst
-            && !monsterIsHidden(monst, monsterAtLoc(originLoc))
-            && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
-*/
+
         // Don't allow zapping (or whipping) submerged monsters
         if (monsterKnowsLocationOfMonster(caster, monst, notSeeInvis)
             && !(monst->bookkeepingFlags & MB_SUBMERGED)) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3528,14 +3528,21 @@ void getImpactLoc(pos *returnLoc, const pos originLoc, const pos targetLoc,
     pos coords[DCOLS + 1];
     short i, n;
     creature *monst;
+    creature *caster = monsterAtLoc(originLoc);
 
     n = getLineCoordinates(coords, originLoc, targetLoc, theBolt);
     n = min(n, maxDistance);
     for (i=0; i<n; i++) {
         monst = monsterAtLoc(coords[i]);
+/*
         if (monst
             && !monsterIsHidden(monst, monsterAtLoc(originLoc))
             && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
+*/
+        // Don't allow zapping (or whipping) submerged monsters
+        if (monsterKnowsLocationOfMonster(caster, monst, notSeeInvis)
+            && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
+
             // Imaginary bolt hit the player or a monster.
             break;
         }

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -543,15 +543,6 @@ boolean monstersAreTeammates(const creature *monst1, const creature *monst2) {
     return  sameLeader(monst1, monst2)
         || isFollowing(monst1, monst2)
         || isFollowing(monst2, monst1);
-/*
-    return ((((monst1->bookkeepingFlags & MB_FOLLOWER) && monst1->leader == monst2)
-             || ((monst2->bookkeepingFlags & MB_FOLLOWER) && monst2->leader == monst1)
-             || (monst1->creatureState == MONSTER_ALLY && monst2 == &player)
-             || (monst1 == &player && monst2->creatureState == MONSTER_ALLY)
-             || (monst1->creatureState == MONSTER_ALLY && monst2->creatureState == MONSTER_ALLY)
-             || ((monst1->bookkeepingFlags & MB_FOLLOWER) && (monst2->bookkeepingFlags & MB_FOLLOWER)
-                 && monst1->leader == monst2->leader)) ? true : false);
-*/
 }
 
 boolean monstersAreEnemies(const creature *monst1, const creature *monst2) {

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -660,10 +660,15 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
     getImpactLoc(&strikeLoc, originLoc, targetLoc, 5, false, &boltCatalog[BOLT_WHIP]);
 
     defender = monsterAtLoc(strikeLoc);
+/*
     if (defender
         && (attacker != &player || canSeeMonster(defender))
         && !monsterIsHidden(defender, attacker)
         && monsterWillAttackTarget(attacker, defender)) {
+*/
+    // Passing range=0 to ignore defender's location
+    if (ableAndWillingToAttack(attacker, defender, notSeeInvis, 0)
+        && !(defender->bookkeepingFlags & MB_SUBMERGED)) {
 
         if (attacker == &player) {
             hitList[0] = defender;
@@ -725,18 +730,25 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         hitlist. Any of those that are either right by us or visible will
         trigger the attack. */
         defender = monsterAtLoc(targetLoc);
+/*
         if (defender
             && (!cellHasTerrainFlag(targetLoc, T_OBSTRUCTS_PASSABILITY)
                 || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))
             && monsterWillAttackTarget(attacker, defender)) {
+*/
+        if (ableAndWillingToAttack(attacker, defender, notSeeInvis, range)) {
 
             hitList[h++] = defender;
 
             /* We check if i=0, i.e. the defender is right next to us, because
             we have to do "normal" attacking here. We can't just return
             false and leave to playerMoves/moveMonster due to the collateral hitlist. */
+/*
             if (i == 0 || !monsterIsHidden(defender, attacker)
                 && (attacker != &player || canSeeMonster(defender))) {
+*/
+            if (i == 0 || monsterKnowsLocationOfMonster(attacker, defender, notSeeInvis)) {
+
                 // We'll attack.
                 proceed = true;
             }
@@ -801,6 +813,7 @@ static void buildFlailHitList(const short x, const short y, const short newX, co
         creature *monst = nextCreature(&it);
         mx = monst->loc.x;
         my = monst->loc.y;
+/*
         if (distanceBetween((pos){x, y}, (pos){mx, my}) == 1
             && distanceBetween((pos){newX, newY}, (pos){mx, my}) == 1
             && canSeeMonster(monst)
@@ -808,6 +821,10 @@ static void buildFlailHitList(const short x, const short y, const short newX, co
             && monst->creatureState != MONSTER_ALLY
             && !(monst->bookkeepingFlags & MB_IS_DYING)
             && (!cellHasTerrainFlag(monst->loc, T_OBSTRUCTS_PASSABILITY) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
+*/
+        if (distanceBetween((pos){x, y}, (pos){mx, my}) == 1
+            && distanceBetween((pos){newX, newY}, (pos){mx, my}) == 1
+            && ableAndWillingToAttack(&player, monst, notSeeInvis, 0)) {
 
             while (hitList[i]) {
                 i++;
@@ -1108,13 +1125,15 @@ boolean playerMoves(short direction) {
             newestY = player.loc.y + 2*nbDirs[direction][1];
             if (coordinatesAreInMap(newestX, newestY) && (pmap[newestX][newestY].flags & HAS_MONSTER)) {
                 tempMonst = monsterAtLoc((pos){ newestX, newestY });
+/*
                 if (tempMonst
                     && (canSeeMonster(tempMonst) || monsterRevealed(tempMonst))
                     && monstersAreEnemies(&player, tempMonst)
                     && tempMonst->creatureState != MONSTER_ALLY
                     && !(tempMonst->bookkeepingFlags & MB_IS_DYING)
                     && (!cellHasTerrainFlag(tempMonst->loc, T_OBSTRUCTS_PASSABILITY) || (tempMonst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
-
+*/
+                if (ableAndWillingToAttack(&player, tempMonst, notSeeInvis, 2)) {
                     hitList[0] = tempMonst;
                     if (abortAttack(hitList)) {
                         brogueAssert(!committed);

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -656,6 +656,7 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
         return false;
     }
 
+    // getImpactLoc won't be stopped by monsters the player can't see
     pos strikeLoc;
     getImpactLoc(&strikeLoc, originLoc, targetLoc, 5, false, &boltCatalog[BOLT_WHIP]);
 
@@ -666,7 +667,24 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
         && !monsterIsHidden(defender, attacker)
         && monsterWillAttackTarget(attacker, defender)) {
 */
-    // Passing range=0 to ignore defender's location
+
+    // TODO: Test striking visible monster with invisible monster in-between
+    //       ..@.P.g..
+
+    // TODO: Test striking visible monster with submerged monster in-between
+    //       ..@.e.g..
+
+    // TODO: Test striking across a chasm / lava
+    //       ..@.::.g..
+
+    // If defender exists, it must be known by the player (from getImpactLoc)
+    //    but there may be an unknown obstacle in between (eg. invis enemy)
+    //
+    // Here we check to see if the attacker wants to attack the defender
+    //   range 0 to ignore defender's location (already checked in getImpactLoc)
+    //   and whips can't strike underwater
+    //
+    // zap() does the hard work of actually casting the whip and deciding what happens
     if (ableAndWillingToAttack(attacker, defender, notSeeInvis, 0)
         && !(defender->bookkeepingFlags & MB_SUBMERGED)) {
 
@@ -695,8 +713,8 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
 // (in which case the player/monster should move instead).
 boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *aborted) {
     creature *defender, *hitList[8] = {0};
-    short range = 2, i = 0, h = 0;
-    boolean proceed = false, visualEffect = false;
+    short range = 2, i = 0, hits = 0;
+    boolean visualEffect = false;
 
     const char boltChar[DIRECTION_COUNT] = "||--\\//\\";
 
@@ -730,28 +748,13 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         hitlist. Any of those that are either right by us or visible will
         trigger the attack. */
         defender = monsterAtLoc(targetLoc);
-/*
-        if (defender
-            && (!cellHasTerrainFlag(targetLoc, T_OBSTRUCTS_PASSABILITY)
-                || (defender->info.flags & MONST_ATTACKABLE_THRU_WALLS))
-            && monsterWillAttackTarget(attacker, defender)) {
-*/
-        if (ableAndWillingToAttack(attacker, defender, notSeeInvis, range)) {
 
-            hitList[h++] = defender;
-
-            /* We check if i=0, i.e. the defender is right next to us, because
-            we have to do "normal" attacking here. We can't just return
-            false and leave to playerMoves/moveMonster due to the collateral hitlist. */
-/*
-            if (i == 0 || !monsterIsHidden(defender, attacker)
-                && (attacker != &player || canSeeMonster(defender))) {
-*/
-            if (i == 0 || monsterKnowsLocationOfMonster(attacker, defender, notSeeInvis)) {
-
-                // We'll attack.
-                proceed = true;
-            }
+        // Passing range 0 here to ignore monster location (defined by outer loop instead)
+        //   at i == 0 we check if ANY monster we are willing to attack exists (eg. we're bumping that location)
+        //   at i == 1 we check if we KNOW of a monster we are willing to attack in that cell
+        // The attack proceeds if there are any monsters in the hit list
+        if (ableAndWillingToAttack(attacker, defender, i == 0, 0)) {
+            hitList[hits++] = defender;
         }
 
         if (cellHasTerrainFlag(targetLoc, (T_OBSTRUCTS_PASSABILITY | T_OBSTRUCTS_VISION))) {
@@ -759,7 +762,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         }
     }
     range = i;
-    if (proceed) {
+    if (hits > 0) {
         if (attacker == &player) {
             if (abortAttack(hitList)) {
                 if (aborted) {
@@ -785,7 +788,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
         attacker->bookkeepingFlags &= ~MB_SUBMERGED;
         // Artificially reverse the order of the attacks,
         // so that spears of force can send both monsters flying.
-        for (i = h - 1; i >= 0; i--) {
+        for (i = hits - 1; i >= 0; i--) {
             attack(attacker, hitList[i], false);
         }
         if (visualEffect) {
@@ -806,30 +809,22 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
 }
 
 static void buildFlailHitList(const short x, const short y, const short newX, const short newY, creature *hitList[16]) {
-    short mx, my;
     short i = 0;
+    while (hitList[i]) {
+        i++;
+    }
 
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
-        mx = monst->loc.x;
-        my = monst->loc.y;
-/*
-        if (distanceBetween((pos){x, y}, (pos){mx, my}) == 1
-            && distanceBetween((pos){newX, newY}, (pos){mx, my}) == 1
-            && canSeeMonster(monst)
-            && monstersAreEnemies(&player, monst)
-            && monst->creatureState != MONSTER_ALLY
-            && !(monst->bookkeepingFlags & MB_IS_DYING)
-            && (!cellHasTerrainFlag(monst->loc, T_OBSTRUCTS_PASSABILITY) || (monst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
-*/
-        if (distanceBetween((pos){x, y}, (pos){mx, my}) == 1
-            && distanceBetween((pos){newX, newY}, (pos){mx, my}) == 1
+
+        // Difference in logic old vs new:
+        // - Original code does not check "willingness", only enemies
+        // - eg. flail won't hit allies when player is confused
+        if (distanceBetween((pos){x, y}, monst->loc) == 1
+            && distanceBetween((pos){newX, newY}, monst->loc) == 1
             && ableAndWillingToAttack(&player, monst, notSeeInvis, 0)) {
 
-            while (hitList[i]) {
-                i++;
-            }
-            hitList[i] = monst;
+            hitList[i++] = monst;
         }
     }
 }
@@ -1011,9 +1006,9 @@ boolean playerMoves(short direction) {
                 // Attack!
                 for (i=0; i<16; i++) {
                     if (hitList[i]
-                        && monsterWillAttackTarget(&player, hitList[i])
-                        && !(hitList[i]->bookkeepingFlags & MB_IS_DYING)
-                        && !rogue.gameHasEnded) {
+                        // buildHitList does this too but it has to stay
+                        //    since attacking a creature might end the game
+                         && !rogue.gameHasEnded) {
 
                         if (attack(&player, hitList[i], false)) {
                             anyAttackHit = true;
@@ -1121,26 +1116,19 @@ boolean playerMoves(short direction) {
         }
 
         if (rogue.weapon && (rogue.weapon->flags & ITEM_LUNGE_ATTACKS)) {
-            newestX = player.loc.x + 2*nbDirs[direction][0];
-            newestY = player.loc.y + 2*nbDirs[direction][1];
-            if (coordinatesAreInMap(newestX, newestY) && (pmap[newestX][newestY].flags & HAS_MONSTER)) {
-                tempMonst = monsterAtLoc((pos){ newestX, newestY });
-/*
-                if (tempMonst
-                    && (canSeeMonster(tempMonst) || monsterRevealed(tempMonst))
-                    && monstersAreEnemies(&player, tempMonst)
-                    && tempMonst->creatureState != MONSTER_ALLY
-                    && !(tempMonst->bookkeepingFlags & MB_IS_DYING)
-                    && (!cellHasTerrainFlag(tempMonst->loc, T_OBSTRUCTS_PASSABILITY) || (tempMonst->info.flags & MONST_ATTACKABLE_THRU_WALLS))) {
-*/
-                if (ableAndWillingToAttack(&player, tempMonst, notSeeInvis, 2)) {
-                    hitList[0] = tempMonst;
-                    if (abortAttack(hitList)) {
-                        brogueAssert(!committed);
-                        cancelKeystroke();
-                        rogue.disturbed = true;
-                        return false;
-                    }
+            const pos p = posNeighborInDirection( posNeighborInDirection(player.loc, direction), direction );
+
+            // Difference in logic old vs new:
+            // - Original code does not check "willingness", only enemies
+            // - eg. rapier won't hit allies when player is confused
+            tempMonst = monsterAtLoc(p);
+            if (ableAndWillingToAttack(&player, tempMonst, notSeeInvis, 0)) {
+                hitList[0] = tempMonst;
+                if (abortAttack(hitList)) {
+                    brogueAssert(!committed);
+                    cancelKeystroke();
+                    rogue.disturbed = true;
+                    return false;
                 }
             }
         }

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -661,12 +661,6 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
     getImpactLoc(&strikeLoc, originLoc, targetLoc, 5, false, &boltCatalog[BOLT_WHIP]);
 
     defender = monsterAtLoc(strikeLoc);
-/*
-    if (defender
-        && (attacker != &player || canSeeMonster(defender))
-        && !monsterIsHidden(defender, attacker)
-        && monsterWillAttackTarget(attacker, defender)) {
-*/
 
     // TODO: Test striking visible monster with invisible monster in-between
     //       ..@.P.g..

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3177,13 +3177,14 @@ extern "C" {
 
 
     // Convenience values for passing to the following functions
-    const boolean yesSeeInvis;
-    const boolean notSeeInvis;
+    const short notSeeInvis;
+    const short yesSeeInvis;
+    const short isBumping;
     boolean monsterIsAggressiveToMonster(const creature *attacker, const creature *defender);
     boolean monsterIsWillingToAttackMonster(const creature *attacker, const creature *defender);
     boolean monsterIsAbleToStrikeMonster(const creature *attacker, const creature *defender, int maxRange);
-    boolean monsterKnowsLocationOfMonster(const creature *source, const creature *target, boolean ignoreInvisibility );
-    boolean ableAndWillingToAttack( const creature *attacker, const creature *defender, boolean ignoreInvisibility, int maxRange );
+    boolean monsterKnowsLocationOfMonster(const creature *source, const creature *target, short sensing );
+    boolean ableAndWillingToAttack( const creature *attacker, const creature *defender, short sensing, int maxRange );
 
 
     boolean monsterRevealed(creature *monst);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3142,7 +3142,7 @@ extern "C" {
     void decrementMonsterStatus(creature *monst);
     boolean specifiedPathBetween(short x1, short y1, short x2, short y2,
                                  unsigned long blockingTerrain, unsigned long blockingFlags);
-    boolean traversiblePathBetween(creature *monst, short x2, short y2);
+    boolean traversiblePathBetween(const creature *monst, short x2, short y2);
     boolean openPathBetween(short x1, short y1, short x2, short y2);
     creature *monsterAtLoc(pos p);
     creature *dormantMonsterAtLoc(pos p);
@@ -3174,6 +3174,18 @@ extern "C" {
     short distanceBetween(pos loc1, pos loc2);
     void alertMonster(creature *monst);
     void wakeUp(creature *monst);
+
+
+    // Convenience values for passing to the following functions
+    const boolean yesSeeInvis;
+    const boolean notSeeInvis;
+    boolean monsterIsAggressiveToMonster(const creature *attacker, const creature *defender);
+    boolean monsterIsWillingToAttackMonster(const creature *attacker, const creature *defender);
+    boolean monsterIsAbleToStrikeMonster(const creature *attacker, const creature *defender, int maxRange);
+    boolean monsterKnowsLocationOfMonster(const creature *source, const creature *target, boolean ignoreInvisibility );
+    boolean ableAndWillingToAttack( const creature *attacker, const creature *defender, boolean ignoreInvisibility, int maxRange );
+
+
     boolean monsterRevealed(creature *monst);
     boolean monsterHiddenBySubmersion(const creature *monst, const creature *observer);
     boolean monsterIsHidden(const creature *monst, const creature *observer);


### PR DESCRIPTION
This is an experimental PR to fix #540.
Curious to get some eyes on it.

- Fixes whip/pike/flail/axe attacking invisible but revealed enemies.
- Full rewrite of the core mechanics for monster vision, aggression, and willingness to attack.
- I've verified that they can work as replacements for the original code, with minor tweaks.

Because the new functions consistently apply the 'laws' of Brogue, they also introduce some new behaviors:

- Player will attack entranced monsters when bumping.
- Confused player will lunge-attack allies.
- Confused player will spear-attack allies.
- Confused player will axe-sweep allies.
- Confused player will flail allies when passing.

Similar changes in behavior occur when replacing the original code in other areas of the codebase.