### PR TITLE
Fix const-related warnings, and a few others

### DIFF
--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -1741,7 +1741,7 @@ void killCreature(creature *decedent, boolean administrativeDeath) {
     }
 }
 
-void buildHitList(const creature **hitList, const creature *attacker, creature *defender, const boolean sweep) {
+void buildHitList(creature **hitList, const creature *attacker, creature *defender, const boolean sweep) {
     short i, x, y, newX, newY, newestX, newestY;
     enum directions dir, newDir;
 

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -1423,7 +1423,7 @@ void call(item *theItem) {
 // If baseColor is provided, then the suffix will be in gray, flavor portions of the item name (e.g. a "pink" potion,
 //  a "sandalwood" staff, a "ruby" ring) will be in dark purple, and the Amulet of Yendor and lumenstones will be in yellow.
 //  BaseColor itself will be the color that the name reverts to outside of these colored portions.
-void itemName(item *theItem, char *root, boolean includeDetails, boolean includeArticle, const color *baseColor) {
+void itemName(const item *theItem, char *root, boolean includeDetails, boolean includeArticle, const color *baseColor) {
     char buf[DCOLS * 5], pluralization[10], article[10] = "", runicName[30],
     grayEscapeSequence[5], purpleEscapeSequence[5], yellowEscapeSequence[5], baseEscapeSequence[5];
     color tempColor;
@@ -1714,7 +1714,7 @@ void itemName(item *theItem, char *root, boolean includeDetails, boolean include
     return;
 }
 
-void itemKindName(item *theItem, char *kindName) {
+void itemKindName(const item *theItem, char *kindName) {
 
     // use lookup table for randomly generated items with more than one kind per category
     if (theItem->category & (ARMOR | CHARM | FOOD | POTION | RING | SCROLL | STAFF | WAND | WEAPON)) {
@@ -1741,7 +1741,7 @@ void itemKindName(item *theItem, char *kindName) {
     }
 }
 
-void itemRunicName(item *theItem, char *runicName) {
+void itemRunicName(const item *theItem, char *runicName) {
     char vorpalEnemyMonsterClass[15] ="";
 
     if (theItem->flags & ITEM_RUNIC) {
@@ -3687,7 +3687,7 @@ static boolean tunnelize(short x, short y) {
 /// @param monst The monster
 /// @param isBolt True to check for a negation bolt. False for negation blast.
 /// @return True if negation will have an effect
-static boolean negationWillAffectMonster(creature *monst, boolean isBolt) {
+static boolean negationWillAffectMonster(const creature *monst, boolean isBolt) {
 
     // negation bolts don't affect monsters that always reflect. negation never affects the warden.
     if ((isBolt && (monst->info.abilityFlags & MA_REFLECT_100))
@@ -4342,7 +4342,7 @@ enum boltEffects boltEffectForItem(item *theItem) {
     }
 }
 
-enum boltType boltForItem(item *theItem) {
+enum boltType boltForItem(const item *theItem) {
     if (theItem->category & (STAFF | WAND)) {
         return tableForItemCategory(theItem->category)[theItem->kind].power;
     } else {
@@ -7462,7 +7462,7 @@ short magicCharDiscoverySuffix(short category, short kind) {
 -1 if the item is of bad magic
  0 if it is neutral
  1 if it is of good magic */
-int itemMagicPolarity(item *theItem) {
+int itemMagicPolarity(const item *theItem) {
     itemTable *theItemTable = tableForItemCategory(theItem->category);
     switch (theItem->category) {
         case WEAPON:

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -163,7 +163,7 @@ void initializeMonster(creature *monst, boolean itemPossible) {
 /// @brief Checks if the player knows a monster's location via telepathy or entrancement.
 /// @param monst the monster
 /// @return true if the monster is either entranced or revealed by telepathy
-boolean monsterRevealed(creature *monst) {
+boolean monsterRevealed(const creature *monst) {
     if (monst == &player) {
         return false;
     } else if (monst->bookkeepingFlags & MB_TELEPATHICALLY_REVEALED) {
@@ -226,7 +226,7 @@ boolean monsterIsHidden(const creature *monst, const creature *observer) {
 /// verbiage used in combat/dungeon messages (or whether a message appears at all).
 /// @param monst the monster
 /// @return true if the monster is not hidden and the player knows its location
-boolean canSeeMonster(creature *monst) {
+boolean canSeeMonster(const creature *monst) {
     if (monst == &player) {
         return true;
     }
@@ -242,7 +242,7 @@ boolean canSeeMonster(creature *monst) {
 /// darkening is a factor because it affects a cell's VISIBLE flag.
 /// @param monst the monster
 /// @return true if the player can physically see the monster
-boolean canDirectlySeeMonster(creature *monst) {
+boolean canDirectlySeeMonster(const creature *monst) {
     if (monst == &player) {
         return true;
     }
@@ -252,7 +252,7 @@ boolean canDirectlySeeMonster(creature *monst) {
     return false;
 }
 
-void monsterName(char *buf, creature *monst, boolean includeArticle) {
+void monsterName(char *buf, const creature *monst, boolean includeArticle) {
     short oldRNG;
 
     if (monst == &player) {
@@ -3714,7 +3714,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
     short i;
     short confusedDirection, swarmDirection;
     creature *defender = NULL;
-    const creature *hitList[16] = {NULL};
+    creature *hitList[16] = {NULL};
     enum directions dir;
 
     if (dx == 0 && dy == 0) {

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -138,7 +138,7 @@ void describedItemName(const item *theItem, char *description, int maxLength) {
     }
 }
 
-void describeLocation(char *buf, short x, short y) {
+void describeLocation(char buf[DCOLS], short x, short y) {
     creature *monst;
     item *theItem, *magicItem;
     boolean standsInTerrain;
@@ -555,7 +555,7 @@ boolean freeCaptivesEmbeddedAt(short x, short y) {
 /// @brief Ask the player for confirmation before attacking an acidic monster
 /// @param hitList the creature(s) getting attacked
 /// @return true to abort the attack
-static boolean abortAttackAgainstAcidicTarget(const creature *hitList[8]) {
+static boolean abortAttackAgainstAcidicTarget(creature *hitList[8]) {
     short i;
     char monstName[COLS], weaponName[COLS];
     char buf[COLS*3];
@@ -588,7 +588,7 @@ static boolean abortAttackAgainstAcidicTarget(const creature *hitList[8]) {
 /// @brief Ask the player for confirmation before attacking a discordant ally
 /// @param hitList the creature(s) getting attacked
 /// @return true to abort the attack
-static boolean abortAttackAgainstDiscordantAlly(const creature *hitList[8]) {
+static boolean abortAttackAgainstDiscordantAlly(creature *hitList[8]) {
 
     for (int i=0; i<8; i++) {
         if (hitList[i]
@@ -614,7 +614,7 @@ static boolean abortAttackAgainstDiscordantAlly(const creature *hitList[8]) {
 /// hallucinating (but not telepathic).
 /// @param hitList the creature(s) getting attacked
 /// @return true to abort the attack
-static boolean abortAttack(const creature *hitList[8]) {
+static boolean abortAttack(creature *hitList[8]) {
 
     // too bad so sad if you're confused or hallucinating (but not telepathic)
     if (player.status[STATUS_CONFUSED]
@@ -638,7 +638,7 @@ static boolean abortAttack(const creature *hitList[8]) {
 boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *aborted) {
     bolt theBolt;
     creature *defender;
-    const creature *hitList[8] = {0};
+    creature *hitList[8] = {0};
 
     const char boltChar[DIRECTION_COUNT] = "||~~\\//\\";
 
@@ -694,7 +694,7 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
 // (in which case the player/monster should move instead).
 boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *aborted) {
     creature *defender;
-    const creature *hitList[8] = {0};
+    creature *hitList[8] = {0};
     short range = 2, i = 0, h = 0;
     boolean proceed = false, visualEffect = false;
 
@@ -798,7 +798,7 @@ boolean handleSpearAttacks(creature *attacker, enum directions dir, boolean *abo
     return false;
 }
 
-static void buildFlailHitList(const short x, const short y, const short newX, const short newY, const creature *hitList[16]) {
+static void buildFlailHitList(const short x, const short y, const short newX, const short newY, creature *hitList[16]) {
     short mx, my;
     short i = 0;
 
@@ -846,7 +846,7 @@ boolean playerMoves(short direction) {
     short newX, newY, newestX, newestY;
     boolean playerMoved = false, specialAttackAborted = false, anyAttackHit = false;
     creature *defender = NULL, *tempMonst = NULL;
-    const creature *hitList[16] = {NULL};
+    creature *hitList[16] = {NULL};
     char monstName[COLS];
     char buf[COLS*3];
     const int directionKeys[8] = {UP_KEY, DOWN_KEY, LEFT_KEY, RIGHT_KEY, UPLEFT_KEY, DOWNLEFT_KEY, UPRIGHT_KEY, DOWNRIGHT_KEY};

--- a/src/brogue/PowerTables.c
+++ b/src/brogue/PowerTables.c
@@ -42,7 +42,7 @@
 
 // game data formulae:
 
-short wandDominate(creature *monst)                 {return (((monst)->currentHP * 5 < (monst)->info.maxHP) ? 100 : \
+short wandDominate(const creature *monst)           {return (((monst)->currentHP * 5 < (monst)->info.maxHP) ? 100 : \
                                                      max(0, 100 * ((monst)->info.maxHP - (monst)->currentHP) / (monst)->info.maxHP));}
 
 // All "enchant" parameters must already be multiplied by FP_FACTOR:

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -468,7 +468,6 @@ void initRecording() {
     }
 
     short i;
-    enum gameMode mode;
     unsigned short recPatch;
     char buf[1000], *versionString = rogue.versionString;
     FILE *recordFile;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3235,12 +3235,12 @@ extern "C" {
     short distanceBetween(pos loc1, pos loc2);
     void alertMonster(creature *monst);
     void wakeUp(creature *monst);
-    boolean monsterRevealed(creature *monst);
+    boolean monsterRevealed(const creature *monst);
     boolean monsterHiddenBySubmersion(const creature *monst, const creature *observer);
     boolean monsterIsHidden(const creature *monst, const creature *observer);
-    boolean canSeeMonster(creature *monst);
-    boolean canDirectlySeeMonster(creature *monst);
-    void monsterName(char *buf, creature *monst, boolean includeArticle);
+    boolean canSeeMonster(const creature *monst);
+    boolean canDirectlySeeMonster(const creature *monst);
+    void monsterName(char *buf, const creature *monst, boolean includeArticle);
     boolean monsterIsInClass(const creature *monst, const short monsterClass);
     boolean chooseTarget(pos *returnLoc, short maxDistance, enum autoTargetMode targetingMode, const item *theItem);
     fixpt strengthModifier(item *theItem);
@@ -3255,7 +3255,7 @@ extern "C" {
                           short damage, const color *flashColor, boolean ignoresProtectionShield);
     void addPoison(creature *monst, short totalDamage, short concentrationIncrement);
     void killCreature(creature *decedent, boolean administrativeDeath);
-    void buildHitList(const creature **hitList, const creature *attacker, creature *defender, const boolean sweep);
+    void buildHitList(creature **hitList, const creature *attacker, creature *defender, const boolean sweep);
     void addScentToCell(short x, short y, short distance);
     void populateItems(pos upstairs);
     item *placeItemAt(item *theItem, pos dest);
@@ -3278,7 +3278,7 @@ extern "C" {
     short reflectBolt(short targetX, short targetY, pos listOfCoordinates[], short kinkCell, boolean retracePath);
     void checkForMissingKeys(short x, short y);
     enum boltEffects boltEffectForItem(item *theItem);
-    enum boltType boltForItem(item *theItem);
+    enum boltType boltForItem(const item *theItem);
     boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, boolean reverseBoltDir);
     boolean nextTargetAfter(const item *theItem,
                             pos *returnLoc,
@@ -3300,9 +3300,9 @@ extern "C" {
     char nextAvailableInventoryCharacter(void);
     void checkForDisenchantment(item *theItem);
     void updateFloorItems(void);
-    void itemKindName(item *theItem, char *kindName);
-    void itemRunicName(item *theItem, char *runicName);
-    void itemName(item *theItem, char *root, boolean includeDetails, boolean includeArticle, const color *baseColor);
+    void itemKindName(const item *theItem, char *kindName);
+    void itemRunicName(const item *theItem, char *runicName);
+    void itemName(const item *theItem, char *root, boolean includeDetails, boolean includeArticle, const color *baseColor);
     int itemKindCount(enum itemCategory category, int magicPolarity);
     char displayInventory(unsigned short categoryMask,
                           unsigned long requiredFlags,
@@ -3405,7 +3405,7 @@ extern "C" {
     item *itemOfPackLetter(char letter);
     boolean unequipItem(item *theItem, boolean force);
     short magicCharDiscoverySuffix(short category, short kind);
-    int itemMagicPolarity(item *theItem);
+    int itemMagicPolarity(const item *theItem);
     item *itemAtLoc(pos loc);
     item *dropItem(item *theItem);
     itemTable *tableForItemCategory(enum itemCategory theCat);
@@ -3470,7 +3470,7 @@ extern "C" {
     void parseFile(void);
     void RNGLog(char *message);
 
-    short wandDominate(creature *monst);
+    short wandDominate(const creature *monst);
     short staffDamageLow(fixpt enchant);
     short staffDamageHigh(fixpt enchant);
     short staffDamage(fixpt enchant);

--- a/src/platform/platformdependent.c
+++ b/src/platform/platformdependent.c
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <inttypes.h>
 
 #include "platform.h"
 #include "GlobalsBase.h"
@@ -492,7 +493,7 @@ void saveRunHistory(char *result, char *killedBy, int score, int lumenstones) {
     setRunHistoryFilename(runHistoryFilename, BROGUE_FILENAME_MAX);
     runHistoryFile = fopen(runHistoryFilename, "a"); // append. create if not found.
 
-    fprintf(runHistoryFile, "%llu\t%li\t%s\t%s\t%i\t%i\t%i\t%i\t%i\n", rogue.seed, (long) time(NULL), result, killedBy, 
+    fprintf(runHistoryFile, "%" PRIu64 "\t%li\t%s\t%s\t%i\t%i\t%i\t%i\t%i\n", rogue.seed, (long) time(NULL), result, killedBy, 
             score, (int) rogue.gold, lumenstones, (int) rogue.deepestLevel, (int) rogue.playerTurnNumber);
     fclose(runHistoryFile);
 }
@@ -531,7 +532,7 @@ rogueRun* loadRunHistory(void) {
         memset(run, '\0', sizeof(rogueRun));
         run->nextRun = NULL;
 
-        int vals = sscanf(line, "%llu\t%li\t%s\t%[^\t]\t%i\t%i\t%i\t%i\t%i\n", &run->seed, &run->dateNumber,
+        int vals = sscanf(line, "%" PRIu64 "\t%li\t%s\t%[^\t]\t%i\t%i\t%i\t%i\t%i\n", &run->seed, &run->dateNumber,
                    run->result, run->killedBy, &run->score, &run->gold, &run->lumenstones,
                    &run->deepestLevel, &run->turns);
 

--- a/src/variants/GlobalsBulletBrogue.c
+++ b/src/variants/GlobalsBulletBrogue.c
@@ -38,6 +38,7 @@
 #include "Rogue.h"
 #include "GlobalsBase.h"
 #include "Globals.h"
+#include "GlobalsBulletBrogue.h"
 
 #define AMULET_LEVEL            3          // how deep before the amulet appears
 #define DEEPEST_LEVEL           5         // how deep the universe goes


### PR DESCRIPTION
This fixes all warnings related to pointers to consts. It also fixes a few other straightforward-to-fix warnings which didn't seem big enough for a separate commit (though I'm happy to make separate commits for them if that would be helpful).

There's a few cases where there's a type like `creature *hitList[8]`, which seem like they should be able to be `const`, but doing so requires some ugly casts, so this makes them non-const, for simplicity. In all other cases, this commit adds `const`s rather than removing them.

After this commit, the vast majority of warnings displayed on my system are along the lines of "output may be truncated copying 299 bytes from a string of length 299 " or "reading 100 bytes from a region of size 10". I intend to look into those later.