### PR TITLE
Replaced hitList with const hitList

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1733,7 +1733,7 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
     }
 }
 
-void buildHitList(creature **hitList, const creature *attacker, creature *defender, const boolean sweep) {
+void buildHitList(const creature **hitList, const creature *attacker, creature *defender, const boolean sweep) {
     short i, x, y, newX, newY, newestX, newestY;
     enum directions dir, newDir;
 

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -3637,7 +3637,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
     short i;
     short confusedDirection, swarmDirection;
     creature *defender = NULL;
-    creature *hitList[16] = {NULL};
+    const creature *hitList[16] = {NULL};
     enum directions dir;
 
     if (dx == 0 && dy == 0) {

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -552,7 +552,7 @@ boolean freeCaptivesEmbeddedAt(short x, short y) {
 /// @brief Ask the player for confirmation before attacking an acidic monster
 /// @param hitList the creature(s) getting attacked
 /// @return true to abort the attack
-static boolean abortAttackAgainstAcidicTarget(creature *hitList[8]) {
+static boolean abortAttackAgainstAcidicTarget(const creature *hitList[8]) {
     short i;
     char monstName[COLS], weaponName[COLS];
     char buf[COLS*3];
@@ -634,7 +634,8 @@ static boolean abortAttack(const creature *hitList[8]) {
 // (in which case the player/monster should move instead).
 boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *aborted) {
     bolt theBolt;
-    creature *defender, *hitList[8] = {0};
+    creature *defender;
+    const creature *hitList[8] = {0};
 
     const char boltChar[DIRECTION_COUNT] = "||~~\\//\\";
 
@@ -689,7 +690,8 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
 // should be aborted), as opposed to there being no valid spear attack available
 // (in which case the player/monster should move instead).
 boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *aborted) {
-    creature *defender, *hitList[8] = {0};
+    creature *defender;
+    const creature *hitList[8] = {0};
     short range = 2, i = 0, h = 0;
     boolean proceed = false, visualEffect = false;
 
@@ -793,7 +795,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
     return false;
 }
 
-static void buildFlailHitList(const short x, const short y, const short newX, const short newY, creature *hitList[16]) {
+static void buildFlailHitList(const short x, const short y, const short newX, const short newY, const creature *hitList[16]) {
     short mx, my;
     short i = 0;
 
@@ -840,7 +842,8 @@ boolean playerMoves(short direction) {
     short x = player.loc.x, y = player.loc.y;
     short newX, newY, newestX, newestY;
     boolean playerMoved = false, specialAttackAborted = false, anyAttackHit = false;
-    creature *defender = NULL, *tempMonst = NULL, *hitList[16] = {NULL};
+    creature *defender = NULL, *tempMonst = NULL;
+    const creature *hitList[16] = {NULL};
     char monstName[COLS];
     char buf[COLS*3];
     const int directionKeys[8] = {UP_KEY, DOWN_KEY, LEFT_KEY, RIGHT_KEY, UPLEFT_KEY, DOWNLEFT_KEY, UPRIGHT_KEY, DOWNRIGHT_KEY};

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3195,7 +3195,7 @@ extern "C" {
                           short damage, const color *flashColor, boolean ignoresProtectionShield);
     void addPoison(creature *monst, short totalDamage, short concentrationIncrement);
     void killCreature(creature *decedent, boolean administrativeDeath);
-    void buildHitList(creature **hitList, const creature *attacker, creature *defender, const boolean sweep);
+    void buildHitList(const creature **hitList, const creature *attacker, creature *defender, const boolean sweep);
     void addScentToCell(short x, short y, short distance);
     void populateItems(pos upstairs);
     item *placeItemAt(item *theItem, pos dest);


### PR DESCRIPTION
I have replaced every `creature **hitList` with `const creature **hitList`. This removes the incompatible const pointer errors with GCC 14 and allows for compilation without the `-Wno-error=incompatible-pointer-types` flag. However it introduces many strncpy and strncat warnings so I am not sure if this is an appropriate solution.

Refs #696 

Any advice would be appreciated.