### PR TITLE
Always allow scrolling through inventory with arrow keys and 8/2

### DIFF
--- a/changes/fix-inventory-scrolling.md
+++ b/changes/fix-inventory-scrolling.md
@@ -1,0 +1,1 @@
+Allow scrolling through inventory with arrow keys and 8/2 even when other actions are disabled. Applies to enchant/ID menu, replays, and the death screen.

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -5099,27 +5099,22 @@ unsigned long printCarriedItemDetails(item *theItem,
             buttons[b].hotkey[0] = RELABEL_KEY;
             b++;
         }
-
-        // Add invisible previous and next buttons, so up and down arrows can page through items.
-        // Previous
-        buttons[b].flags = B_ENABLED; // clear everything else
-        buttons[b].hotkey[0] = UP_KEY;
-        buttons[b].hotkey[1] = NUMPAD_8;
-        buttons[b].hotkey[2] = UP_ARROW;
-        b++;
-        // Next
-        buttons[b].flags = B_ENABLED; // clear everything else
-        buttons[b].hotkey[0] = DOWN_KEY;
-        buttons[b].hotkey[1] = NUMPAD_2;
-        buttons[b].hotkey[2] = DOWN_ARROW;
-        b++;
     }
+    // Add invisible previous and next buttons, so up and down arrows can page through items.
+    // Previous
+    buttons[b].flags = B_ENABLED; // clear everything else
+    buttons[b].hotkey[0] = UP_KEY;
+    buttons[b].hotkey[1] = NUMPAD_8;
+    buttons[b].hotkey[2] = UP_ARROW;
+    b++;
+    // Next
+    buttons[b].flags = B_ENABLED; // clear everything else
+    buttons[b].hotkey[0] = DOWN_KEY;
+    buttons[b].hotkey[1] = NUMPAD_2;
+    buttons[b].hotkey[2] = DOWN_ARROW;
+    b++;
+
     b = printTextBox(textBuf, x, y, width, &white, &interfaceBoxColor, buttons, b);
-
-    if (!includeButtons) {
-        waitForKeystrokeOrMouseClick();
-        return -1;
-    }
 
     if (b >= 0) {
         return buttons[b].hotkey[0];


### PR DESCRIPTION
Background: whenever the inventory is open, you can scroll up and down with arrow keys and 8/2.

Previously, scrolling was not allowed in scenarios where other actions (apply, equip, etc.) were disabled.
You could select the very first or last item as normal, then the bugged code kicks in and doesn't allow scrolling further.
This bug applies to viewing the inventory after using an enchant/id scroll, in a replay, and on the death screen.

This pull request fixes that bug. This is my first Brogue pull request, but I believe I've followed all of the guidelines (included a changes file, targeted release for a change which does not break replays).

I looked through the whole call stack and tested everything I could think of that might break, and it seems okay.
P.S. You still can't enchant or identify via scrolling; the enter button will do nothing. That would require additional fixes.