### PR TITLE
Lumenstone score calculation on loss fix

### DIFF
--- a/changes/Lumenstone-score-fix.md
+++ b/changes/Lumenstone-score-fix.md
@@ -1,0 +1,1 @@
+Fixed an issue in score calculation for losing where lumenstones were miscounted. Lumenstone stacks were counted instead of individual lumenstones.

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1145,7 +1145,12 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     }
 
     // Count gems as 500 gold each
-    short numGems = numberOfMatchingPackItems(GEM, 0, 0, false);
+    short numGems = 0;
+    for (i = 4, theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+        if (theItem->category & GEM) {
+            numGems += theItem->quantity;
+        }
+}
     rogue.gold += 500 * numGems;
     theEntry.score = rogue.gold;
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1146,7 +1146,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
 
     // Count gems as 500 gold each
     short numGems = 0;
-    for (i = 4, theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+    for (theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
         if (theItem->category & GEM) {
             numGems += theItem->quantity;
         }


### PR DESCRIPTION
Fixed the lumenstone score calculation on death.

I copied the winning score calculation code across, making an adjustment to a variable name (gemCount to numGems).

I tested it with a recording converted to a save and rewinded 1 turn (on 1.14.1). It recorded the score correctly. It should work correctly for 1.15.1.

This is for issue #805.