### PR TITLE
use pos type for `getQualifyingPathLocNear`

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3529,8 +3529,7 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
             pmap[*x][*y].flags &= ~HAS_MONSTER;
         }
 
-        pos qualifiedPosition = { *x, *y };
-        qualifiedPosition = getQualifyingPathLocNear(*x, *y, true, T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
+        pos qualifiedPosition = getQualifyingPathLocNear((pos){ *x, *y }, true, T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
                                  avoidedFlagsForMonster(&(monst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS | IS_IN_MACHINE), true);
         *x = qualifiedPosition.x;
         *y = qualifiedPosition.y;

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3530,7 +3530,7 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
         }
 
         pos qualifiedPosition = { *x, *y };
-        getQualifyingPathLocNear(&qualifiedPosition, *x, *y, true, T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
+        qualifiedPosition = getQualifyingPathLocNear(*x, *y, true, T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
                                  avoidedFlagsForMonster(&(monst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS | IS_IN_MACHINE), true);
         *x = qualifiedPosition.x;
         *y = qualifiedPosition.y;

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3528,8 +3528,12 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
             // so clearing it might screw up an existing monster.)
             pmap[*x][*y].flags &= ~HAS_MONSTER;
         }
-        getQualifyingPathLocNear(x, y, *x, *y, true, T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
+
+        pos qualifiedPosition = { *x, *y };
+        getQualifyingPathLocNear(&qualifiedPosition, *x, *y, true, T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
                                  avoidedFlagsForMonster(&(monst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS | IS_IN_MACHINE), true);
+        *x = qualifiedPosition.x;
+        *y = qualifiedPosition.y;
     }
     pmap[*x][*y].flags |= HAS_MONSTER;
     monst->bookkeepingFlags &= ~(MB_PREPLACED | MB_APPROACHING_DOWNSTAIRS | MB_APPROACHING_UPSTAIRS | MB_APPROACHING_PIT | MB_ABSORBING);

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -683,7 +683,7 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
 
                 for (i = 0; i < (weaponImageCount(enchant)); i++) {
                     newMonst = generateMonster(MK_SPECTRAL_IMAGE, true, false);
-                    getQualifyingPathLocNear(&newMonst, defender->loc.x, defender->loc.y, true,
+                    newMonst->loc = getQualifyingPathLocNear(defender->loc.x, defender->loc.y, true,
                                              T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                              avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                     newMonst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER | MB_TELEPATHICALLY_REVEALED);

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -683,7 +683,7 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
 
                 for (i = 0; i < (weaponImageCount(enchant)); i++) {
                     newMonst = generateMonster(MK_SPECTRAL_IMAGE, true, false);
-                    newMonst->loc = getQualifyingPathLocNear(defender->loc.x, defender->loc.y, true,
+                    newMonst->loc = getQualifyingPathLocNear(defender->loc, true,
                                              T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                              avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                     newMonst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER | MB_TELEPATHICALLY_REVEALED);

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -683,7 +683,7 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
 
                 for (i = 0; i < (weaponImageCount(enchant)); i++) {
                     newMonst = generateMonster(MK_SPECTRAL_IMAGE, true, false);
-                    getQualifyingPathLocNear(&(newMonst->loc.x), &(newMonst->loc.y), defender->loc.x, defender->loc.y, true,
+                    getQualifyingPathLocNear(&newMonst, defender->loc.x, defender->loc.y, true,
                                              T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                              avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                     newMonst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER | MB_TELEPATHICALLY_REVEALED);

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -245,44 +245,43 @@ void randomLocationInGrid(short **grid, short *x, short *y, short validValue) {
 }
 
 // Finds the lowest positive number in a grid, chooses one location with that number randomly and returns it as (x, y).
-// If there are no valid locations, returns (-1, -1).
-static void randomLeastPositiveLocationInGrid(short **grid, short *x, short *y, boolean deterministic) {
+// If there are no valid locations, returns INVALID_POS, aka (-1, -1).
+static pos randomLeastPositiveLocationInGrid(short **grid, boolean deterministic) {
     const short targetValue = leastPositiveValueInGrid(grid);
-    short locationCount;
-    short i, j, index;
 
     if (targetValue == 0) {
-        *x = *y = -1;
-        return;
+        return INVALID_POS;
     }
 
-    locationCount = 0;
-    for(i = 0; i < DCOLS; i++) {
-        for(j = 0; j < DROWS; j++) {
+    short locationCount = 0;
+    for(int i = 0; i < DCOLS; i++) {
+        for(int j = 0; j < DROWS; j++) {
             if (grid[i][j] == targetValue) {
                 locationCount++;
             }
         }
     }
 
+    short index;
     if (deterministic) {
         index = locationCount / 2;
     } else {
         index = rand_range(0, locationCount - 1);
     }
 
-    for(i = 0; i < DCOLS && index >= 0; i++) {
-        for(j = 0; j < DROWS && index >= 0; j++) {
+    for(int i = 0; i < DCOLS && index >= 0; i++) {
+        for(int j = 0; j < DROWS && index >= 0; j++) {
             if (grid[i][j] == targetValue) {
                 if (index == 0) {
-                    *x = i;
-                    *y = j;
+                    return (pos){ .x = i, .y = j };
                 }
                 index--;
             }
         }
     }
-    return;
+    // This should not be reachable, since we should have already hit
+    // the unique 'index == 0' point.
+    return INVALID_POS;
 }
 
 boolean getQualifyingPathLocNear(pos *retLoc,
@@ -331,7 +330,7 @@ boolean getQualifyingPathLocNear(pos *retLoc,
     }
 
     // Get the solution.
-    randomLeastPositiveLocationInGrid(grid, &retLoc->x, &retLoc->y, deterministic);
+    *retLoc = randomLeastPositiveLocationInGrid(grid, deterministic);
 
 //    dumpLevelToScreen();
 //    displayGrid(grid);

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -284,7 +284,7 @@ static pos randomLeastPositiveLocationInGrid(short **grid, boolean deterministic
     return INVALID_POS;
 }
 
-boolean getQualifyingPathLocNear(pos *retLoc,
+pos getQualifyingPathLocNear(
                                  short x, short y,
                                  boolean hallwaysAllowed,
                                  unsigned long blockingTerrainFlags,
@@ -299,8 +299,7 @@ boolean getQualifyingPathLocNear(pos *retLoc,
         && !(pmap[x][y].flags & (blockingMapFlags | forbiddenMapFlags))
         && (hallwaysAllowed || passableArcCount(x, y) <= 1)) {
 
-        *retLoc = (pos){ x, y };
-        return true;
+        return (pos){ x, y };
     }
 
     // Allocate the grids.
@@ -330,7 +329,7 @@ boolean getQualifyingPathLocNear(pos *retLoc,
     }
 
     // Get the solution.
-    *retLoc = randomLeastPositiveLocationInGrid(grid, deterministic);
+    pos retLoc = randomLeastPositiveLocationInGrid(grid, deterministic);
 
 //    dumpLevelToScreen();
 //    displayGrid(grid);
@@ -343,20 +342,20 @@ boolean getQualifyingPathLocNear(pos *retLoc,
     freeGrid(costMap);
 
     // Fall back to a pathing-agnostic alternative if there are no solutions.
-    if (!isPosInMap(*retLoc)) {
-        pos loc;
-        if (getQualifyingLocNear(&loc, (pos){ x, y }, hallwaysAllowed, NULL,
-                                 (blockingTerrainFlags | forbiddenTerrainFlags),
-                                 (blockingMapFlags | forbiddenMapFlags),
-                                 false, deterministic)) {
-            *retLoc = loc;
-            return true; // Found a fallback solution.
-        } else {
-            return false; // No solutions.
-        }
-    } else {
-        return true; // Found a primary solution.
+    if (isPosInMap(retLoc)) {
+        return retLoc;
     }
+    
+    pos loc;
+    if (getQualifyingLocNear(&loc, (pos){ x, y }, hallwaysAllowed, NULL,
+                                (blockingTerrainFlags | forbiddenTerrainFlags),
+                                (blockingMapFlags | forbiddenMapFlags),
+                                false, deterministic)) {
+        return loc;
+    } else {
+        return retLoc;
+    }
+    
 }
 
 static void cellularAutomataRound(short **grid, char birthParameters[9], char survivalParameters[9]) {

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -285,7 +285,7 @@ static void randomLeastPositiveLocationInGrid(short **grid, short *x, short *y, 
     return;
 }
 
-boolean getQualifyingPathLocNear(short *retValX, short *retValY,
+boolean getQualifyingPathLocNear(pos *retLoc,
                                  short x, short y,
                                  boolean hallwaysAllowed,
                                  unsigned long blockingTerrainFlags,
@@ -300,8 +300,7 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
         && !(pmap[x][y].flags & (blockingMapFlags | forbiddenMapFlags))
         && (hallwaysAllowed || passableArcCount(x, y) <= 1)) {
 
-        *retValX = x;
-        *retValY = y;
+        *retLoc = (pos){ x, y };
         return true;
     }
 
@@ -332,7 +331,7 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
     }
 
     // Get the solution.
-    randomLeastPositiveLocationInGrid(grid, retValX, retValY, deterministic);
+    randomLeastPositiveLocationInGrid(grid, &retLoc->x, &retLoc->y, deterministic);
 
 //    dumpLevelToScreen();
 //    displayGrid(grid);
@@ -345,14 +344,13 @@ boolean getQualifyingPathLocNear(short *retValX, short *retValY,
     freeGrid(costMap);
 
     // Fall back to a pathing-agnostic alternative if there are no solutions.
-    if (*retValX == -1 && *retValY == -1) {
+    if (!isPosInMap(*retLoc)) {
         pos loc;
         if (getQualifyingLocNear(&loc, (pos){ x, y }, hallwaysAllowed, NULL,
                                  (blockingTerrainFlags | forbiddenTerrainFlags),
                                  (blockingMapFlags | forbiddenMapFlags),
                                  false, deterministic)) {
-            *retValX = loc.x;
-            *retValY = loc.y;
+            *retLoc = loc;
             return true; // Found a fallback solution.
         } else {
             return false; // No solutions.

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -285,21 +285,22 @@ static pos randomLeastPositiveLocationInGrid(short **grid, boolean deterministic
 }
 
 pos getQualifyingPathLocNear(
-                                 short x, short y,
-                                 boolean hallwaysAllowed,
-                                 unsigned long blockingTerrainFlags,
-                                 unsigned long blockingMapFlags,
-                                 unsigned long forbiddenTerrainFlags,
-                                 unsigned long forbiddenMapFlags,
-                                 boolean deterministic) {
+    pos target,
+    boolean hallwaysAllowed,
+    unsigned long blockingTerrainFlags,
+    unsigned long blockingMapFlags,
+    unsigned long forbiddenTerrainFlags,
+    unsigned long forbiddenMapFlags,
+    boolean deterministic
+) {
     short **grid, **costMap;
 
     // First check the given location to see if it works, as an optimization.
-    if (!cellHasTerrainFlag((pos){ x, y }, blockingTerrainFlags | forbiddenTerrainFlags)
-        && !(pmap[x][y].flags & (blockingMapFlags | forbiddenMapFlags))
-        && (hallwaysAllowed || passableArcCount(x, y) <= 1)) {
+    if (!cellHasTerrainFlag(target, blockingTerrainFlags | forbiddenTerrainFlags)
+        && !(pmapAt(target)->flags & (blockingMapFlags | forbiddenMapFlags))
+        && (hallwaysAllowed || passableArcCount(target.x, target.y) <= 1)) {
 
-        return (pos){ x, y };
+        return target;
     }
 
     // Allocate the grids.
@@ -317,8 +318,8 @@ pos getQualifyingPathLocNear(
     }
 
     // Run the distance scan.
-    grid[x][y] = 1;
-    costMap[x][y] = 1;
+    grid[target.x][target.y] = 1;
+    costMap[target.x][target.y] = 1;
     dijkstraScan(grid, costMap, true);
     findReplaceGrid(grid, 30000, 30000, 0);
 
@@ -347,7 +348,7 @@ pos getQualifyingPathLocNear(
     }
     
     pos loc;
-    if (getQualifyingLocNear(&loc, (pos){ x, y }, hallwaysAllowed, NULL,
+    if (getQualifyingLocNear(&loc, target, hallwaysAllowed, NULL,
                                 (blockingTerrainFlags | forbiddenTerrainFlags),
                                 (blockingMapFlags | forbiddenMapFlags),
                                 false, deterministic)) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4728,7 +4728,7 @@ static void detonateBolt(bolt *theBolt, creature *caster, short x, short y, bool
         case BE_CONJURATION:
             for (i = 0; i < (staffBladeCount(theBolt->magnitude * FP_FACTOR)); i++) {
                 monst = generateMonster(MK_SPECTRAL_BLADE, true, false);
-                getQualifyingPathLocNear(&monst->loc, x, y, true,
+                monst->loc = getQualifyingPathLocNear(x, y, true,
                                          T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                                          avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                 monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);
@@ -6632,7 +6632,7 @@ static void summonGuardian(item *theItem) {
     creature *monst;
 
     monst = generateMonster(MK_CHARM_GUARDIAN, false, false);
-    getQualifyingPathLocNear(&monst->loc, x, y, true,
+    monst->loc = getQualifyingPathLocNear(x, y, true,
                              T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                              avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
     monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4728,7 +4728,7 @@ static void detonateBolt(bolt *theBolt, creature *caster, short x, short y, bool
         case BE_CONJURATION:
             for (i = 0; i < (staffBladeCount(theBolt->magnitude * FP_FACTOR)); i++) {
                 monst = generateMonster(MK_SPECTRAL_BLADE, true, false);
-                monst->loc = getQualifyingPathLocNear(x, y, true,
+                monst->loc = getQualifyingPathLocNear((pos){ x, y }, true,
                                          T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                                          avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                 monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);
@@ -6632,7 +6632,7 @@ static void summonGuardian(item *theItem) {
     creature *monst;
 
     monst = generateMonster(MK_CHARM_GUARDIAN, false, false);
-    monst->loc = getQualifyingPathLocNear(x, y, true,
+    monst->loc = getQualifyingPathLocNear((pos){ x, y }, true,
                              T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                              avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
     monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4728,7 +4728,7 @@ static void detonateBolt(bolt *theBolt, creature *caster, short x, short y, bool
         case BE_CONJURATION:
             for (i = 0; i < (staffBladeCount(theBolt->magnitude * FP_FACTOR)); i++) {
                 monst = generateMonster(MK_SPECTRAL_BLADE, true, false);
-                getQualifyingPathLocNear(&(monst->loc.x), &(monst->loc.y), x, y, true,
+                getQualifyingPathLocNear(&monst->loc, x, y, true,
                                          T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                                          avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                 monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);
@@ -6632,7 +6632,7 @@ static void summonGuardian(item *theItem) {
     creature *monst;
 
     monst = generateMonster(MK_CHARM_GUARDIAN, false, false);
-    getQualifyingPathLocNear(&(monst->loc.x), &(monst->loc.y), x, y, true,
+    getQualifyingPathLocNear(&monst->loc, x, y, true,
                              T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                              avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
     monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -597,7 +597,7 @@ creature *cloneMonster(creature *monst, boolean announce, boolean placeClone) {
 //      getQualifyingLocNear(loc, monst->loc.x, monst->loc.y, true, 0, forbiddenFlagsForMonster(&(monst->info)), (HAS_PLAYER | HAS_MONSTER), false, false);
 //      newMonst->loc.x = loc[0];
 //      newMonst->loc.y = loc[1];
-        getQualifyingPathLocNear(&newMonst->loc, monst->loc.x, monst->loc.y, true,
+        newMonst->loc = getQualifyingPathLocNear(monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                  avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
         pmapAt(newMonst->loc)->flags |= HAS_MONSTER;
@@ -718,7 +718,7 @@ static boolean spawnMinions(short hordeID, creature *leader, boolean summoned, b
             monst = generateMonster(theHorde->memberType[iSpecies], itemPossible, !summoned);
             failsafe = 0;
             do {
-                getQualifyingPathLocNear(&monst->loc, x, y, summoned,
+                monst->loc = getQualifyingPathLocNear(x, y, summoned,
                                          T_DIVIDES_LEVEL & forbiddenTerrainFlags, (HAS_PLAYER | HAS_STAIRS),
                                          forbiddenTerrainFlags, HAS_MONSTER, false);
             } while (theHorde->spawnsIn && !cellHasTerrainType(monst->loc, theHorde->spawnsIn) && failsafe++ < 20);
@@ -2909,7 +2909,7 @@ boolean resurrectAlly(const pos loc) {
         removeCreature(&purgatory, monToRaise);
         prependCreature(monsters, monToRaise);
 
-        getQualifyingPathLocNear(&monToRaise->loc, loc.x, loc.y, true,
+        monToRaise->loc = getQualifyingPathLocNear(loc.x, loc.y, true,
                                  (T_PATHING_BLOCKER | T_HARMFUL_TERRAIN), 0,
                                  0, (HAS_PLAYER | HAS_MONSTER), false);
         pmapAt(monToRaise->loc)->flags |= HAS_MONSTER;
@@ -3835,7 +3835,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
                     pmapAt(monst->loc)->flags |= HAS_MONSTER;
 
                     if (monsterAvoids(defender, (pos){x, y})) { // don't want a flying monster to swap a non-flying monster into lava!
-                        getQualifyingPathLocNear(&defender->loc, x, y, true,
+                        defender->loc = getQualifyingPathLocNear(x, y, true,
                                                  forbiddenFlagsForMonster(&(defender->info)), HAS_PLAYER,
                                                  forbiddenFlagsForMonster(&(defender->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                     } else {
@@ -4065,7 +4065,7 @@ boolean getQualifyingGridLocNear(pos *loc,
 
 void makeMonsterDropItem(creature *monst) {
     pos dropLocation;
-    getQualifyingPathLocNear(&dropLocation, monst->loc.x, monst->loc.y, true,
+    dropLocation = getQualifyingPathLocNear(monst->loc.x, monst->loc.y, true,
                              (T_DIVIDES_LEVEL), 0,
                              T_OBSTRUCTS_ITEMS, (HAS_PLAYER | HAS_STAIRS | HAS_ITEM), false);
     placeItemAt(monst->carriedItem, dropLocation);
@@ -4156,8 +4156,7 @@ void toggleMonsterDormancy(creature *monst) {
 
         // Does it need a new location?
         if (pmapAt(monst->loc)->flags & (HAS_MONSTER | HAS_PLAYER)) { // Occupied!
-            getQualifyingPathLocNear(
-                &monst->loc,
+            monst->loc = getQualifyingPathLocNear(
                 monst->loc.x,
                 monst->loc.y,
                 true,

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -597,7 +597,7 @@ creature *cloneMonster(creature *monst, boolean announce, boolean placeClone) {
 //      getQualifyingLocNear(loc, monst->loc.x, monst->loc.y, true, 0, forbiddenFlagsForMonster(&(monst->info)), (HAS_PLAYER | HAS_MONSTER), false, false);
 //      newMonst->loc.x = loc[0];
 //      newMonst->loc.y = loc[1];
-        getQualifyingPathLocNear(&(newMonst->loc.x), &(newMonst->loc.y), monst->loc.x, monst->loc.y, true,
+        getQualifyingPathLocNear(&newMonst->loc, monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                  avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
         pmapAt(newMonst->loc)->flags |= HAS_MONSTER;
@@ -718,7 +718,7 @@ static boolean spawnMinions(short hordeID, creature *leader, boolean summoned, b
             monst = generateMonster(theHorde->memberType[iSpecies], itemPossible, !summoned);
             failsafe = 0;
             do {
-                getQualifyingPathLocNear(&(monst->loc.x), &(monst->loc.y), x, y, summoned,
+                getQualifyingPathLocNear(&monst->loc, x, y, summoned,
                                          T_DIVIDES_LEVEL & forbiddenTerrainFlags, (HAS_PLAYER | HAS_STAIRS),
                                          forbiddenTerrainFlags, HAS_MONSTER, false);
             } while (theHorde->spawnsIn && !cellHasTerrainType(monst->loc, theHorde->spawnsIn) && failsafe++ < 20);
@@ -2909,7 +2909,7 @@ boolean resurrectAlly(const pos loc) {
         removeCreature(&purgatory, monToRaise);
         prependCreature(monsters, monToRaise);
 
-        getQualifyingPathLocNear(&monToRaise->loc.x, &monToRaise->loc.y, loc.x, loc.y, true,
+        getQualifyingPathLocNear(&monToRaise->loc, loc.x, loc.y, true,
                                  (T_PATHING_BLOCKER | T_HARMFUL_TERRAIN), 0,
                                  0, (HAS_PLAYER | HAS_MONSTER), false);
         pmapAt(monToRaise->loc)->flags |= HAS_MONSTER;
@@ -3835,7 +3835,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
                     pmapAt(monst->loc)->flags |= HAS_MONSTER;
 
                     if (monsterAvoids(defender, (pos){x, y})) { // don't want a flying monster to swap a non-flying monster into lava!
-                        getQualifyingPathLocNear(&(defender->loc.x), &(defender->loc.y), x, y, true,
+                        getQualifyingPathLocNear(&defender->loc, x, y, true,
                                                  forbiddenFlagsForMonster(&(defender->info)), HAS_PLAYER,
                                                  forbiddenFlagsForMonster(&(defender->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                     } else {
@@ -4064,13 +4064,13 @@ boolean getQualifyingGridLocNear(pos *loc,
 }
 
 void makeMonsterDropItem(creature *monst) {
-    short x, y;
-    getQualifyingPathLocNear(&x, &y, monst->loc.x, monst->loc.y, true,
+    pos dropLocation;
+    getQualifyingPathLocNear(&dropLocation, monst->loc.x, monst->loc.y, true,
                              (T_DIVIDES_LEVEL), 0,
                              T_OBSTRUCTS_ITEMS, (HAS_PLAYER | HAS_STAIRS | HAS_ITEM), false);
-    placeItemAt(monst->carriedItem, (pos){ x, y });
+    placeItemAt(monst->carriedItem, dropLocation);
     monst->carriedItem = NULL;
-    refreshDungeonCell((pos){ x, y });
+    refreshDungeonCell(dropLocation);
 }
 
 void checkForContinuedLeadership(creature *monst) {
@@ -4157,8 +4157,7 @@ void toggleMonsterDormancy(creature *monst) {
         // Does it need a new location?
         if (pmapAt(monst->loc)->flags & (HAS_MONSTER | HAS_PLAYER)) { // Occupied!
             getQualifyingPathLocNear(
-                &(monst->loc.x),
-                &(monst->loc.y),
+                &monst->loc,
                 monst->loc.x,
                 monst->loc.y,
                 true,

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -4064,10 +4064,12 @@ boolean getQualifyingGridLocNear(pos *loc,
 }
 
 void makeMonsterDropItem(creature *monst) {
-    pos dropLocation;
-    dropLocation = getQualifyingPathLocNear(monst->loc, true,
-                             (T_DIVIDES_LEVEL), 0,
-                             T_OBSTRUCTS_ITEMS, (HAS_PLAYER | HAS_STAIRS | HAS_ITEM), false);
+    pos dropLocation = getQualifyingPathLocNear(
+        monst->loc, true,
+        (T_DIVIDES_LEVEL), 0,
+        T_OBSTRUCTS_ITEMS, (HAS_PLAYER | HAS_STAIRS | HAS_ITEM),
+        false
+    );
     placeItemAt(monst->carriedItem, dropLocation);
     monst->carriedItem = NULL;
     refreshDungeonCell(dropLocation);

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -597,7 +597,7 @@ creature *cloneMonster(creature *monst, boolean announce, boolean placeClone) {
 //      getQualifyingLocNear(loc, monst->loc.x, monst->loc.y, true, 0, forbiddenFlagsForMonster(&(monst->info)), (HAS_PLAYER | HAS_MONSTER), false, false);
 //      newMonst->loc.x = loc[0];
 //      newMonst->loc.y = loc[1];
-        newMonst->loc = getQualifyingPathLocNear(monst->loc.x, monst->loc.y, true,
+        newMonst->loc = getQualifyingPathLocNear(monst->loc, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(newMonst->info)), HAS_PLAYER,
                                  avoidedFlagsForMonster(&(newMonst->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
         pmapAt(newMonst->loc)->flags |= HAS_MONSTER;
@@ -718,7 +718,7 @@ static boolean spawnMinions(short hordeID, creature *leader, boolean summoned, b
             monst = generateMonster(theHorde->memberType[iSpecies], itemPossible, !summoned);
             failsafe = 0;
             do {
-                monst->loc = getQualifyingPathLocNear(x, y, summoned,
+                monst->loc = getQualifyingPathLocNear((pos){ x, y }, summoned,
                                          T_DIVIDES_LEVEL & forbiddenTerrainFlags, (HAS_PLAYER | HAS_STAIRS),
                                          forbiddenTerrainFlags, HAS_MONSTER, false);
             } while (theHorde->spawnsIn && !cellHasTerrainType(monst->loc, theHorde->spawnsIn) && failsafe++ < 20);
@@ -2909,7 +2909,7 @@ boolean resurrectAlly(const pos loc) {
         removeCreature(&purgatory, monToRaise);
         prependCreature(monsters, monToRaise);
 
-        monToRaise->loc = getQualifyingPathLocNear(loc.x, loc.y, true,
+        monToRaise->loc = getQualifyingPathLocNear(loc, true,
                                  (T_PATHING_BLOCKER | T_HARMFUL_TERRAIN), 0,
                                  0, (HAS_PLAYER | HAS_MONSTER), false);
         pmapAt(monToRaise->loc)->flags |= HAS_MONSTER;
@@ -3835,7 +3835,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
                     pmapAt(monst->loc)->flags |= HAS_MONSTER;
 
                     if (monsterAvoids(defender, (pos){x, y})) { // don't want a flying monster to swap a non-flying monster into lava!
-                        defender->loc = getQualifyingPathLocNear(x, y, true,
+                        defender->loc = getQualifyingPathLocNear((pos){ x, y }, true,
                                                  forbiddenFlagsForMonster(&(defender->info)), HAS_PLAYER,
                                                  forbiddenFlagsForMonster(&(defender->info)), (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                     } else {
@@ -4065,7 +4065,7 @@ boolean getQualifyingGridLocNear(pos *loc,
 
 void makeMonsterDropItem(creature *monst) {
     pos dropLocation;
-    dropLocation = getQualifyingPathLocNear(monst->loc.x, monst->loc.y, true,
+    dropLocation = getQualifyingPathLocNear(monst->loc, true,
                              (T_DIVIDES_LEVEL), 0,
                              T_OBSTRUCTS_ITEMS, (HAS_PLAYER | HAS_STAIRS | HAS_ITEM), false);
     placeItemAt(monst->carriedItem, dropLocation);
@@ -4157,8 +4157,7 @@ void toggleMonsterDormancy(creature *monst) {
         // Does it need a new location?
         if (pmapAt(monst->loc)->flags & (HAS_MONSTER | HAS_PLAYER)) { // Occupied!
             monst->loc = getQualifyingPathLocNear(
-                monst->loc.x,
-                monst->loc.y,
+                monst->loc,
                 true,
                 T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)),
                 HAS_PLAYER,

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1188,7 +1188,7 @@ boolean playerMoves(short direction) {
                 defender->loc.x = x;
                 defender->loc.y = y;
                 if (monsterAvoids(defender, (pos){x, y})) {
-                    defender->loc = getQualifyingPathLocNear(player.loc.x, player.loc.y, true, forbiddenFlagsForMonster(&(defender->info)), 0, 0, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
+                    defender->loc = getQualifyingPathLocNear(player.loc, true, forbiddenFlagsForMonster(&(defender->info)), 0, 0, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                 }
                 //getQualifyingLocNear(loc, player.loc.x, player.loc.y, true, NULL, forbiddenFlagsForMonster(&(defender->info)) & ~(T_IS_DF_TRAP | T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES), HAS_MONSTER, false, false);
                 //defender->loc.x = loc[0];

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1188,7 +1188,7 @@ boolean playerMoves(short direction) {
                 defender->loc.x = x;
                 defender->loc.y = y;
                 if (monsterAvoids(defender, (pos){x, y})) {
-                    getQualifyingPathLocNear(&defender->loc, player.loc.x, player.loc.y, true, forbiddenFlagsForMonster(&(defender->info)), 0, 0, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
+                    defender->loc = getQualifyingPathLocNear(player.loc.x, player.loc.y, true, forbiddenFlagsForMonster(&(defender->info)), 0, 0, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                 }
                 //getQualifyingLocNear(loc, player.loc.x, player.loc.y, true, NULL, forbiddenFlagsForMonster(&(defender->info)) & ~(T_IS_DF_TRAP | T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES), HAS_MONSTER, false, false);
                 //defender->loc.x = loc[0];

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1188,7 +1188,7 @@ boolean playerMoves(short direction) {
                 defender->loc.x = x;
                 defender->loc.y = y;
                 if (monsterAvoids(defender, (pos){x, y})) {
-                    getQualifyingPathLocNear(&(defender->loc.x), &(defender->loc.y), player.loc.x, player.loc.y, true, forbiddenFlagsForMonster(&(defender->info)), 0, 0, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
+                    getQualifyingPathLocNear(&defender->loc, player.loc.x, player.loc.y, true, forbiddenFlagsForMonster(&(defender->info)), 0, 0, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
                 }
                 //getQualifyingLocNear(loc, player.loc.x, player.loc.y, true, NULL, forbiddenFlagsForMonster(&(defender->info)) & ~(T_IS_DF_TRAP | T_IS_DEEP_WATER | T_SPONTANEOUSLY_IGNITES), HAS_MONSTER, false, false);
                 //defender->loc.x = loc[0];

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3345,13 +3345,14 @@ extern "C" {
     short validLocationCount(short **grid, short validValue);
     void randomLocationInGrid(short **grid, short *x, short *y, short validValue);
     pos getQualifyingPathLocNear(
-                                     short x, short y,
-                                     boolean hallwaysAllowed,
-                                     unsigned long blockingTerrainFlags,
-                                     unsigned long blockingMapFlags,
-                                     unsigned long forbiddenTerrainFlags,
-                                     unsigned long forbiddenMapFlags,
-                                     boolean deterministic);
+        pos target,
+        boolean hallwaysAllowed,
+        unsigned long blockingTerrainFlags,
+        unsigned long blockingMapFlags,
+        unsigned long forbiddenTerrainFlags,
+        unsigned long forbiddenMapFlags,
+        boolean deterministic
+    );
     void createBlobOnGrid(short **grid,
                           short *retMinX, short *retMinY, short *retWidth, short *retHeight,
                           short roundCount,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3344,7 +3344,7 @@ extern "C" {
     void getTMGrid(short **grid, short value, unsigned long TMflags);
     short validLocationCount(short **grid, short validValue);
     void randomLocationInGrid(short **grid, short *x, short *y, short validValue);
-    boolean getQualifyingPathLocNear(short *retValX, short *retValY,
+    boolean getQualifyingPathLocNear(pos *retLoc,
                                      short x, short y,
                                      boolean hallwaysAllowed,
                                      unsigned long blockingTerrainFlags,

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3344,7 +3344,7 @@ extern "C" {
     void getTMGrid(short **grid, short value, unsigned long TMflags);
     short validLocationCount(short **grid, short validValue);
     void randomLocationInGrid(short **grid, short *x, short *y, short validValue);
-    boolean getQualifyingPathLocNear(pos *retLoc,
+    pos getQualifyingPathLocNear(
                                      short x, short y,
                                      boolean hallwaysAllowed,
                                      unsigned long blockingTerrainFlags,

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -844,7 +844,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             }
         }
         if (!placedPlayer) {
-            getQualifyingPathLocNear(&loc,
+            loc = getQualifyingPathLocNear(
                                      player.loc.x, player.loc.y,
                                      true,
                                      T_DIVIDES_LEVEL, 0,

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -845,7 +845,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
         }
         if (!placedPlayer) {
             loc = getQualifyingPathLocNear(
-                                     player.loc.x, player.loc.y,
+                                     player.loc,
                                      true,
                                      T_DIVIDES_LEVEL, 0,
                                      T_PATHING_BLOCKER, (HAS_MONSTER | HAS_STAIRS | IS_IN_MACHINE),

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -844,7 +844,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             }
         }
         if (!placedPlayer) {
-            getQualifyingPathLocNear(&loc.x, &loc.y,
+            getQualifyingPathLocNear(&loc,
                                      player.loc.x, player.loc.y,
                                      true,
                                      T_DIVIDES_LEVEL, 0,

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1889,7 +1889,7 @@ static void monsterEntersLevel(creature *monst, short n) {
     monst->targetCorpseLoc = INVALID_POS;
 
     if (!pit) {
-        getQualifyingPathLocNear(&(monst->loc.x), &(monst->loc.y), monst->loc.x, monst->loc.y, true,
+        getQualifyingPathLocNear(&monst->loc, monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
                                  avoidedFlagsForMonster(&(monst->info)), HAS_STAIRS, false);
     }
@@ -1899,7 +1899,7 @@ static void monsterEntersLevel(creature *monst, short n) {
         // Monsters using the stairs will displace any creatures already located there, to thwart stair-dancing.
         creature *prevMonst = monsterAtLoc(monst->loc);
         brogueAssert(prevMonst);
-        getQualifyingPathLocNear(&(prevMonst->loc.x), &(prevMonst->loc.y), monst->loc.x, monst->loc.y, true,
+        getQualifyingPathLocNear(&prevMonst->loc, monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(prevMonst->info)), 0,
                                  avoidedFlagsForMonster(&(prevMonst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS), false);
         pmapAt(monst->loc)->flags &= ~(HAS_PLAYER | HAS_MONSTER);

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1889,7 +1889,7 @@ static void monsterEntersLevel(creature *monst, short n) {
     monst->targetCorpseLoc = INVALID_POS;
 
     if (!pit) {
-        getQualifyingPathLocNear(&monst->loc, monst->loc.x, monst->loc.y, true,
+        monst->loc = getQualifyingPathLocNear(monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
                                  avoidedFlagsForMonster(&(monst->info)), HAS_STAIRS, false);
     }
@@ -1899,7 +1899,7 @@ static void monsterEntersLevel(creature *monst, short n) {
         // Monsters using the stairs will displace any creatures already located there, to thwart stair-dancing.
         creature *prevMonst = monsterAtLoc(monst->loc);
         brogueAssert(prevMonst);
-        getQualifyingPathLocNear(&prevMonst->loc, monst->loc.x, monst->loc.y, true,
+        prevMonst->loc = getQualifyingPathLocNear(monst->loc.x, monst->loc.y, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(prevMonst->info)), 0,
                                  avoidedFlagsForMonster(&(prevMonst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS), false);
         pmapAt(monst->loc)->flags &= ~(HAS_PLAYER | HAS_MONSTER);

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1889,7 +1889,7 @@ static void monsterEntersLevel(creature *monst, short n) {
     monst->targetCorpseLoc = INVALID_POS;
 
     if (!pit) {
-        monst->loc = getQualifyingPathLocNear(monst->loc.x, monst->loc.y, true,
+        monst->loc = getQualifyingPathLocNear(monst->loc, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)), 0,
                                  avoidedFlagsForMonster(&(monst->info)), HAS_STAIRS, false);
     }
@@ -1899,7 +1899,7 @@ static void monsterEntersLevel(creature *monst, short n) {
         // Monsters using the stairs will displace any creatures already located there, to thwart stair-dancing.
         creature *prevMonst = monsterAtLoc(monst->loc);
         brogueAssert(prevMonst);
-        prevMonst->loc = getQualifyingPathLocNear(monst->loc.x, monst->loc.y, true,
+        prevMonst->loc = getQualifyingPathLocNear(monst->loc, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(prevMonst->info)), 0,
                                  avoidedFlagsForMonster(&(prevMonst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS), false);
         pmapAt(monst->loc)->flags &= ~(HAS_PLAYER | HAS_MONSTER);


### PR DESCRIPTION
Replaces the 4 coordinate parameters (2 out, 2 in) with a single input `pos` and a return `pos` value.

The function previously returned a `boolean`, but this value was never checked by any of its callers. The `false` return state is now represented by returning `INVALID_POS`.

There should be no behavioral changes in this PR.