### PR TITLE
Bugfix paralysis runic

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -164,6 +164,42 @@ static void addMonsterToContiguousMonsterGrid(short x, short y, creature *monst,
     }
 }
 
+static short alliedCloneCount(creature *monst) {
+    short count = 0;
+    for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
+        creature *temp = nextCreature(&it);
+        if (temp != monst
+            && temp->info.monsterID == monst->info.monsterID
+            && monstersAreTeammates(temp, monst)) {
+
+            count++;
+        }
+    }
+    if (rogue.depthLevel > 1) {
+        for (creatureIterator it = iterateCreatures(&levels[rogue.depthLevel - 2].monsters); hasNextCreature(it);) {
+            creature *temp = nextCreature(&it);
+            if (temp != monst
+                && temp->info.monsterID == monst->info.monsterID
+                && monstersAreTeammates(temp, monst)) {
+
+                count++;
+            }
+        }
+    }
+    if (rogue.depthLevel < gameConst->deepestLevel) {
+        for (creatureIterator it = iterateCreatures(&levels[rogue.depthLevel].monsters); hasNextCreature(it);) {
+            creature *temp = nextCreature(&it);
+            if (temp != monst
+                && temp->info.monsterID == monst->info.monsterID
+                && monstersAreTeammates(temp, monst)) {
+
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
 // Splits a monster in half.
 // The split occurs only if there is a spot adjacent to the contiguous
 // group of monsters that the monster would not avoid.
@@ -262,42 +298,6 @@ static void splitMonster(creature *monst, pos loc) {
             }
         }
     }
-}
-
-static short alliedCloneCount(creature *monst) {
-    short count = 0;
-    for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
-        creature *temp = nextCreature(&it);
-        if (temp != monst
-            && temp->info.monsterID == monst->info.monsterID
-            && monstersAreTeammates(temp, monst)) {
-
-            count++;
-        }
-    }
-    if (rogue.depthLevel > 1) {
-        for (creatureIterator it = iterateCreatures(&levels[rogue.depthLevel - 2].monsters); hasNextCreature(it);) {
-            creature *temp = nextCreature(&it);
-            if (temp != monst
-                && temp->info.monsterID == monst->info.monsterID
-                && monstersAreTeammates(temp, monst)) {
-
-                count++;
-            }
-        }
-    }
-    if (rogue.depthLevel < gameConst->deepestLevel) {
-        for (creatureIterator it = iterateCreatures(&levels[rogue.depthLevel].monsters); hasNextCreature(it);) {
-            creature *temp = nextCreature(&it);
-            if (temp != monst
-                && temp->info.monsterID == monst->info.monsterID
-                && monstersAreTeammates(temp, monst)) {
-
-                count++;
-            }
-        }
-    }
-    return count;
 }
 
 // This function is called whenever one creature acts aggressively against another in a way that directly causes damage.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4446,6 +4446,7 @@ static boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                     if (!alreadyReflected
                         || caster != &player) {
                         moralAttack(caster, monst);
+                        splitMonster(monst, caster);
                     }
                 }
                 if (theBolt->flags & BF_FIERY) {
@@ -6053,6 +6054,7 @@ static boolean hitMonsterWithProjectileWeapon(creature *thrower, creature *monst
             messageWithColor(buf, messageColorFromVictim(monst), 0);
         }
         moralAttack(thrower, monst);
+        splitMonster(monst, thrower);
         if (armorRunicString[0]) {
             message(armorRunicString, 0);
         }

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3205,6 +3205,7 @@ extern "C" {
     void initializeStatus(creature *monst);
     void handlePaladinFeat(creature *defender);
     void moralAttack(creature *attacker, creature *defender);
+    void splitMonster(creature *monst, creature *attacker);
     short runicWeaponChance(item *theItem, boolean customEnchantLevel, fixpt enchantLevel);
     void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed);
     void disentangle(creature *monst);


### PR DESCRIPTION
Fixes #699. Removed monster splitting from moralAttack(). Confirmed expected behavior with thrown weapons, damage staffs, standard weapons, quietus runic, and paralysis runic. 