### PR TITLE
Fix potential uninitialized variable in titleMenu()

### DIFF
--- a/src/brogue/MainMenu.c
+++ b/src/brogue/MainMenu.c
@@ -539,6 +539,7 @@ static void titleMenu() {
     rogue.creaturesWillFlashThisTurn = false; // total unconscionable hack
 
     rogueEvent theEvent;
+    theEvent.eventType = EVENT_ERROR;
     short mainIndex = -1;
     short flyoutIndex = -1;
     windowpos bPos;


### PR DESCRIPTION
After a recent issue turned out to have been detectable with Valgrind (#817) and I found some uninitialized variables while working on a PR (#800), I used Valgrind to look for other similar issues. It found a potential one in `titleMenu()`, and although I'm not sure whether is actually causes issues, it seems worth fixing.