### PR TITLE
Add 'void' to clear strict-prototype warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 include config.mk
 
+# Warning flags: enable flags first, "no-" flags next, "error" flags last
 cflags := -Isrc/brogue -Isrc/platform -Isrc/variants -std=c99 \
-	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-unused-result \
-	-Wformat -Werror=format-security -Wformat-overflow=0 -Wmissing-prototypes
+	-Wall -Wpedantic  -Wformat -Wmissing-prototypes \
+	-Wno-parentheses -Wno-unused-result -Wno-format-overflow \
+	-Werror=implicit -Werror=format-security -Werror=strict-prototypes
 libs := -lm
 cppflags := -DDATADIR=$(DATADIR)
 

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -1729,7 +1729,7 @@ boolean buildAMachine(enum machineTypes bp,
 }
 
 // add machines to the dungeon.
-static void addMachines() {
+static void addMachines(void) {
     short machineCount, failsafe;
     short randomMachineFactor;
 
@@ -1853,7 +1853,7 @@ static void runAutogenerators(boolean buildAreaMachines) {
 }
 
 // Knock down the boundaries between similar lakes where possible.
-static void cleanUpLakeBoundaries() {
+static void cleanUpLakeBoundaries(void) {
     short i, j, x, y, failsafe, layer;
     boolean reverse, madeChange;
     unsigned long subjectFlags;
@@ -1910,7 +1910,7 @@ static void cleanUpLakeBoundaries() {
     } while (madeChange && failsafe > 0);
 }
 
-static void removeDiagonalOpenings() {
+static void removeDiagonalOpenings(void) {
     short i, j, k, x1, y1, x2, layer;
     boolean diagonalCornerRemoved;
 
@@ -2730,7 +2730,7 @@ static void fillLakes(short **lakeMap) {
     }
 }
 
-static void finishDoors() {
+static void finishDoors(void) {
     short i, j;
     const short secretDoorChance = clamp((rogue.depthLevel - 1) * 67 / (gameConst->amuletLevel - 1), 0, 67);
     for (i=1; i<DCOLS-1; i++) {
@@ -2757,7 +2757,7 @@ static void finishDoors() {
     }
 }
 
-static void clearLevel() {
+static void clearLevel(void) {
     short i, j;
 
     for( i=0; i<DCOLS; i++ ) {
@@ -2783,7 +2783,7 @@ static void clearLevel() {
 
 // Scans the map in random order looking for a good place to build a bridge.
 // If it finds one, it builds a bridge there, halts and returns true.
-static boolean buildABridge() {
+static boolean buildABridge(void) {
     short i, j, k, l, i2, j2, nCols[DCOLS], nRows[DROWS];
     short bridgeRatioX, bridgeRatioY;
     boolean foundExposure;
@@ -2874,7 +2874,7 @@ static boolean buildABridge() {
 
 // This is the master function for digging out a dungeon level.
 // Finishing touches -- items, monsters, staircases, etc. -- are handled elsewhere.
-void digDungeon() {
+void digDungeon(void) {
     short i, j;
 
     short **grid;
@@ -2979,7 +2979,7 @@ void digDungeon() {
     }
 }
 
-void updateMapToShore() {
+void updateMapToShore(void) {
     short i, j;
     short **costMap;
 
@@ -3030,7 +3030,7 @@ void refreshWaypoint(short wpIndex) {
     freeGrid(costMap);
 }
 
-void setUpWaypoints() {
+void setUpWaypoints(void) {
     short i, j, sCoord[DCOLS * DROWS], x, y;
     char grid[DCOLS][DROWS];
 
@@ -3197,7 +3197,7 @@ short levelIsDisconnectedWithBlockingMap(char blockingMap[DCOLS][DROWS], boolean
     return (smallestQualifyingZoneSize < 10000 ? smallestQualifyingZoneSize : 0);
 }
 
-void resetDFMessageEligibility() {
+void resetDFMessageEligibility(void) {
     short i;
 
     for (i=0; i<NUMBER_DUNGEON_FEATURES; i++) {
@@ -3570,7 +3570,7 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
     }
 }
 
-void restoreItems() {
+void restoreItems(void) {
     item *theItem, *nextItem;
     pos loc;
     item preplaced;

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -980,7 +980,7 @@ void applyArmorRunicEffect(char returnString[DCOLS], creature *attacker, short *
     }
 }
 
-static void decrementWeaponAutoIDTimer() {
+static void decrementWeaponAutoIDTimer(void) {
     char buf[COLS*3], buf2[COLS*3];
 
     if (rogue.weapon
@@ -1324,7 +1324,7 @@ void combatMessage(char *theMsg, const color *theColor) {
 // they may be joined together by semi-colons.  Notice that combat messages may
 // be flushed by a number of different callers.  One is message() itself
 // creating a recursion, which this function is responsible for terminating.
-void displayCombatText() {
+void displayCombatText(void) {
     char buf[COLS * 2];
     char *start, *end;
 

--- a/src/brogue/Grid.c
+++ b/src/brogue/Grid.c
@@ -27,7 +27,7 @@
 
 
 // mallocing two-dimensional arrays! dun dun DUN!
-short **allocGrid() {
+short **allocGrid(void) {
     short i;
     short **array = malloc(DCOLS * sizeof(short *));
 

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -72,7 +72,7 @@ void hilitePath(pos path[1000], short steps, boolean unhilite) {
 }
 
 // More expensive than hilitePath(__, __, true), but you don't need access to the path itself.
-void clearCursorPath() {
+void clearCursorPath(void) {
     short i, j;
 
     if (!rogue.playbackMode) { // There are no cursor paths during playback.
@@ -87,14 +87,14 @@ void clearCursorPath() {
     }
 }
 
-void hideCursor() {
+void hideCursor(void) {
     // Drop out of cursor mode if we're in it, and hide the path either way.
     rogue.cursorMode = false;
     rogue.cursorPathIntensity = (rogue.cursorMode ? 50 : 20);
     rogue.cursorLoc = INVALID_POS;
 }
 
-void showCursor() {
+void showCursor(void) {
     // Return or enter turns on cursor mode. When the path is hidden, move the cursor to the player.
     if (!isPosInMap(rogue.cursorLoc)) {
         rogue.cursorLoc = player.loc;
@@ -534,7 +534,7 @@ static void initializeMenuButtons(buttonState *state, brogueButton buttons[5]) {
 
 
 // This is basically the main loop for the game.
-void mainInputLoop() {
+void mainInputLoop(void) {
     pos oldTargetLoc = { 0, 0 };
     short steps, oldRNG, dir;
     pos path[1000];
@@ -837,7 +837,7 @@ void mainInputLoop() {
 
 #define MILLISECONDS_FOR_CAUTION    100
 
-void considerCautiousMode() {
+void considerCautiousMode(void) {
     /*
     signed long oldMilliseconds = rogue.milliseconds;
     rogue.milliseconds = MILLISECONDS;
@@ -854,7 +854,7 @@ static screenDisplayBuffer previouslyPlottedCells;
 
 // Only cells which have changed since the previous commitDraws are actually
 // drawn.
-void commitDraws() {
+void commitDraws(void) {
     for (int j = 0; j < ROWS; j++) {
         for (int i = 0; i < COLS; i++) {
             cellDisplayBuffer *lastPlotted = &previouslyPlottedCells.cells[i][j];
@@ -887,7 +887,7 @@ void commitDraws() {
 
 // flags the entire window as needing to be redrawn at next flush.
 // very low level -- does not interface with the guts of the game.
-void refreshScreen() {
+void refreshScreen(void) {
     for (int i = 0; i < COLS; i++) {
         for (int j = 0; j < ROWS; j++) {
             cellDisplayBuffer *curr = &displayBuffer.cells[i][j];
@@ -907,7 +907,7 @@ void refreshScreen() {
 }
 
 // higher-level redraw
-void displayLevel() {
+void displayLevel(void) {
     short i, j;
 
     for( i=0; i<DCOLS; i++ ) {
@@ -1073,7 +1073,7 @@ static boolean glyphIsWallish(enum displayGlyph glyph) {
     }
 }
 
-static enum monsterTypes randomAnimateMonster() {
+static enum monsterTypes randomAnimateMonster(void) {
     /* Randomly pick an animate and vulnerable monster type. Used by
     getCellAppearance for hallucination effects. */
     static int listLength = 0;
@@ -1847,7 +1847,7 @@ void plotForegroundChar(enum displayGlyph inputChar, short x, short y, const col
 }
 
 // Debug feature: display the level to the screen without regard to lighting, field of view, etc.
-void dumpLevelToScreen() {
+void dumpLevelToScreen(void) {
     short i, j;
     pcell backup;
 
@@ -1912,7 +1912,7 @@ void hiliteCharGrid(char hiliteCharGrid[DCOLS][DROWS], const color *hiliteColor,
     restoreRNG;
 }
 
-void blackOutScreen() {
+void blackOutScreen(void) {
     short i, j;
 
     for (i=0; i<COLS; i++) {
@@ -2203,7 +2203,7 @@ void funkyFade(screenDisplayBuffer *displayBuf, const color *colorStart,
     restoreRNG;
 }
 
-static void displayWaypoints() {
+static void displayWaypoints(void) {
     short i, j, w, lowestDistance;
 
     for (i=0; i<DCOLS; i++) {
@@ -2223,7 +2223,7 @@ static void displayWaypoints() {
     displayLevel();
 }
 
-static void displayMachines() {
+static void displayMachines(void) {
     short i, j;
     color foreColor, backColor, machineColors[50];
     enum displayGlyph dchar;
@@ -2261,7 +2261,7 @@ static void displayMachines() {
 }
 
 #define CHOKEMAP_DISPLAY_CUTOFF 160
-static void displayChokeMap() {
+static void displayChokeMap(void) {
     short i, j;
     color foreColor, backColor;
     enum displayGlyph dchar;
@@ -2286,7 +2286,7 @@ static void displayChokeMap() {
     displayLevel();
 }
 
-static void displayLoops() {
+static void displayLoops(void) {
     short i, j;
     color foreColor, backColor;
     enum displayGlyph dchar;
@@ -2907,7 +2907,7 @@ void flashTemporaryAlert(char *message, int time) {
     flashMessage(message, (COLS - strLenWithoutEscapes(message)) / 2, ROWS / 2, time, &teal, &black);
 }
 
-void waitForAcknowledgment() {
+void waitForAcknowledgment(void) {
     rogueEvent theEvent;
 
     if (rogue.autoPlayingLevel || (rogue.playbackMode && !rogue.playbackOOS) || nonInteractivePlayback) {
@@ -2923,7 +2923,7 @@ void waitForAcknowledgment() {
                || theEvent.eventType == MOUSE_UP));
 }
 
-void waitForKeystrokeOrMouseClick() {
+void waitForKeystrokeOrMouseClick(void) {
     rogueEvent theEvent;
     do {
         nextBrogueEvent(&theEvent, false, false, false);
@@ -3006,13 +3006,13 @@ void displayMonsterFlashes(boolean flashingEnabled) {
     restoreRNG;
 }
 
-static void dequeueEvent() {
+static void dequeueEvent(void) {
     rogueEvent returnEvent;
     nextBrogueEvent(&returnEvent, false, false, true);
 }
 
 // Empty the message archive
-void clearMessageArchive() {
+void clearMessageArchive(void) {
     messageArchivePosition = 0;
 }
 
@@ -3203,7 +3203,7 @@ void formatRecentMessages(char buffer[][COLS*2], size_t height, short *linesForm
 }
 
 // Display recent archived messages after recalculating message confirmations.
-void displayRecentMessages() {
+void displayRecentMessages(void) {
     short i;
     char messageBuffer[MESSAGE_LINES][COLS*2];
 
@@ -3353,7 +3353,7 @@ static short scrollMessageArchive(char messages[MESSAGE_ARCHIVE_LINES][COLS*2], 
     return offset;
 }
 
-void displayMessageArchive() {
+void displayMessageArchive(void) {
     short length, offset, height;
     char messageBuffer[MESSAGE_ARCHIVE_LINES][COLS*2];
 
@@ -3514,7 +3514,7 @@ void message(const char *msg, unsigned long flags) {
 }
 
 // Only used for the "you die..." message, to enable posthumous inventory viewing.
-void displayMoreSignWithoutWaitingForAcknowledgment() {
+void displayMoreSignWithoutWaitingForAcknowledgment(void) {
     if (strLenWithoutEscapes(displayedMessage[0]) < DCOLS - 8 || messagesUnconfirmed > 0) {
         printString("--MORE--", COLS - 8, MESSAGE_LINES-1, &black, &white, 0);
     } else {
@@ -3522,7 +3522,7 @@ void displayMoreSignWithoutWaitingForAcknowledgment() {
     }
 }
 
-void displayMoreSign() {
+void displayMoreSign(void) {
     short i;
 
     if (rogue.autoPlayingLevel) {
@@ -3609,7 +3609,7 @@ const color *messageColorFromVictim(creature *monst) {
     }
 }
 
-void updateMessageDisplay() {
+void updateMessageDisplay(void) {
     short i, j, m;
     color messageColor;
 
@@ -3642,7 +3642,7 @@ void updateMessageDisplay() {
 }
 
 // Does NOT clear the message archive.
-void deleteMessages() {
+void deleteMessages(void) {
     short i;
     for (i=0; i<MESSAGE_LINES; i++) {
         displayedMessage[i][0] = '\0';
@@ -3650,7 +3650,7 @@ void deleteMessages() {
     confirmMessages();
 }
 
-void confirmMessages() {
+void confirmMessages(void) {
     messagesUnconfirmed = 0;
     updateMessageDisplay();
 }
@@ -4063,7 +4063,7 @@ char nextKeyPress(boolean textInput) {
 
 #define BROGUE_HELP_LINE_COUNT  33
 
-void printHelpScreen() {
+void printHelpScreen(void) {
     short i, j;
     char helpText[BROGUE_HELP_LINE_COUNT][DCOLS*3] = {
         "",
@@ -4185,7 +4185,7 @@ static void printDiscoveries(short category, short count, unsigned short itemCha
 }
 
 /// @brief Display the feats screen. Lists all feats and their achievement status.
-void displayFeatsScreen() {
+void displayFeatsScreen(void) {
     char availableColorEscape[5] = "", achievedColorEscape[5] = "", failedColorEscape[5] = "";
     encodeMessageColor(availableColorEscape, 0, &white);
     encodeMessageColor(achievedColorEscape, 0, &advancementMessageColor);
@@ -4237,7 +4237,7 @@ void displayFeatsScreen() {
     restoreDisplayBuffer(&rbuf);
 }
 
-void printDiscoveriesScreen() {
+void printDiscoveriesScreen(void) {
     short i, j, y;
     const SavedDisplayBuffer rbuf = saveDisplayBuffer();
 
@@ -4388,7 +4388,7 @@ void displayGrid(short **map) {
 }
 
 /// @brief Display a message with the seed #, turn #, game mode (except normal), and game version
-void printSeed() {
+void printSeed(void) {
     char buf[COLS];
     char mode[14] = "";
 
@@ -4472,7 +4472,7 @@ void highlightScreenCell(short x, short y, const color *highlightColor, short st
 
 // Like `armorValueIfUnenchanted` for the currently-equipped armor, but takes the penalty from
 // donning into account.
-static short estimatedArmorValue() {
+static short estimatedArmorValue(void) {
     short retVal = armorValueIfUnenchanted(rogue.armor) - player.status[STATUS_DONNING];
     return max(0, retVal);
 }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -31,7 +31,7 @@
 #define MAGIC_POLARITY_NEUTRAL 0
 #define MAGIC_POLARITY_ANY 0
 
-item *initializeItem() {
+item *initializeItem(void) {
     short i;
     item *theItem;
 
@@ -1017,7 +1017,7 @@ item *addItemToPack(item *theItem) {
     return theItem;
 }
 
-short numberOfItemsInPack() {
+short numberOfItemsInPack(void) {
     short theCount = 0;
     item *theItem;
     for(theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
@@ -1026,7 +1026,7 @@ short numberOfItemsInPack() {
     return theCount;
 }
 
-char nextAvailableInventoryCharacter() {
+char nextAvailableInventoryCharacter(void) {
     boolean charTaken[26];
     short i;
     item *theItem;
@@ -1189,7 +1189,7 @@ static boolean swapItemEnchants(const short machineNumber) {
     return false;
 }
 
-void updateFloorItems() {
+void updateFloorItems(void) {
     short x, y;
     char buf[DCOLS*3], buf2[DCOLS*3];
     enum dungeonLayers layer;
@@ -1757,7 +1757,7 @@ void itemRunicName(item *theItem, char *runicName) {
     }
 }
 
-static int enchantMagnitude() {
+static int enchantMagnitude(void) {
     return tableForItemCategory(SCROLL)[SCROLL_ENCHANTING].power;
 }
 
@@ -3164,7 +3164,7 @@ short numberOfMatchingPackItems(unsigned short categoryMask,
     return matchingItemCount;
 }
 
-void updateEncumbrance() {
+void updateEncumbrance(void) {
     short moveSpeed, attackSpeed;
 
     moveSpeed = player.info.movementSpeed;
@@ -3192,7 +3192,7 @@ short armorValueIfUnenchanted(item *theItem) {
 }
 
 // Calculates the armor value to display to the player (estimated if the item is unidentified).
-short displayedArmorValue() {
+short displayedArmorValue(void) {
     if (!rogue.armor || (rogue.armor->flags & ITEM_IDENTIFIED)) {
         return player.info.defense / 10;
     } else {
@@ -6438,7 +6438,7 @@ void relabel(item *theItem) {
 
 // If the most recently equipped item caused another item to be unequiped, is
 // uncursed, and both haven't left the inventory since, swap them back.
-void swapLastEquipment() {
+void swapLastEquipment(void) {
     item *theItem;
     unsigned char command[10];
 
@@ -6873,7 +6873,7 @@ static short lotteryDraw(short *frequencies, short itemCount) {
     return 0;
 }
 
-short chooseVorpalEnemy() {
+short chooseVorpalEnemy(void) {
     short i, frequencies[MONSTER_CLASS_COUNT];
     for (i = 0; i < MONSTER_CLASS_COUNT; i++) {
         if (monsterClassCatalog[i].maxDepth <= 0
@@ -6925,7 +6925,7 @@ void updateIdentifiableItem(item *theItem) {
     }
 }
 
-void updateIdentifiableItems() {
+void updateIdentifiableItems(void) {
     item *theItem;
     for (theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
         updateIdentifiableItem(theItem);
@@ -7538,7 +7538,7 @@ void unequip(item *theItem) {
     playerTurnEnded();
 }
 
-static boolean canDrop() {
+static boolean canDrop(void) {
     if (cellHasTerrainFlag(player.loc, T_OBSTRUCTS_ITEMS)) {
         return false;
     }
@@ -7684,7 +7684,7 @@ item *dropItem(item *theItem) {
     }
 }
 
-void recalculateEquipmentBonuses() {
+void recalculateEquipmentBonuses(void) {
     fixpt enchant;
     item *theItem;
     if (rogue.weapon) {
@@ -7849,7 +7849,7 @@ boolean unequipItem(item *theItem, boolean force) {
     return true;
 }
 
-void updateRingBonuses() {
+void updateRingBonuses(void) {
     short i;
     item *rings[2] = {rogue.ringLeft, rogue.ringRight};
 
@@ -7900,7 +7900,7 @@ void updateRingBonuses() {
     }
 }
 
-void updatePlayerRegenerationDelay() {
+void updatePlayerRegenerationDelay(void) {
     short maxHP;
     long turnsForFull; // In thousandths of a turn.
     maxHP = player.info.maxHP;
@@ -7946,7 +7946,7 @@ static void resetItemTableEntry(itemTable *theEntry) {
     theEntry->callTitle[0] = '\0';
 }
 
-void shuffleFlavors() {
+void shuffleFlavors(void) {
     short i, j, randIndex, randNumber;
     char buf[COLS];
 

--- a/src/brogue/Light.c
+++ b/src/brogue/Light.c
@@ -25,7 +25,7 @@
 #include "GlobalsBase.h"
 #include "Globals.h"
 
-void logLights() {
+void logLights(void) {
     short i, j;
 
     printf("    ");
@@ -117,7 +117,7 @@ boolean paintLight(const lightSource *theLight, short x, short y, boolean isMine
 
 
 // sets miner's light strength and characteristics based on rings of illumination, scrolls of darkness and water submersion
-void updateMinersLightRadius() {
+void updateMinersLightRadius(void) {
     fixpt base_fraction, fraction, lightRadius;
 
     lightRadius = 100 * rogue.minersLightRadius;
@@ -153,7 +153,7 @@ void updateMinersLightRadius() {
     rogue.minersLight.lightRadius.upperBound = rogue.minersLight.lightRadius.lowerBound = clamp(lightRadius / FP_FACTOR, -30000, 30000);
 }
 
-static void updateDisplayDetail() {
+static void updateDisplayDetail(void) {
     short i, j;
 
     for (i = 0; i < DCOLS; i++) {
@@ -194,7 +194,7 @@ void restoreLighting(short lights[DCOLS][DROWS][3]) {
     }
 }
 
-static void recordOldLights() {
+static void recordOldLights(void) {
     short i, j, k;
     for (i = 0; i < DCOLS; i++) {
         for (j = 0; j < DROWS; j++) {
@@ -205,7 +205,7 @@ static void recordOldLights() {
     }
 }
 
-void updateLighting() {
+void updateLighting(void) {
     short i, j, k;
     enum dungeonLayers layer;
     enum tileType tile;
@@ -280,7 +280,7 @@ void updateLighting() {
     }
 }
 
-boolean playerInDarkness() {
+boolean playerInDarkness(void) {
     return (tmapAt(player.loc)->light[0] + 10 < minersLightColor.red
             && tmapAt(player.loc)->light[1] + 10 < minersLightColor.green
             && tmapAt(player.loc)->light[2] + 10 < minersLightColor.blue);
@@ -403,7 +403,7 @@ void animateFlares(flare **flares, short count) {
     updateFieldOfViewDisplay(false, true);
 }
 
-void deleteAllFlares() {
+void deleteAllFlares(void) {
     short i;
     for (i=0; i<rogue.flareCount; i++) {
         free(rogue.flares[i]);

--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -387,7 +387,7 @@ static void initializeFlyoutMenu(buttonState *menu, screenDisplayBuffer *shadowB
 }
 
 /// @brief Displays a dialog window for the user to chose a game variant
-static void chooseGameVariant() {
+static void chooseGameVariant(void) {
     short gameVariantChoice;
     char textBuf[TEXT_MAX_LENGTH] = "", tmpBuf[TEXT_MAX_LENGTH] = "", goldColorEscape[5] = "", whiteColorEscape[5] = "";
 
@@ -427,7 +427,7 @@ static void chooseGameVariant() {
 
 /// @brief Displays a dialog window for the user to chose a game mode. The game mode is displayed in the bottom left
 /// on the title screen (except normal mode).
-static void chooseGameMode() {
+static void chooseGameMode(void) {
     short gameMode;
     char textBuf[TEXT_MAX_LENGTH] = "", tmpBuf[TEXT_MAX_LENGTH] = "", goldColorEscape[5] = "", whiteColorEscape[5] = "";
 
@@ -468,7 +468,7 @@ static void chooseGameMode() {
 
 /// @brief Used on the title screen for showing/hiding the flyout menus
 /// @return True if rogue.nextGame is a flyout command
-static boolean isFlyoutActive() {
+static boolean isFlyoutActive(void) {
     return ((int)rogue.nextGame >= (int)NG_FLYOUT_PLAY && rogue.nextGame <= (int)NG_FLYOUT_OPTIONS);
 }
 
@@ -504,7 +504,7 @@ static void redrawMainMenuButtons(buttonState *menu, screenDisplayBuffer *button
 
 #define FLYOUT_X 59
 
-static void titleMenu() {
+static void titleMenu(void) {
     signed short flames[COLS][(ROWS + MENU_FLAME_ROW_PADDING)][3]; // red, green and blue
     signed short colorSources[MENU_FLAME_COLOR_SOURCE_COUNT][4]; // red, green, blue, and rand, one for each color source (no more than MENU_FLAME_COLOR_SOURCE_COUNT).
     const color *colors[COLS][(ROWS + MENU_FLAME_ROW_PADDING)];
@@ -621,7 +621,7 @@ static void titleMenu() {
 }
 
 // Closes Brogue without any further prompts, animations, or user interaction.
-int quitImmediately() {
+int quitImmediately(void) {
     // If we are recording a game, save it.
     if (rogue.recording) {
         flushBufferToFile();
@@ -1098,7 +1098,7 @@ static void viewGameStats(void) {
 // accompanying path, and it's a command that should take a path, then pop up a dialog to have
 // the player specify a path. If there is no command (i.e. if rogue.nextGame contains NG_NOTHING),
 // then we'll display the title screen so the player can choose.
-void mainBrogueJunction() {
+void mainBrogueJunction(void) {
     rogueEvent theEvent;
     char path[BROGUE_FILENAME_MAX], buf[100], seedDefault[100];
     short i, j, k;

--- a/src/brogue/Math.c
+++ b/src/brogue/Math.c
@@ -170,7 +170,7 @@ long rand_range(long lowerBound, long upperBound) {
 }
 #endif
 
-uint64_t rand_64bits() {
+uint64_t rand_64bits(void) {
     if (rogue.RNG == RNG_SUBSTANTIVE) {
         randomNumbersGenerated++;
     }

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -406,7 +406,7 @@ void initializeGender(creature *monst) {
 }
 
 /// @brief Sets the character used to represent the player in the game, based on the game mode
-void setPlayerDisplayChar() {
+void setPlayerDisplayChar(void) {
     if (rogue.mode == GAME_MODE_EASY) {
         player.info.displayChar = G_DEMON;
     } else {
@@ -908,7 +908,7 @@ void fadeInMonster(creature *monst) {
     flashMonster(monst, &bColor, 100);
 }
 
-creatureList createCreatureList() {
+creatureList createCreatureList(void) {
     creatureList list;
     list.head = NULL;
     return list;
@@ -1068,7 +1068,7 @@ static boolean summonMinions(creature *summoner) {
 }
 
 // Generates and places monsters for the level.
-void populateMonsters() {
+void populateMonsters(void) {
     if (!MONSTERS_ENABLED) {
         return;
     }
@@ -1112,7 +1112,7 @@ boolean getRandomMonsterSpawnLocation(short *x, short *y) {
     return true;
 }
 
-void spawnPeriodicHorde() {
+void spawnPeriodicHorde(void) {
     creature *monst;
     short x, y;
 

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -1869,7 +1869,7 @@ void populateCreatureCostMap(short **costMap, creature *monst) {
     }
 }
 
-enum directions adjacentFightingDir() {
+enum directions adjacentFightingDir(void) {
     if (cellHasTerrainFlag(player.loc, T_OBSTRUCTS_PASSABILITY)) {
         return NO_DIRECTION;
     }

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -49,7 +49,7 @@ static void recordChar(unsigned char c) {
     }
 }
 
-static void considerFlushingBufferToFile() {
+static void considerFlushingBufferToFile(void) {
     if (locationInRecordingBuffer >= INPUT_RECORD_BUFFER) {
         flushBufferToFile();
     }
@@ -144,7 +144,7 @@ void recordKeystroke(int keystroke, boolean controlKey, boolean shiftKey) {
     recordEvent(&theEvent);
 }
 
-void cancelKeystroke() {
+void cancelKeystroke(void) {
     brogueAssert(locationInRecordingBuffer >= 3);
     locationInRecordingBuffer -= 3; // a keystroke is encoded into 3 bytes
     recordingLocation -= 3;
@@ -220,7 +220,7 @@ static void writeHeaderInfo(char *path) {
     }
 }
 
-void flushBufferToFile() {
+void flushBufferToFile(void) {
     if (rogue.playbackMode) {
         return;
     }
@@ -248,7 +248,7 @@ void flushBufferToFile() {
     locationInRecordingBuffer = 0;
 }
 
-void fillBufferFromFile() {
+void fillBufferFromFile(void) {
 //  short i;
     FILE *recordFile;
 
@@ -263,7 +263,7 @@ void fillBufferFromFile() {
     locationInRecordingBuffer = 0;
 }
 
-static unsigned char recallChar() {
+static unsigned char recallChar(void) {
     unsigned char c;
     if (recordingLocation > lengthOfPlaybackFile) {
         return END_OF_RECORDING;
@@ -302,7 +302,7 @@ simply be the result of a bug.\n\n\
 If this is a different computer from the one on which the recording was saved, the recording \
 might succeed on the original computer."
 
-static void playbackPanic() {
+static void playbackPanic(void) {
 
     if (!rogue.playbackOOS) {
         rogue.playbackFastForward = false;
@@ -382,7 +382,7 @@ void recallEvent(rogueEvent *event) {
     event->shiftKey =   (c & Fl(2)) ? true : false;
 }
 
-static void loadNextAnnotation() {
+static void loadNextAnnotation(void) {
     unsigned long currentReadTurn;
     short i;
     FILE *annotationFile;
@@ -432,7 +432,7 @@ static void loadNextAnnotation() {
     fclose(annotationFile);
 }
 
-void displayAnnotation() {
+void displayAnnotation(void) {
     if (rogue.playbackMode
         && rogue.playerTurnNumber == rogue.nextAnnotationTurn) {
 
@@ -462,7 +462,7 @@ static boolean getPatchVersion(char *versionString, unsigned short *patchVersion
 
 // creates a game recording file, or if in playback mode,
 // initializes based on and starts reading from the recording file
-void initRecording() {
+void initRecording(void) {
     if (currentFilePath[0] == '\0') {
         return;
     }
@@ -579,7 +579,7 @@ void OOSCheck(unsigned long x, short numberOfBytes) {
 }
 
 // compare a random number once per player turn so we instantly know if we are out of sync during playback
-void RNGCheck() {
+void RNGCheck(void) {
     short oldRNG;
     unsigned long randomNumber;
 
@@ -596,7 +596,7 @@ void RNGCheck() {
     rogue.RNG = oldRNG;
 }
 
-static boolean unpause() {
+static boolean unpause(void) {
     if (rogue.playbackOOS) {
         flashTemporaryAlert(" Out of sync ", 2000);
     } else if (rogue.playbackPaused) {
@@ -608,7 +608,7 @@ static boolean unpause() {
 
 #define PLAYBACK_HELP_LINE_COUNT    20
 
-static void printPlaybackHelpScreen() {
+static void printPlaybackHelpScreen(void) {
     short i, j;
     screenDisplayBuffer dbuf;
     char helpText[PLAYBACK_HELP_LINE_COUNT][80] = {
@@ -664,7 +664,7 @@ static void printPlaybackHelpScreen() {
     restoreDisplayBuffer(&rbuf);
 }
 
-static void resetPlayback() {
+static void resetPlayback(void) {
     boolean omniscient, stealth, trueColors;
 
     omniscient = rogue.playbackOmniscience;
@@ -810,7 +810,7 @@ static void promptToAdvanceToLocation(short keystroke) {
     }
 }
 
-void pausePlayback() {
+void pausePlayback(void) {
     //short oldRNG;
     if (!rogue.playbackPaused) {
         rogue.playbackPaused = true;
@@ -1161,7 +1161,7 @@ static void getDefaultFilePath(char *defaultPath, boolean gameOver) {
     }
 }
 
-void saveGameNoPrompt() {
+void saveGameNoPrompt(void) {
     char filePath[BROGUE_FILENAME_MAX], defaultPath[BROGUE_FILENAME_MAX];
     if (rogue.playbackMode) {
         return;
@@ -1178,7 +1178,7 @@ void saveGameNoPrompt() {
 }
 #define MAX_TEXT_INPUT_FILENAME_LENGTH (COLS - 12) // max length including the suffix
 
-void saveGame() {
+void saveGame(void) {
     char filePathWithoutSuffix[BROGUE_FILENAME_MAX - sizeof(GAME_SUFFIX)], filePath[BROGUE_FILENAME_MAX], defaultPath[BROGUE_FILENAME_MAX];
     boolean askAgain;
 
@@ -1281,7 +1281,7 @@ static void copyFile(char *fromFilePath, char *toFilePath, unsigned long fromFil
 }
 
 // at the end of loading a saved game, this function transitions into active play mode.
-void switchToPlaying() {
+void switchToPlaying(void) {
     char lastGamePath[BROGUE_FILENAME_MAX];
 
     getAvailableFilePath(lastGamePath, LAST_GAME_NAME, GAME_SUFFIX);
@@ -1308,7 +1308,7 @@ void switchToPlaying() {
 }
 
 // Return whether the load was cancelled by an event
-boolean loadSavedGame() {
+boolean loadSavedGame(void) {
     unsigned long progressBarInterval;
     unsigned long previousRecordingLocation;
     rogueEvent theEvent;
@@ -1432,7 +1432,7 @@ static boolean selectFile(char *prompt, char *defaultName, char *suffix) {
     return retval;
 }
 
-void parseFile() {
+void parseFile(void) {
     FILE *descriptionFile;
     unsigned long oldFileLoc, oldRecLoc, oldLength, oldBufLoc, i, numTurns, numDepths, fileLength, startLoc;
     uint64_t seed;

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -30,13 +30,13 @@
 
 #include <time.h>
 
-int rogueMain() {
+int rogueMain(void) {
     previousGameSeed = 0;
     mainBrogueJunction();
     return rogue.gameExitStatusCode;
 }
 
-void printBrogueVersion() {
+void printBrogueVersion(void) {
     printf("Brogue version: %s\n", brogueVersion);
     printf("Supports variant (rapid_brogue): %s\n", rapidBrogueVersion);
     printf("Supports variant (bullet_brogue): %s\n", bulletBrogueVersion);
@@ -115,7 +115,7 @@ boolean openFile(const char *path) {
 }
 
 #ifdef SCREEN_UPDATE_BENCHMARK
-static void screen_update_benchmark() {
+static void screen_update_benchmark(void) {
     short i, j, k;
     const color sparklesauce = {10, 0, 20,  60, 40, 100, 30, true};
     enum displayGlyph theChar;
@@ -154,7 +154,7 @@ static const char *getOrdinalSuffix(int number) {
     }
 }
 
-static void welcome() {
+static void welcome(void) {
     char buf[DCOLS*3], buf2[DCOLS*3];
     message("Hello and welcome, adventurer, to the Dungeons of Doom!", 0);
     strcpy(buf, "Retrieve the ");
@@ -170,7 +170,7 @@ static void welcome() {
     flavorMessage("The doors to the dungeon slam shut behind you.");
 }
 
-void initializeGameVariant() {
+void initializeGameVariant(void) {
 
     switch (gameVariant) {
         case VARIANT_RAPID_BROGUE:
@@ -535,7 +535,7 @@ void initializeRogue(uint64_t seed) {
 }
 
 // call this once per level to set all the dynamic colors as a function of depth
-static void updateColors() {
+static void updateColors(void) {
     short i;
 
     for (i=0; i<NUMBER_DYNAMIC_COLORS; i++) {
@@ -976,12 +976,12 @@ static void removeDeadMonstersFromList(creatureList *list) {
 
 // Removes dead monsters from `monsters`/`dormantMonsters`, and inserts them into `purgatory` if
 // the decedent is a player ally at the moment of death, for possible future resurrection.
-void removeDeadMonsters() {
+void removeDeadMonsters(void) {
     removeDeadMonstersFromList(monsters);
     removeDeadMonstersFromList(dormantMonsters);
 }
 
-void freeEverything() {
+void freeEverything(void) {
     short i;
     item *theItem, *theItem2;
 
@@ -1381,7 +1381,7 @@ void victory(boolean superVictory) {
     rogue.gameExitStatusCode = EXIT_STATUS_SUCCESS;
 }
 
-void enableEasyMode() {
+void enableEasyMode(void) {
     if (rogue.mode == GAME_MODE_EASY) {
         message("Alas, all hope of salvation is lost. You shed scalding tears at your plight.", 0);
         return;

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -50,7 +50,7 @@ void exposeCreatureToFire(creature *monst) {
     monst->status[STATUS_BURNING] = monst->maxStatus[STATUS_BURNING] = max(monst->status[STATUS_BURNING], 7);
 }
 
-void updateFlavorText() {
+void updateFlavorText(void) {
     char buf[DCOLS * 3];
     if (rogue.disturbed && !rogue.gameHasEnded) {
         if (rogue.armor
@@ -68,7 +68,7 @@ void updateFlavorText() {
     }
 }
 
-void updatePlayerUnderwaterness() {
+void updatePlayerUnderwaterness(void) {
     if (rogue.inWater) {
         if (!cellHasTerrainFlag(player.loc, T_IS_DEEP_WATER) || player.status[STATUS_LEVITATING]
             || cellHasTerrainFlag(player.loc, (T_ENTANGLES | T_OBSTRUCTS_PASSABILITY))) {
@@ -549,7 +549,7 @@ static void applyGradualTileEffectsToCreature(creature *monst, short ticks) {
     }
 }
 
-void updateClairvoyance() {
+void updateClairvoyance(void) {
     short i, j, clairvoyanceRadius, dx, dy;
     boolean cursed;
     unsigned long cFlags;
@@ -597,7 +597,7 @@ void updateClairvoyance() {
     }
 }
 
-static void updateTelepathy() {
+static void updateTelepathy(void) {
     short i, j;
     boolean grid[DCOLS][DROWS];
 
@@ -646,7 +646,7 @@ short scentDistance(short x1, short y1, short x2, short y2) {
     }
 }
 
-static void updateScent() {
+static void updateScent(void) {
     short i, j;
     char grid[DCOLS][DROWS];
 
@@ -673,7 +673,7 @@ short armorStealthAdjustment(item *theArmor) {
     return max(0, armorTable[theArmor->kind].strengthRequired - 12);
 }
 
-short currentStealthRange() {
+short currentStealthRange(void) {
     // Default value of 14 in the light.
     short stealthRange = 14;
 
@@ -715,7 +715,7 @@ short currentStealthRange() {
     return stealthRange;
 }
 
-void demoteVisibility() {
+void demoteVisibility(void) {
     short i, j;
 
     for (i=0; i<DCOLS; i++) {
@@ -801,7 +801,7 @@ void updateVision(boolean refreshDisplay) {
     }
 }
 
-static void checkNutrition() {
+static void checkNutrition(void) {
     item *theItem;
     char buf[DCOLS*3], foodWarning[DCOLS*3];
 
@@ -880,7 +880,7 @@ static void flashCreatureAlert(creature *monst, char msg[200], const color *fore
     rogue.autoPlayingLevel = false;
 }
 
-static void handleHealthAlerts() {
+static void handleHealthAlerts(void) {
     short i, currentPercent, previousPercent,
     thresholds[] = {5, 10, 25, 40},
     pThresholds[] = {100, 90, 50};
@@ -953,7 +953,7 @@ static void addXPXPToAlly(creature *monst) {
 }
 
 /// @brief Allies gain experience if they are within 1 depth level of the player
-static void handleXPXP() {
+static void handleXPXP(void) {
 
     for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
         creature *monst = nextCreature(&it);
@@ -974,7 +974,7 @@ static void handleXPXP() {
     rogue.xpxpThisTurn = 0;
 }
 
-static void playerFalls() {
+static void playerFalls(void) {
     short damage;
     short layer;
 
@@ -1221,7 +1221,7 @@ boolean exposeTileToFire(short x, short y, boolean alwaysIgnite) {
 }
 
 // Only the gas layer can be volumetric.
-static void updateVolumetricMedia() {
+static void updateVolumetricMedia(void) {
     short i, j, newX, newY, numSpaces;
     unsigned long highestNeighborVolume;
     unsigned long sum;
@@ -1321,7 +1321,7 @@ static void updateVolumetricMedia() {
     }
 }
 
-static void updateYendorWardenTracking() {
+static void updateYendorWardenTracking(void) {
     short n;
 
     if (!rogue.yendorWarden) {
@@ -1358,7 +1358,7 @@ static void updateYendorWardenTracking() {
 
 // Monsters who are over chasms or other descent tiles won't fall until this is called.
 // This is to avoid having the monster chain change unpredictably in the middle of a turn.
-void monstersFall() {
+void monstersFall(void) {
     short x, y;
     char buf[DCOLS], buf2[DCOLS];
 
@@ -1409,7 +1409,7 @@ void monstersFall() {
     }
 }
 
-void updateEnvironment() {
+void updateEnvironment(void) {
     short i, j, direction, newX, newY, promotions[DCOLS][DROWS];
     long promoteChance;
     enum dungeonLayers layer;
@@ -1519,7 +1519,7 @@ void updateEnvironment() {
     updateFloorItems();
 }
 
-void updateAllySafetyMap() {
+void updateAllySafetyMap(void) {
     short i, j;
     short **playerCostMap, **monsterCostMap;
 
@@ -1595,7 +1595,7 @@ static void resetDistanceCellInGrid(short **grid, short x, short y) {
     }
 }
 
-void updateSafetyMap() {
+void updateSafetyMap(void) {
     short i, j;
     short **playerCostMap, **monsterCostMap;
     creature *monst;
@@ -1729,7 +1729,7 @@ void updateSafetyMap() {
     freeGrid(monsterCostMap);
 }
 
-void updateSafeTerrainMap() {
+void updateSafeTerrainMap(void) {
     short i, j;
     short **costMap;
     creature *monst;
@@ -1769,7 +1769,7 @@ void updateSafeTerrainMap() {
     freeGrid(costMap);
 }
 
-static void processIncrementalAutoID() {
+static void processIncrementalAutoID(void) {
     item *theItem, *autoIdentifyItems[3] = {rogue.armor, rogue.ringLeft, rogue.ringRight};
     char buf[DCOLS*3], theItemName[DCOLS*3];
     short i;
@@ -1943,7 +1943,7 @@ static void monsterEntersLevel(creature *monst, short n) {
     }
 }
 
-static void monstersApproachStairs() {
+static void monstersApproachStairs(void) {
     short n;
 
     for (n = rogue.depthLevel - 2; n <= rogue.depthLevel; n += 2) { // cycle through previous and next level
@@ -1966,7 +1966,7 @@ static void monstersApproachStairs() {
     }
 }
 
-static void decrementPlayerStatus() {
+static void decrementPlayerStatus(void) {
     // Handle hunger.
     if (!player.status[STATUS_PARALYZED]) {
         // No nutrition is expended while paralyzed.
@@ -2084,7 +2084,7 @@ static boolean dangerChanged(boolean danger[4]) {
     return false;
 }
 
-void autoRest() {
+void autoRest(void) {
     boolean danger[4];
     for (enum directions dir = 0; dir < 4; dir++) {
         const pos newLoc = posNeighborInDirection(player.loc, dir);
@@ -2143,7 +2143,7 @@ void autoRest() {
     rogue.automationActive = false;
 }
 
-void manualSearch() {
+void manualSearch(void) {
     recordKeystroke(SEARCH_KEY, false, false);
 
     if (player.status[STATUS_SEARCHING] <= 0) {
@@ -2184,7 +2184,7 @@ void manualSearch() {
 
 // Call this periodically (when haste/slow wears off and when moving between depths)
 // to keep environmental updates in sync with player turns.
-void synchronizePlayerTimeState() {
+void synchronizePlayerTimeState(void) {
     rogue.ticksTillUpdateEnvironment = player.ticksUntilTurn;
 }
 
@@ -2202,7 +2202,7 @@ void playerRecoversFromAttacking(boolean anAttackHit) {
 }
 
 
-static void recordCurrentCreatureHealths() {
+static void recordCurrentCreatureHealths(void) {
 
     boolean handledPlayer = false;
     for (creatureIterator it = iterateCreatures(monsters); !handledPlayer || hasNextCreature(it);) {
@@ -2216,7 +2216,7 @@ static void recordCurrentCreatureHealths() {
 // It hands control over to monsters until they've all expended their accumulated ticks,
 // updating the environment (gas spreading, flames spreading and burning out, etc.) every
 // 100 ticks.
-void playerTurnEnded() {
+void playerTurnEnded(void) {
     short soonestTurn, damage, turnsRequiredToShore, turnsToShore;
     char buf[COLS], buf2[COLS];
     boolean fastForward = false;
@@ -2621,7 +2621,7 @@ void playerTurnEnded() {
     }
 }
 
-void resetScentTurnNumber() { // don't want player.scentTurnNumber to roll over the short maxint!
+void resetScentTurnNumber(void) { // don't want player.scentTurnNumber to roll over the short maxint!
     short i, j, d;
     rogue.scentTurnNumber -= 15000;
     for (d = 0; d < gameConst->deepestLevel; d++) {

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -88,7 +88,7 @@ static short dialogSelectEntryFromList(
 }
 
 // Display a dialog window for the user to chose a vorpal enemy. Remove the runic if none selected.
-static short dialogCreateItemChooseVorpalEnemy() {
+static short dialogCreateItemChooseVorpalEnemy(void) {
     char buttonText[COLS];
     short i;
     brogueButton buttons[DIALOG_CREATE_ITEM_MAX_BUTTONS];
@@ -302,7 +302,7 @@ static void dialogCreateMonsterChooseMutation(creature *theMonster) {
 }
 
 // Display a series of dialog windows for creating an arbitrary monster chosen by the user
-static void dialogCreateMonster() {
+static void dialogCreateMonster(void) {
     brogueButton buttons[DIALOG_CREATE_ITEM_MAX_BUTTONS];
     char buttonText[COLS];
     pos selectedPosition;
@@ -436,7 +436,7 @@ static void dialogCreateMonster() {
 }
 
 // Display a series of dialog windows for creating an arbitrary item chosen by the user
-static void dialogCreateItem() {
+static void dialogCreateItem(void) {
     brogueButton buttons[DIALOG_CREATE_ITEM_MAX_BUTTONS];
     char buttonText[COLS];
     short i, selectedCategory, selectedKind;
@@ -505,7 +505,7 @@ static void dialogCreateItem() {
     messageWithColor(message, &itemMessageColor, 0);
 }
 
-void dialogCreateItemOrMonster() {
+void dialogCreateItemOrMonster(void) {
     brogueButton buttons[DIALOG_CREATE_ITEM_MAX_BUTTONS];
     short selectedType;
 

--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -6,7 +6,7 @@
 #include "platform.h"
 #include "term.h"
 
-static void gameLoop() {
+static void gameLoop(void) {
     signal(SIGINT, SIG_DFL); // keep SDL from overriding the default ^C handler when it's linked
 
     if (!Term.start()) {
@@ -107,7 +107,7 @@ static int rewriteKey(int key, boolean text) {
 
 #define PAUSE_BETWEEN_EVENT_POLLING     34//17
 
-static uint64_t getTime() {
+static uint64_t getTime(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (uint64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -16,7 +16,7 @@ boolean hasGraphics = false;
 enum graphicsModes graphicsMode = TEXT_GRAPHICS;
 boolean isCsvFormat = false;
 
-static void printCommandlineHelp() {
+static void printCommandlineHelp(void) {
     printf("%s",
     "--help         -h          print this help message and exit \n"
     "--version      -V          print the version and exit\n"

--- a/src/platform/null-platform.c
+++ b/src/platform/null-platform.c
@@ -1,6 +1,6 @@
 #include "platform.h"
 
-static void null_gameLoop() {
+static void null_gameLoop(void) {
     exit(rogueMain());
 }
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -36,7 +36,7 @@ struct brogueConsole {
     The platform entrypoint, called by the main function. Should initialize
     and then call rogueMain.
     */
-    void (*gameLoop)();
+    void (*gameLoop)(void);
 
     /*
     Pause the game, returning a boolean specifying whether an input event
@@ -76,7 +76,7 @@ struct brogueConsole {
     /*
     Optional. Take a screenshot in current working directory
     */
-    boolean (*takeScreenshot)();
+    boolean (*takeScreenshot)(void);
 
     /*
     Optional. Enables or disables graphical tiles, returning the new state. This

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -228,10 +228,10 @@ void plotChar(enum displayGlyph inputChar,
     currentConsole.plotChar(inputChar, xLoc, yLoc, foreRed, foreGreen, foreBlue, backRed, backGreen, backBlue);
 }
 
-boolean shiftKeyIsDown() {
+boolean shiftKeyIsDown(void) {
     return currentConsole.modifierHeld(0);
 }
-boolean controlKeyIsDown() {
+boolean controlKeyIsDown(void) {
     return currentConsole.modifierHeld(1);
 }
 
@@ -249,7 +249,7 @@ void notifyEvent(short eventId, int data1, int data2, const char *str1, const ch
     }
 }
 
-boolean takeScreenshot() {
+boolean takeScreenshot(void) {
     if (currentConsole.takeScreenshot) {
         return currentConsole.takeScreenshot();
     } else {
@@ -266,7 +266,7 @@ enum graphicsModes setGraphicsMode(enum graphicsModes mode) {
 }
 
 // creates an empty high scores file
-static void initScores() {
+static void initScores(void) {
     short i;
     FILE *scoresFile;
     char highScoresFilename[BROGUE_FILENAME_MAX];
@@ -282,7 +282,7 @@ static void initScores() {
 
 // sorts the entries of the scoreBuffer global variable by score in descending order;
 // returns the sorted line number of the most recent entry
-static short sortScoreBuffer() {
+static short sortScoreBuffer(void) {
     short i, j, highestUnsortedLine, mostRecentSortedLine = 0;
     long highestUnsortedScore, mostRecentDate;
     brogueScoreEntry sortedScoreBuffer[HIGH_SCORES_COUNT];
@@ -326,7 +326,7 @@ void setHighScoresFilename(char *buffer, int bufferMaxLength) {
 
 // loads the ([V]ariantName)HighScores.txt file into the scoreBuffer global variable
 // score file format is: score, tab, date in seconds, tab, description, newline.
-static short loadScoreBuffer() {
+static short loadScoreBuffer(void) {
     short i;
     FILE *scoresFile;
     time_t rawtime;
@@ -360,7 +360,7 @@ static short loadScoreBuffer() {
     return sortScoreBuffer();
 }
 
-void loadKeymap() {
+void loadKeymap(void) {
     int i;
     FILE *f;
     char buffer[512];
@@ -401,7 +401,7 @@ void loadKeymap() {
 // thus overwriting whatever is already there.
 // The numerical version of the date is what gets saved; the "mm/dd/yy" version is ignored.
 // Does NOT do any sorting.
-static void saveScoreBuffer() {
+static void saveScoreBuffer(void) {
     short i;
     FILE *scoresFile;
     char highScoresFilename[BROGUE_FILENAME_MAX];
@@ -418,7 +418,7 @@ static void saveScoreBuffer() {
     fclose(scoresFile);
 }
 
-void dumpScores() {
+void dumpScores(void) {
     int i;
 
     rogueHighScoresEntry list[HIGH_SCORES_COUNT];
@@ -563,7 +563,7 @@ struct filelist {
     int nextname, maxname;
 };
 
-static struct filelist *newFilelist() {
+static struct filelist *newFilelist(void) {
     struct filelist *list = malloc(sizeof(*list));
 
     list->nfiles = 0;

--- a/src/platform/sdl2-platform.c
+++ b/src/platform/sdl2-platform.c
@@ -243,7 +243,7 @@ static boolean pollBrogueEvent(rogueEvent *returnEvent, boolean textInput) {
 }
 
 
-static void _gameLoop() {
+static void _gameLoop(void) {
 #ifdef SDL_PATHS
     char *path = SDL_GetBasePath();
     if (path) {
@@ -410,7 +410,7 @@ static void _remap(const char *from, const char *to) {
 /*
  * Take screenshot in current working directory (ScreenshotN.png)
  */
-static boolean _takeScreenshot() {
+static boolean _takeScreenshot(void) {
     SDL_Surface *screenshot = captureScreen();
     if (!screenshot) return false;
 

--- a/src/platform/term.c
+++ b/src/platform/term.c
@@ -88,13 +88,13 @@ static void term_title(const char *title) {
     }
 }
 
-static void term_title_pop() {
+static void term_title_pop(void) {
     if (is_xterm) {
         term_title("Terminal");
         printf ("\033[22;2t");
     }
 }
-static void term_title_push() {
+static void term_title_push(void) {
     if (is_xterm) {
         printf ("\033[23;2t");
     }
@@ -161,7 +161,7 @@ static int curses_init( ) {
 }
 
 
-static int term_start() {
+static int term_start(void) {
     char *term = getenv("TERM");
     is_xterm = (strncmp(term, "xterm", 5) == 0) || (strncmp(term, "gnome", 5) == 0) || (strncmp(term, "st", 2) == 0);
 
@@ -174,7 +174,7 @@ static int term_start() {
     return ok;
 }
 
-static void term_end() {
+static void term_end(void) {
     term_title_pop();
     clear();
     refresh();
@@ -282,7 +282,7 @@ static float CIE76(Lab *L1, Lab *L2) {
     return sqrt(lbias * SQUARE(L2->L - L1->L) + SQUARE(L2->a - L1->a) + SQUARE(L2->b - L1->b));
 }
 
-static void init_coersion() {
+static void init_coersion(void) {
     fcolor sRGB_white = (fcolor) {1, 1, 1};
     white = toCIE(sRGB_white);
 
@@ -363,7 +363,7 @@ static int best (fcolor *fg, fcolor *bg) {
 
 
 
-static void initialize_prs() {
+static void initialize_prs(void) {
     int i;
     for (i = 16; i < 255; i++) {
         prs[i].next = i + 1;
@@ -510,7 +510,7 @@ static void buffer_plot(int ch, int x, int y, fcolor *fg, fcolor *bg) {
     cell_buffer[cell].back = cube_bg;
 }
 
-static void buffer_render_256() {
+static void buffer_render_256(void) {
     // build a new palette
     initialize_prs();
 
@@ -547,7 +547,7 @@ static void buffer_render_256() {
 
 static int fullRefresh = 1; // screen needs a full refresh
 
-static void buffer_render_24bit() {
+static void buffer_render_24bit(void) {
     int cx, cy;      // cursor coordinates
     intcolor fg, bg; // current colors
 
@@ -601,7 +601,7 @@ static void term_mvaddch(int x, int y, int ch, fcolor *fg, fcolor *bg) {
     }
 }
 
-static void term_refresh() {
+static void term_refresh(void) {
     // to set up a 256-color terminal, see:
     // http://push.cx/2008/256-color-xterms-in-ubuntu
     if (0 && can_change_color()) {
@@ -675,7 +675,7 @@ static int term_getkey( ) {
     }
 }
 
-static int term_has_key() {
+static int term_has_key(void) {
     int ch = getch();
     if (ch != ERR) {
         ungetch(ch);

--- a/src/platform/tiles.c
+++ b/src/platform/tiles.c
@@ -349,7 +349,7 @@ static double downscaleTile(SDL_Surface *surface, int tileWidth, int tileHeight,
 ///
 /// This is a slow function (takes ~2 minutes) so the results are saved to disk and reloaded when Brogue starts.
 /// After you modify the PNG, you should also delete "tiles.bin" and run Brogue so that the new tiles get optimized.
-static void optimizeTiles() {
+static void optimizeTiles(void) {
     SDL_Window *window = SDL_CreateWindow("Brogue", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 400, 300, 0);
 
     for (int row = 0; row < TILE_ROWS; row++) {
@@ -443,7 +443,7 @@ static void optimizeTiles() {
 
 
 /// Loads the PNG and analyses it.
-void initTiles() {
+void initTiles(void) {
     char filename[BROGUE_FILENAME_MAX];
     sprintf(filename, "%s/assets/tiles.png", dataDirectory);
 
@@ -618,7 +618,7 @@ void updateTile(int row, int column, short charIndex,
 /// This works because, unlike the accelerated renderers, the software renderer draws on a
 /// single surface and doesn't do double-buffering.
 ///
-void updateScreen() {
+void updateScreen(void) {
     if (!Win) return;
 
     SDL_Renderer *renderer = SDL_GetRenderer(Win);
@@ -792,7 +792,7 @@ void resizeWindow(int width, int height) {
 }
 
 
-SDL_Surface *captureScreen() {
+SDL_Surface *captureScreen(void) {
     if (!Win) return NULL;
 
     // get the renderer

--- a/src/platform/web-platform.c
+++ b/src/platform/web-platform.c
@@ -57,7 +57,7 @@ static int readFromSocket(unsigned char *buf, int size);
 static void writeToSocket(unsigned char *buf, int size);
 static void flushOutputBuffer();
 
-static void gameLoop() {
+static void gameLoop(void) {
     openLogfile();
     writeToLog("Logfile started\n");
 
@@ -70,7 +70,7 @@ static void gameLoop() {
     exit(statusCode);
 }
 
-static void openLogfile() {
+static void openLogfile(void) {
     logfile = fopen("brogue-web.txt", "a");
     if (logfile == NULL)
     {
@@ -78,7 +78,7 @@ static void openLogfile() {
     }
 }
 
-static void closeLogfile() {
+static void closeLogfile(void) {
     fclose(logfile);
 }
 
@@ -87,7 +87,7 @@ static void writeToLog(const char *msg) {
     fflush(logfile);
 }
 
-static void setupSockets() {
+static void setupSockets(void) {
     struct sockaddr_un addr_read;
 
     // Open read socket (from external)
@@ -112,7 +112,7 @@ int readFromSocket(unsigned char *buf, int size) {
     return recvfrom(rfd, buf, size, 0, NULL, NULL);
 }
 
-static void flushOutputBuffer() {
+static void flushOutputBuffer(void) {
     char msg[80];
     int no_bytes_sent;
 
@@ -177,7 +177,7 @@ static void web_plotChar(enum displayGlyph inputChar,
     writeToSocket(outputBuffer, OUTPUT_SIZE);
 }
 
-static void sendStatusUpdate() {
+static void sendStatusUpdate(void) {
     unsigned char statusOutputBuffer[OUTPUT_SIZE];
     unsigned long statusValues[STATUS_TYPES_NUMBER];
     int i, j;

--- a/src/variants/GlobalsBrogue.c
+++ b/src/variants/GlobalsBrogue.c
@@ -1063,7 +1063,7 @@ const gameConstants brogueGameConst = {
     .mainMenuTitleWidth = MENU_TITLE_WIDTH
 };
 
-void initializeGameVariantBrogue() {
+void initializeGameVariantBrogue(void) {
 
     // Game constants
     gameConst = &brogueGameConst;

--- a/src/variants/GlobalsBulletBrogue.c
+++ b/src/variants/GlobalsBulletBrogue.c
@@ -1077,7 +1077,7 @@ const gameConstants bulletBrogueGameConst = {
     .mainMenuTitleWidth = MENU_TITLE_WIDTH
 };
 
-void initializeGameVariantBulletBrogue() {
+void initializeGameVariantBulletBrogue(void) {
 
     // Game constants
     gameConst = &bulletBrogueGameConst;

--- a/src/variants/GlobalsRapidBrogue.c
+++ b/src/variants/GlobalsRapidBrogue.c
@@ -1067,7 +1067,7 @@ const gameConstants rapidBrogueGameConst = {
     .mainMenuTitleWidth = MENU_TITLE_WIDTH
 };
 
-void initializeGameVariantRapidBrogue() {
+void initializeGameVariantRapidBrogue(void) {
 
     // Game constants
     gameConst = &rapidBrogueGameConst;


### PR DESCRIPTION
When building on my machine, a LOT of "strict-prototype" warnings are generated (hundreds).  This PR fixes them, and should have no in-game effects.

My compiler:
```
cc --version
Apple clang version 17.0.0 (clang-1700.6.3.2)
Target: arm64-apple-darwin25.2.0
Thread model: posix

```

This is a largely automatic refactor, the majority of these changes can be found using a find/replace regex:

find:  `^(.*)\(\) \{`
replace:  `$1(void) {`

The last few are in `platform.h` added manually.
