### PR TITLE
Fix clang error with incompatible function pointer types

### DIFF
--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -128,7 +128,7 @@ static void _delayUpTo(short ms) {
     lastDelayTime = getTime();
 }
 
-static boolean curses_pauseForMilliseconds(short milliseconds) {
+static boolean curses_pauseForMilliseconds(short milliseconds, PauseBehavior behavior) {
     Term.refresh();
     _delayUpTo(milliseconds);
 


### PR DESCRIPTION

    This fixes the following compiler error.
    
    src/platform/curses-platform.c:226:5: error: incompatible function pointer types initializing
    'char ()(short, PauseBehavior)' (aka 'char ()(short, struct PauseBehavior)')
    with an expression of type 'char (short)' [-Wincompatible-function-pointer-types]
    curses_pauseForMilliseconds,
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
