### PR TITLE
Build a universal binary (arm64 and x86_64) for macOS #739

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: "Install dependencies"
       run: |
@@ -16,7 +16,7 @@ jobs:
         sudo apt install -y libsdl2-dev libsdl2-image-dev
 
     - name: "Checkout sources"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: "Compile"
       run: |
@@ -34,21 +34,21 @@ jobs:
         path: BrogueCE-linux-x86_64.tar.gz
         compression-level: 0  # There's no point compressing something already compressed
 
-  macos:
+  macos-intel:
     runs-on: macos-13
     steps:
     - name: "Checkout sources"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: "Prepare"
       run: |
         make macos/sdl2.rb
 
     - name: "Cache SDL2"
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: sdl2-cellar
-        key: sdl2-${{hashFiles('macos/sdl2.rb')}}
+        key: sdl2-macos-amd64-${{hashFiles('macos/sdl2.rb')}}
 
     - name: "Compile and install dependencies"
       run: |
@@ -83,11 +83,59 @@ jobs:
         path: BrogueCE-macos-x86_64.zip
         compression-level: 0  # There's no point compressing something already compressed
 
+  macos-arm:
+    runs-on: macos-15
+    steps:
+    - name: "Checkout sources"
+      uses: actions/checkout@v4
+
+    - name: "Prepare"
+      run: |
+        make macos/sdl2.rb
+
+    - name: "Cache SDL2"
+      uses: actions/cache@v4
+      with:
+        path: sdl2-cellar
+        key: sdl2-macos-arm64-${{hashFiles('macos/sdl2.rb')}}
+
+    - name: "Compile and install dependencies"
+      run: |
+        if [ -d sdl2-cellar ]; then
+          cp -r sdl2-cellar $(brew --cellar)/sdl2
+          brew link sdl2
+        else
+          brew install --build-from-source ./macos/sdl2.rb
+          cp -r $(brew --cellar)/sdl2 sdl2-cellar
+        fi
+        brew install sdl2_image dylibbundler
+
+    - name: "Compile"
+      run: |
+        make MAC_APP=YES Brogue.app
+      env:
+        MACOSX_DEPLOYMENT_TARGET: "10.7"
+
+    - name: "Fix and bundle dylib references"
+      run: |
+        cd Brogue.app/Contents && dylibbundler -cd -b -x MacOS/brogue
+
+    - name: "Create artifact"
+      run: |
+        make BrogueCE-macos
+        zip -rll BrogueCE-macos-arm64.zip BrogueCE-macos
+
+    - name: "Upload artifact"
+      uses: actions/upload-artifact@v4
+      with:
+        name: macos-arm64
+        path: BrogueCE-macos-arm64.zip
+
   windows:
     runs-on: windows-latest
     steps:
     - name: "Checkout sources"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: "Install dependencies"
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: "Fix and bundle dylib references"
       run: |
-        cd Brogue.app/Contents && dylibbundler -cd -b -x MacOS/brogue
+        cd Brogue.app/Contents && dylibbundler -cd -b -x MacOS/brogue -d ./libs-intel/ -p @executable_path/../libs-intel/
 
     - name: "Create artifact"
       run: |
@@ -118,7 +118,7 @@ jobs:
 
     - name: "Fix and bundle dylib references"
       run: |
-        cd Brogue.app/Contents && dylibbundler -cd -b -x MacOS/brogue
+        cd Brogue.app/Contents && dylibbundler -cd -b -x MacOS/brogue -d ./libs-arm/ -p @executable_path/../libs-arm/
 
     - name: "Create artifact"
       run: |
@@ -130,6 +130,83 @@ jobs:
       with:
         name: macos-arm64
         path: BrogueCE-macos-arm64.zip
+        compression-level: 0  # There's no point compressing something already compressed
+
+  macos-universal:
+    needs: [macos-intel, macos-arm]
+    runs-on: macos-15
+    steps:
+
+    - name: "Download artifacts"
+      uses: actions/download-artifact@v4
+      with:
+        pattern: macos-*
+        merge-multiple: true
+
+    - name: "Create script"
+      uses: 1arp/create-a-file-action@0.4.5
+      with:
+        file: 'process.sh'
+        content: |
+          #!/bin/bash
+          set -euo pipefail
+          IFS=$'\n\t'
+
+          rm -Rf arm64 x86_64 universal
+
+          # Define an array
+          architectures=("arm64" "x86_64")
+
+          # Loop through the array
+          for arch in "${architectures[@]}"; do
+              # Create a directory for each architecture
+              # and unzip the corresponding files
+
+              echo "Processing $arch"
+              mkdir -p "$arch"
+              cd "$arch"
+              unzip "../BrogueCE-macos-$arch.zip"
+              rm -f "../BrogueCE-macos-$arch.zip"
+              rm -Rf "BrogueCE-macos/Brogue CE.app/Contents/_CodeSignature"
+              xattr -c "BrogueCE-macos/Brogue CE.app"
+              cd ..
+          done
+
+          # Create a universal binary
+          echo "Creating universal binary"
+          mkdir -p universal
+
+          cp -av arm64/* \
+              x86_64/* \
+              universal/
+          rm "universal/BrogueCE-macos/Brogue CE.app/Contents/MacOS/brogue"
+
+          lipo -create \
+              "arm64/BrogueCE-macos/Brogue CE.app/Contents/MacOS/brogue" \
+              "x86_64/BrogueCE-macos/Brogue CE.app/Contents/MacOS/brogue" \
+              -output "universal/BrogueCE-macos/Brogue CE.app/Contents/MacOS/brogue"
+
+          lipo -info "universal/BrogueCE-macos/Brogue CE.app/Contents/MacOS/brogue"
+          xattr -c "universal/BrogueCE-macos/Brogue CE.app"
+          echo "Universal binary created successfully"
+
+    - name: "Execute script"
+      run: |
+        pwd
+        ls -al
+        bash -x process.sh
+
+    - name: "Create artifact"
+      run: |
+        cd universal
+        zip -rll ../BrogueCE-macos-universal.zip BrogueCE-macos
+
+    - name: "Upload artifact"
+      uses: actions/upload-artifact@v4
+      with:
+        name: macos-universal
+        path: BrogueCE-macos-universal.zip
+        compression-level: 0  # There's no point compressing something already compressed
 
   windows:
     runs-on: windows-latest


### PR DESCRIPTION
Merge intel and apple silicon versions to create an universal binary.

I get a "damaged app" error corrected by "xattr -c". So if somebody else could see if it's just gatekeeper acting up or if I messed something.