### PR TITLE
Fix paths of thrown items and unidentified wands/staffs

### DIFF
--- a/changes/fix-bolt-paths.md
+++ b/changes/fix-bolt-paths.md
@@ -1,0 +1,1 @@
+Thrown items, and unidentified wands and staffs, now always follow the path shown on screen.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -5616,7 +5616,7 @@ boolean chooseTarget(pos *returnLoc,
     short oldRNG;
     boolean stopAtTarget = (targetMode == AUTOTARGET_MODE_THROW);
     color trajColor;
-    bolt theBolt;
+    bolt theBolt = boltCatalog[BOLT_NONE];
 
     // choose the bolt and color to use for highlighting the path to the target
     if (theItem && (targetMode == AUTOTARGET_MODE_USE_STAFF_OR_WAND)
@@ -5632,7 +5632,6 @@ boolean chooseTarget(pos *returnLoc,
         trajColor = red;
     } else {
         trajColor = white;
-        theBolt = boltCatalog[BOLT_NONE];
     }
 
     normColor(&trajColor, 100, 10);


### PR DESCRIPTION
Previously, these wouldn't always follow the path displayed on screen.

This occurred because `theBolt` (in `chooseTarget`) was sometimes uninitialized.

Fixes #817.

This only affects the displayed paths, not the paths projectiles actually follow, so I think it should be okay to merge this into `release`.