### PR TITLE
Improve compiler flags for warnings and disable -Wstringop-foo warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 include config.mk
 
 cflags := -Isrc/brogue -Isrc/platform -Isrc/variants -std=c99 \
-	-Wall -Wpedantic -Werror=implicit -Wno-parentheses -Wno-unused-result \
-	-Wformat -Werror=format-security -Wformat-overflow=0 -Wmissing-prototypes
+	-Wall -Wextra -Wpedantic -Wmissing-prototypes -Wstrict-prototypes \
+	-Werror=implicit -Wno-unused-result -Wno-missing-field-initializers \
+	-Wformat -Werror=format-security -Wno-format-truncation -Wno-format-overflow
 libs := -lm
 cppflags := -DDATADIR=$(DATADIR)
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -31,6 +31,14 @@
 #include <time.h>
 #include "PlatformDefines.h"
 
+// These flags aren't supported by Clang (only by GCC), so they have to be
+// disabled here instead of in the Makefile.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+
 // unicode: comment this line to revert to ASCII
 #define USE_UNICODE
 


### PR DESCRIPTION
This brings the warnings produced by GCC closer to those produced by clang. Clang still generates a few warnings that GCC doesn't seem to support, however.

This also disables -Wstringop-truncation, -overread, and -overflow, since the resulting warnings are probably useless. Clang doesn't support those flags, so this unfortunately has to be done with `#pragma`s in `Rogue.h`.

I recommend not merging this until #789 is merged, because that PR fixes dozens of warnings that currently only show up in Clang, and this PR will enable those warnings in GCC.