### PR TITLE
Add seed hiding controlled by cmd line option

### DIFF
--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -4411,7 +4411,12 @@ void printSeed() {
     } else if (rogue.wizard) {
         strcpy(mode,"wizard mode; ");
     }
-    snprintf(buf, COLS, "Dungeon seed #%llu; turn #%lu; %sversion %s", (unsigned long long)rogue.seed, rogue.playerTurnNumber, mode, gameConst->versionString);
+    if (rogue.hideSeed) {
+        snprintf(buf, COLS, "Dungeon seed HIDDEN; turn #%lu; %sversion %s", rogue.playerTurnNumber, mode, gameConst->versionString);
+    }
+    else {
+        snprintf(buf, COLS, "Dungeon seed #%llu; turn #%lu; %sversion %s", (unsigned long long)rogue.seed, rogue.playerTurnNumber, mode, gameConst->versionString);
+    }
     message(buf, 0);
 }
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2452,6 +2452,7 @@ typedef struct playerCharacter {
     boolean alreadyFell;                // so the player can fall only one depth per turn
     boolean eligibleToUseStairs;        // so the player uses stairs only when he steps onto them
     boolean trueColorMode;              // whether lighting effects are disabled
+    boolean hideSeed;                   // whether seed is hidden when pressing SEED_KEY
     boolean displayStealthRangeMode;    // whether your stealth range is displayed
     boolean quit;                       // to skip the typical end-game theatrics when the player quits
     uint64_t seed;                      // the master seed for generating the entire dungeon

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -187,6 +187,7 @@ void initializeRogue(uint64_t seed) {
     item *theItem;
     boolean playingback, playbackFF, playbackPaused, wizard, easy, displayStealthRangeMode;
     boolean trueColorMode;
+    boolean hideSeed;
     short oldRNG;
     char currentGamePath[BROGUE_FILENAME_MAX];
 
@@ -194,6 +195,7 @@ void initializeRogue(uint64_t seed) {
     playbackPaused = rogue.playbackPaused;
     playbackFF = rogue.playbackFastForward;
     wizard = rogue.wizard;
+    hideSeed = rogue.hideSeed;
     easy = rogue.easyMode;
     displayStealthRangeMode = rogue.displayStealthRangeMode;
     trueColorMode = rogue.trueColorMode;
@@ -209,6 +211,7 @@ void initializeRogue(uint64_t seed) {
     rogue.playbackPaused = playbackPaused;
     rogue.playbackFastForward = playbackFF;
     rogue.wizard = wizard;
+    rogue.hideSeed = hideSeed;
     rogue.easyMode = easy;
     rogue.displayStealthRangeMode = displayStealthRangeMode;
     rogue.trueColorMode = trueColorMode;

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -43,6 +43,7 @@ static void printCommandlineHelp() {
     "--stealth      -S          display stealth range\n"
     "--no-effects   -E          disable color effects\n"
     "--wizard       -W          run in wizard mode, invincible with powerful items\n"
+    "--hide-seed                disable seed display in game\n"
     "[--csv] --print-seed-catalog [START NUM LEVELS]\n"
     "                           (optional csv format)\n"
     "                           prints a catalog of the first LEVELS levels of NUM\n"
@@ -306,6 +307,11 @@ int main(int argc, char *argv[])
 
         if (strcmp(argv[i], "--wizard") == 0 || strcmp(argv[i], "-W") == 0) {
             rogue.wizard = true;
+            continue;
+        }
+
+        if (strcmp(argv[i], "--hide-seed") == 0) {
+            rogue.hideSeed = true;
             continue;
         }
 


### PR DESCRIPTION
Adds a `--hide-seed` command line option that hides the seed display when playing. This is used in web-brogue where seeds are obscured to players until the end of game to avoid players trivially practising the same seed offline.

![seedafter](https://github.com/user-attachments/assets/b638bd42-af13-40c4-a8c7-e279ffb102e4)
