### PR TITLE
Disable items from falling into lava

### DIFF
--- a/changes/items-dont-fall-in-lava.md
+++ b/changes/items-dont-fall-in-lava.md
@@ -1,0 +1,1 @@
+Items can no longer fall into lava when thrown into a chasm. As with other forbidden locations, they now land on a nearby safe tile.

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3591,9 +3591,9 @@ void restoreItems() {
     for (theItem = preplaced.nextItem; theItem != NULL; theItem = nextItem) {
         nextItem = theItem->nextItem;
 
-        // Items can fall into deep water, enclaved lakes, another chasm, even lava!
+        // Items can fall into deep water or another chasm
         getQualifyingLocNear(&loc, theItem->loc, true, 0,
-                            (T_OBSTRUCTS_ITEMS),
+                            (T_OBSTRUCTS_ITEMS | T_LAVA_INSTA_DEATH),
                             (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE), false, false);
         placeItemAt(theItem, loc);
     }


### PR DESCRIPTION
#310 originally made this possible, as part of changes addressing #279. It's my opinion that this is a bit too unfun, and we shouldn't so overtly punish the player to prevent an inventive strategy that is quite tedious anyway.