### PR TITLE
Fix formatting issue in describeLocation function

### DIFF
--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -347,6 +347,9 @@ void describeLocation(char *buf, short x, short y) {
         }
 
         if (theItem) {
+            if (verb[strlen(verb) - 1] != ' ') {
+                strcat(verb, " ");
+            }
             strcpy(preposition, "over");
             if (monsterIsPlayer) {
                 strcat(itemLocation, standsInTerrain ? " in " : " on ");


### PR DESCRIPTION
Fix: #711 

### Issue:
The problem stemmed from the concatenation process in the [describeLocation](https://github.com/tmewett/BrogueCE/blob/cf12bf893eb963771d628dfc78b5a62bf71ddda8/src/brogue/Movement.c#L349) [Movement.c] function. Specifically, when appending strings, the code did not consistently check if a space already existed at the end of one string before adding another space. This could result in double spaces when the next string was concatenated.

### Suggested Solution:
To resolve this, I added a check to ensure that a space is only added if one does not already exist at the end of the string. The updated code snippet ensures that the verb string always ends with exactly one space before concatenating the next part of the sentence:

```c
if (verb[strlen(verb) - 1] != ' ') {
    strcat(verb, " ");
}
```

### Before: 
<img width="829" alt="357658044-9461b391-f7b9-41f2-96e2-ebd48811173f" src="https://github.com/user-attachments/assets/d54cf43c-106c-45e7-a4d1-5f6ff3dc10a4">
 
### After: <img width="1022" alt="Screenshot 2024-08-16 at 12 26 27" src="https://github.com/user-attachments/assets/f93ad12d-09b5-48d2-8467-f728a9e6847a"> 
