### PR TITLE
Enable assertions when DEBUG=YES is specified, and change meaning of DEBUG macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 
 ifeq ($(DEBUG),YES)
 cflags += -g -Og
-cppflags += -DENABLE_PLAYBACK_SWITCH
+cppflags += -DENABLE_PLAYBACK_SWITCH -DDEBUG_ENABLED
 else
 cflags += -O2
 endif

--- a/config.mk
+++ b/config.mk
@@ -15,7 +15,8 @@ SDL_CONFIG := sdl2-config
 # Select web brogue mode. Requires POSIX system.
 WEBBROGUE := NO
 
-# Enable debugging mode. See top of Rogue.h for features
+# Enable debugging mode. Primarily enables assertions and the ability to switch
+# a recording to a regular game.
 DEBUG := NO
 
 # Declare this is a release build

--- a/src/brogue/IO.c
+++ b/src/brogue/IO.c
@@ -335,7 +335,7 @@ static short actionMenu(short x, boolean playingBack) {
             strcpy(buttons[buttonCount].text, "  Discovered items  ");
         }
         buttons[buttonCount].hotkey[0] = DISCOVERIES_KEY;
-        DEBUG {
+        if (WIZARD_MODE) {
             buttonCount++;
             if (KEYBOARD_LABELS) {
                 sprintf(buttons[buttonCount].text, "  %sC: %sCreate item or monster  ", yellowColorEscape, whiteColorEscape);
@@ -2617,7 +2617,7 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
             printDiscoveriesScreen();
             break;
         case CREATE_ITEM_MONSTER_KEY:
-            DEBUG {
+            if (WIZARD_MODE) {
                 dialogCreateItemOrMonster();
             }
             break;
@@ -2670,10 +2670,12 @@ void executeKeystroke(signed long keystroke, boolean controlKey, boolean shiftKe
                 copyDisplayBuffer(&dbuf, &displayBuffer);
                 funkyFade(dbuf, &white, 0, 100, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
             }*/
-            DEBUG displayLoops();
-            DEBUG displayChokeMap();
-            DEBUG displayMachines();
-            DEBUG displayWaypoints();
+            DEBUG {
+                displayLoops();
+                displayChokeMap();
+                displayMachines();
+                displayWaypoints();
+            }
 
 #ifdef LOG_LIGHTS
             logLights();

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -3725,7 +3725,7 @@ boolean moveMonster(creature *monst, short dx, short dy) {
     newY = y + dy;
 
     if (!coordinatesAreInMap(newX, newY)) {
-        //DEBUG printf("\nProblem! Monster trying to move more than one space at a time.");
+        DEBUG printf("\nProblem! Monster trying to move outside the map.");
         return false;
     }
 

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -48,7 +48,6 @@
 
 #define WIZARD_MODE                     (rogue.mode == GAME_MODE_WIZARD)
 
-#define DEBUG                           if (WIZARD_MODE)
 #define MONSTERS_ENABLED                (!WIZARD_MODE || 1) // Quest room monsters can be generated regardless.
 #define ITEMS_ENABLED                   (!WIZARD_MODE || 1)
 
@@ -78,14 +77,16 @@
 // set to false to disable references to keystrokes (e.g. for a tablet port)
 #define KEYBOARD_LABELS true
 
-//#define BROGUE_ASSERTS        // introduces several assert()s -- useful to find certain array overruns and other bugs
 //#define AUDIT_RNG             // VERY slow, but sometimes necessary to debug out-of-sync recording errors
 //#define GENERATE_FONT_FILES   // Displays font in grid upon startup, which can be screen-captured into font files for PC.
 
-#ifdef BROGUE_ASSERTS
+#ifdef DEBUG_ENABLED
+#define DEBUG                   if (true)
 #include <assert.h>
+// introduces several assert()s -- useful to find certain array overruns and other bugs
 #define brogueAssert(x)         assert(x)
 #else
+#define DEBUG                   if (false)
 #define brogueAssert(x)
 #endif
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -448,7 +448,7 @@ void initializeRogue(uint64_t seed) {
         rogue.playbackOmniscience = 1;
     }
 
-    DEBUG {
+    if (WIZARD_MODE) {
         theItem = generateItem(RING, RING_CLAIRVOYANCE);
         theItem->enchant1 = max(DROWS, DCOLS);
         theItem->flags &= ~ITEM_CURSED;


### PR DESCRIPTION
The `DEBUG` macro used to check whether wizard mode was enabled, which was confusing. This PR changes this macro to check whether DEBUG=YES was specified. It also enables a debug check that seems worth enabling.

Every use of the `DEBUG` macro that isn't modified by this PR is commented out.