### PR TITLE
Fix beckoning path when targeting a tile behind a monster

### DIFF
--- a/changes/beckoning2.md
+++ b/changes/beckoning2.md
@@ -1,0 +1,1 @@
+When targeting a wand of beckoning at a tile behind a monster, the monster will now be beckoned along the exact path shown on screen.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -519,7 +519,7 @@ static boolean forceWeaponHit(creature *defender, item *theItem) {
     }
     theBolt = boltCatalog[BOLT_BLINKING];
     theBolt.magnitude = max(1, netEnchant(theItem) / FP_FACTOR);
-    zap(oldLoc, newLoc, &theBolt, false, false);
+    zap(oldLoc, newLoc, &theBolt, false);
     if (!(defender->bookkeepingFlags & MB_IS_DYING)
         && distanceBetween(oldLoc, defender->loc) > 0
         && distanceBetween(oldLoc, defender->loc) < weaponForceDistance(netEnchant(theItem))) {

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4319,16 +4319,15 @@ void checkForMissingKeys(short x, short y) {
     }
 }
 
-static void beckonMonster(creature *monst, short x, short y) {
+static void beckonMonster(creature *monst, pos to, pos beckonTargetLoc) {
     bolt theBolt = boltCatalog[BOLT_BLINKING];
 
     if (monst->bookkeepingFlags & MB_CAPTIVE) {
         freeCaptive(monst);
     }
     pos from = monst->loc;
-    pos to = (pos){ .x = x, .y = y };
-    theBolt.magnitude = max(1, (distanceBetween((pos){x, y}, monst->loc) - 2) / 2);
-    zap(from, to, &theBolt, false, true);
+    theBolt.magnitude = max(1, (distanceBetween(to, from) - 2) / 2);
+    zapBeckoning(from, to, &theBolt, false, beckonTargetLoc);
     if (monst->ticksUntilTurn < player.attackSpeed+1) {
         monst->ticksUntilTurn = player.attackSpeed+1;
     }
@@ -4359,9 +4358,11 @@ enum boltType boltForItem(item *theItem) {
 // *autoID will be set to true. (AutoID can be null.)
 // If the effect causes the level's lighting or vision to change, *lightingChanged
 // will be set to true. (LightingChanged can be null.)
+// `targetLoc` should be the target tile for the bolt (only needed for beckoning).
 static boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                    boolean boltInView, boolean alreadyReflected,
-                   boolean *autoID, boolean *lightingChanged) {
+                   boolean *autoID, boolean *lightingChanged,
+                   pos targetLoc) {
     char buf[COLS], monstName[COLS];
     creature *monst; // Creature being hit by the bolt, if any.
     creature *newMonst; // Utility variable for plenty
@@ -4479,7 +4480,7 @@ static boolean updateBolt(bolt *theBolt, creature *caster, short x, short y,
                     if (canSeeMonster(monst) && autoID) {
                         *autoID = true;
                     }
-                    beckonMonster(monst, caster->loc.x, caster->loc.y);
+                    beckonMonster(monst, caster->loc, targetLoc);
                     if (canSeeMonster(monst) && autoID) {
                         *autoID = true;
                     }
@@ -4811,7 +4812,8 @@ static void detonateBolt(bolt *theBolt, creature *caster, short x, short y, bool
 }
 
 // returns whether the bolt effect should autoID any staff or wand it came from, if it came from a staff or wand
-boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, boolean reverseBoltDir) {
+// `beckonTargetLoc` should only be specified if `reverseBoltDir` is true
+static boolean zapInner(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, boolean reverseBoltDir, pos beckonTargetLoc) {
     pos listOfCoordinates[MAX_BOLT_LENGTH];
     short i, j, k, x, y, x2, y2, numCells, blinkDistance = 0, boltLength, initialBoltLength, lights[DCOLS][DROWS][3];
     creature *monst = NULL, *shootingMonst;
@@ -4847,11 +4849,15 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
         // path, it's possible for the target not to be blinked all the way back to the source
         // because it hits an obstacle (usually a monster). This results in issue #497, as well as
         // unintuitive behavior for the wand of beckoning. As a workaround, for the second bolt, we
-        // compute it as if it went from the source to the target, and then reverse the list of
-        // coordinates. This ensures that the two bolts will include exactly the same coordinates,
-        // so the target won't get stuck on any obstacles while being beckoned.
+        // compute it as if it went from the player to the original target location of the beckoning,
+        // and then reverse the list of coordinates. This ensures that the two bolts will include
+        // exactly the same coordinates, so the target won't get stuck on any obstacles while being
+        // beckoned, and that the targeted monster will follow the displayed path when targeting
+        // a tile behind the monster.
         pos listOfCoordinatesTmp[MAX_BOLT_LENGTH];
-        short numCellsTmp = getLineCoordinates(listOfCoordinatesTmp, targetLoc, originLoc, (hideDetails ? &boltCatalog[BOLT_NONE] : theBolt));
+        // For the purpose of computing these coordinates, we need to use the same bolt type
+        // as is used to compute the original path; otherwise the path won't always be the same.
+        short numCellsTmp = getLineCoordinates(listOfCoordinatesTmp, targetLoc, beckonTargetLoc, (hideDetails ? &boltCatalog[BOLT_NONE] : &boltCatalog[BOLT_BECKONING]));
         numCells = -1;
         for (int i = 0; i < numCellsTmp; i++) {
             if (listOfCoordinatesTmp[i].x == originLoc.x && listOfCoordinatesTmp[i].y == originLoc.y) {
@@ -4860,10 +4866,12 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
             }
         }
         brogueAssert(numCells > -1);
-        for (int i = 0; i < numCells-1; i++) {
-            listOfCoordinates[i] = listOfCoordinatesTmp[numCells-2-i];
+        if (numCells > -1) {
+            for (int i = 0; i < numCells-1; i++) {
+                listOfCoordinates[i] = listOfCoordinatesTmp[numCells-2-i];
+            }
+            listOfCoordinates[numCells-1] = targetLoc;
         }
-        listOfCoordinates[numCells-1] = targetLoc;
     } else {
         numCells = getLineCoordinates(listOfCoordinates, originLoc, targetLoc, (hideDetails ? &boltCatalog[BOLT_NONE] : theBolt));
     }
@@ -4950,7 +4958,7 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
             continue;
         }
 
-        if (updateBolt(theBolt, shootingMonst, x, y, boltInView, alreadyReflected, &autoID, &lightingChanged)) {
+        if (updateBolt(theBolt, shootingMonst, x, y, boltInView, alreadyReflected, &autoID, &lightingChanged, targetLoc)) {
             break;
         }
 
@@ -5172,6 +5180,15 @@ boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, bo
         }
     }
     return autoID;
+}
+
+// Wrapper around `zapInner` that omits parameters only needed for beckoning
+boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails) {
+    return zapInner(originLoc, targetLoc, theBolt, hideDetails, false, INVALID_POS);
+}
+
+boolean zapBeckoning(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, pos beckonTargetLoc) {
+    return zapInner(originLoc, targetLoc, theBolt, hideDetails, true, beckonTargetLoc);
 }
 
 /// @brief Checks if an item is known to be of the given magic polarity
@@ -6605,8 +6622,7 @@ static boolean useStaffOrWand(item *theItem) {
 
             autoID = zap(originLoc, zapTarget,
                          &theBolt,
-                         !boltKnown,   // hide bolt details
-                         false);
+                         !boltKnown);   // hide bolt details
             if (autoID) {
                 if (!tableForItemCategory(theItem->category)[theItem->kind].identified) {
                     sprintf(buf, "(Your %s must be ", buf2);

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -2354,7 +2354,7 @@ boolean monsterBlinkToPreferenceMap(creature *monst, short **preferenceMap, bool
         }
         monst->ticksUntilTurn = monst->attackSpeed * (monst->info.flags & MONST_CAST_SPELLS_SLOWLY ? 2 : 1);
         theBolt = boltCatalog[theBoltType];
-        zap(origin, bestTarget, &theBolt, false, false);
+        zap(origin, bestTarget, &theBolt, false);
         return true;
     }
     return false;
@@ -2766,7 +2766,7 @@ static void monsterCastSpell(creature *caster, creature *target, enum boltType b
     theBolt = boltCatalog[boltIndex];
     pos originLoc = caster->loc;
     pos targetLoc = target->loc;
-    zap(originLoc, targetLoc, &theBolt, false, false);
+    zap(originLoc, targetLoc, &theBolt, false);
 
     if (player.currentHP <= 0) {
         gameOver(monsterCatalog[caster->info.monsterID].monsterName, false);

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -681,7 +681,7 @@ boolean handleWhipAttacks(creature *attacker, enum directions dir, boolean *abor
         attacker->bookkeepingFlags &= ~MB_SUBMERGED;
         theBolt = boltCatalog[BOLT_WHIP];
         theBolt.theChar = boltChar[dir];
-        zap(originLoc, targetLoc, &theBolt, false, false);
+        zap(originLoc, targetLoc, &theBolt, false);
         return true;
     }
     return false;

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3279,7 +3279,8 @@ extern "C" {
     void checkForMissingKeys(short x, short y);
     enum boltEffects boltEffectForItem(item *theItem);
     enum boltType boltForItem(item *theItem);
-    boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, boolean reverseBoltDir);
+    boolean zap(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails);
+    boolean zapBeckoning(pos originLoc, pos targetLoc, bolt *theBolt, boolean hideDetails, pos beckonTargetLoc);
     boolean nextTargetAfter(const item *theItem,
                             pos *returnLoc,
                             pos targetLoc,


### PR DESCRIPTION
Previously, when targeting a beckoning wand at a tile behind a monster, the monster would be beckoned as if the player had targeted the monster's tile. This fixes this so the monster follows the exact path shown on screen.

This also introduces a new function, `zapBeckoning`, to avoid having to pass extra parameters to every call to `zap`.

Fixes #809.

This unfortunately adds some ugly parameters to some bolt-related functions. It should be possible to reuse the already-computed path, but that would be more difficult and I'm not sure whether it would be much simpler.

Unidentified wands of beckoning still don't follow the correct path, but that seems to be unrelated (see #817).