### PR TITLE
fix clang warnings - adjust array sizes

### DIFF
--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -1401,7 +1401,7 @@ boolean loadSavedGame() {
 static void describeKeystroke(unsigned char key, char *description) {
     short i;
     long c;
-    const long keyList[50] = {UP_KEY, DOWN_KEY, LEFT_KEY, RIGHT_KEY, UP_ARROW, LEFT_ARROW,
+    const long keyList[51] = {UP_KEY, DOWN_KEY, LEFT_KEY, RIGHT_KEY, UP_ARROW, LEFT_ARROW,
         DOWN_ARROW, RIGHT_ARROW, UPLEFT_KEY, UPRIGHT_KEY, DOWNLEFT_KEY, DOWNRIGHT_KEY,
         DESCEND_KEY, ASCEND_KEY, REST_KEY, AUTO_REST_KEY, SEARCH_KEY, INVENTORY_KEY,
         ACKNOWLEDGE_KEY, EQUIP_KEY, UNEQUIP_KEY, APPLY_KEY, THROW_KEY, RELABEL_KEY, DROP_KEY, CALL_KEY,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2902,8 +2902,8 @@ extern "C" {
                           short originX, short originY,
                           unsigned long requiredMachineFlags,
                           item *adoptiveItem,
-                          item *parentSpawnedItems[50],
-                          creature *parentSpawnedMonsters[50]);
+                          item *parentSpawnedItems[MACHINES_BUFFER_LENGTH],
+                          creature *parentSpawnedMonsters[MACHINES_BUFFER_LENGTH]);
     void attachRooms(short **grid, const dungeonProfile *theDP, short attempts, short maxRoomCount);
     void digDungeon(void);
     void updateMapToShore(void);


### PR DESCRIPTION
Fixes some small warnings caught by clang about arrays being sized incorrectly:

- `keyList` was slightly too short to have space for the last item, `UNKNOWN_KEY`
- `parentSpawnedItems` were recently increased to length `MACHINES_BUFFER_LENGTH` (actually 200) in the `.c` file, but the declaration in the `Rogue.h` header was missed