### PR TITLE
Fix the player getting a free turn when automatically eating food when starving

### DIFF
--- a/changes/force-eat-food-bug
+++ b/changes/force-eat-food-bug
@@ -1,0 +1,1 @@
+The player no longer gets a free turn after automatically eating food when starving.

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -801,8 +801,8 @@ void updateVision(boolean refreshDisplay) {
     }
 }
 
-static void checkNutrition() {
-    item *theItem;
+// This should be called only after decrementing the player's nutrition.
+static void printNutritionMessages(void) {
     char buf[DCOLS*3], foodWarning[DCOLS*3];
 
     if (numberOfMatchingPackItems(FOOD, 0, 0, false) == 0) {
@@ -812,34 +812,34 @@ static void checkNutrition() {
     }
 
     if (player.status[STATUS_NUTRITION] == HUNGER_THRESHOLD) {
-        player.status[STATUS_NUTRITION]--;
         sprintf(buf, "you are hungry%s.", foodWarning);
         message(buf, foodWarning[0] ? REQUIRE_ACKNOWLEDGMENT : 0);
     } else if (player.status[STATUS_NUTRITION] == WEAK_THRESHOLD) {
-        player.status[STATUS_NUTRITION]--;
         sprintf(buf, "you feel weak with hunger%s.", foodWarning);
         message(buf, REQUIRE_ACKNOWLEDGMENT);
     } else if (player.status[STATUS_NUTRITION] == FAINT_THRESHOLD) {
-        player.status[STATUS_NUTRITION]--;
         sprintf(buf, "you feel faint with hunger%s.", foodWarning);
         message(buf, REQUIRE_ACKNOWLEDGMENT);
-    } else if (player.status[STATUS_NUTRITION] <= 1) {
-        // Force the player to eat something if he has it
-        for (theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
-            if (theItem->category == FOOD) {
-                sprintf(buf, "unable to control your hunger, you eat a %s.", (theItem->kind == FRUIT ? "mango" : "ration of food"));
-                messageWithColor(buf, &itemMessageColor, REQUIRE_ACKNOWLEDGMENT);
-                confirmMessages();
-                eat(theItem, false);
-                playerTurnEnded();
-                break;
-            }
-        }
-    }
-
-    if (player.status[STATUS_NUTRITION] == 1) { // Didn't manage to eat any food above.
-        player.status[STATUS_NUTRITION] = 0;    // So the status bar changes in time for the message:
+    } else if (player.status[STATUS_NUTRITION] == 0) {
         message("you are starving to death!", REQUIRE_ACKNOWLEDGMENT);
+    }
+}
+
+// This should only be called when the player is starving or very close to it.
+static void forceEatFood(void) {
+    brogueAssert(player.status[STATUS_NUTRITION] <= 1);
+    char buf[DCOLS*3];
+    // Force the player to eat something if he has it
+    for (item *theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+        if (theItem->category == FOOD) {
+            const char *foodName = theItem->kind == FRUIT ? "mango" : "ration of food";
+            sprintf(buf, "unable to control your hunger, you eat a %s.", foodName);
+            messageWithColor(buf, &itemMessageColor, REQUIRE_ACKNOWLEDGMENT);
+            confirmMessages();
+            eat(theItem, false);
+            playerTurnEnded();
+            break;
+        }
     }
 }
 
@@ -1973,9 +1973,9 @@ static void decrementPlayerStatus() {
         if (player.status[STATUS_NUTRITION] > 0) {
             if (!numberOfMatchingPackItems(AMULET, 0, 0, false) || rand_percent(20)) {
                 player.status[STATUS_NUTRITION]--;
+                printNutritionMessages();
             }
         }
-        checkNutrition();
     }
 
     if (player.status[STATUS_TELEPATHIC] > 0 && !--player.status[STATUS_TELEPATHIC]) {
@@ -2553,7 +2553,6 @@ void playerTurnEnded() {
             }
         }
 
-        //checkNutrition(); // Now handled within decrementPlayerStatus().
         if (!rogue.playbackFastForward) {
             shuffleTerrainColors(100, false);
         }
@@ -2618,6 +2617,10 @@ void playerTurnEnded() {
     if (rogue.flareCount > 0) {
         animateFlares(rogue.flares, rogue.flareCount);
         rogue.flareCount = 0;
+    }
+    
+    if (player.status[STATUS_NUTRITION] <= 1) {
+        forceEatFood();
     }
 }
 


### PR DESCRIPTION
Previously, automatically eating food when starving would not only eat the food without using a turn, it would give the player a free turn afterwards.

In addition, becoming hungry/weak/etc no longer consumes an extra turn of food. This simplifies the code and should have minimal effect on gameplay.