### PR TITLE
Build object files in separate dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include config.mk
 
 cflags := -Isrc/brogue -Isrc/platform -Isrc/variants -std=c99 \
 	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-unused-result \
-	-Wformat -Werror=format-security -Wformat-overflow=0 -Wmissing-prototypes
+	-Wformat -Werror=format-security -Wno-format-overflow -Wmissing-prototypes
 libs := -lm
 cppflags := -DDATADIR=$(DATADIR)
 
@@ -69,7 +69,7 @@ cflags += $(CFLAGS)
 cppflags += $(CPPFLAGS)
 libs += $(LDLIBS)
 
-objects += $(sources:.c=.o)
+objects += $(sources:%.c=build/%.o)
 
 include make/*.mk
 .DEFAULT_GOAL := bin/brogue$(.exe)

--- a/make/brogue.mk
+++ b/make/brogue.mk
@@ -1,2 +1,7 @@
-bin/brogue bin/brogue.exe: $(objects) vars/cflags vars/LDFLAGS vars/libs vars/objects make/brogue.mk
+dirs:
+	mkdir -p build/src/brogue
+	mkdir -p build/src/platform
+	mkdir -p build/src/variants
+
+bin/brogue bin/brogue.exe: dirs $(objects) vars/cflags vars/LDFLAGS vars/libs vars/objects make/brogue.mk
 	$(CC) $(cflags) $(LDFLAGS) -o $@ $(objects) $(libs)

--- a/make/o.mk
+++ b/make/o.mk
@@ -1,4 +1,4 @@
-$(sources:.c=.o): %.o: %.c src/brogue/Rogue.h src/brogue/Globals.h src/brogue/GlobalsBase.h vars/cppflags vars/cflags make/o.mk
+$(sources:%.c=build/%.o): build/%.o: %.c src/brogue/Rogue.h src/brogue/Globals.h src/brogue/GlobalsBase.h vars/cppflags vars/cflags make/o.mk
 	$(CC) $(cppflags) $(cflags) -c $< -o $@
 
 src/variants/GlobalsBrogue.o src/variants/GlobalsRapidBrogue.o src/variants/GlobalsBulletBrogue.o: vars/extra_version

--- a/make/o.mk
+++ b/make/o.mk
@@ -1,5 +1,5 @@
 $(sources:%.c=build/%.o): build/%.o: %.c src/brogue/Rogue.h src/brogue/Globals.h src/brogue/GlobalsBase.h vars/cppflags vars/cflags make/o.mk
 	$(CC) $(cppflags) $(cflags) -c $< -o $@
 
-src/variants/GlobalsBrogue.o src/variants/GlobalsRapidBrogue.o src/variants/GlobalsBulletBrogue.o: vars/extra_version
-src/variants/GlobalsBrogue.o src/variants/GlobalsRapidBrogue.o src/variants/GlobalsBulletBrogue.o: cppflags += -DBROGUE_EXTRA_VERSION='"$(extra_version)"'
+build/src/variants/GlobalsBrogue.o build/src/variants/GlobalsRapidBrogue.o build/src/variants/GlobalsBulletBrogue.o: vars/extra_version
+build/src/variants/GlobalsBrogue.o build/src/variants/GlobalsRapidBrogue.o build/src/variants/GlobalsBulletBrogue.o: cppflags += -DBROGUE_EXTRA_VERSION='"$(extra_version)"'


### PR DESCRIPTION
Cleaning up the build by moving files to a separate build directory.

Also switched `format-overflow=0` to `no-format-overflow` due to incompatibility with Mac build tools.  Hoping the new flag is more compatible.