### PR TITLE
Run history fix

### DIFF
--- a/changes/RunHistoryFix.md
+++ b/changes/RunHistoryFix.md
@@ -1,0 +1,1 @@
+Fixed an issue where wizard mode instead of normal mode victories were saved in the run history file.

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1373,7 +1373,7 @@ void victory(boolean superVictory) {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
     }
 
-    if (!rogue.playbackMode && rogue.mode != GAME_MODE_EASY && rogue.mode != GAME_MODE_NORMAL) {
+    if (!rogue.playbackMode && rogue.mode != GAME_MODE_EASY && rogue.mode != GAME_MODE_WIZARD) {
         saveRunHistory(victoryVerb, "-", (int) theEntry.score, gemCount);
     }
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1207,7 +1207,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
     }
 
-    if (!rogue.playbackMode && rogue.mode != GAME_MODE_EASY &&  rogue.mode != GAME_MODE_WIZARD) {
+    if (!rogue.playbackMode && rogue.mode == GAME_MODE_NORMAL) {
         saveRunHistory(rogue.quit ? "Quit" : "Died", rogue.quit ? "-" : killedBy, (int) theEntry.score, numGems);
     }
 
@@ -1373,7 +1373,7 @@ void victory(boolean superVictory) {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
     }
 
-    if (!rogue.playbackMode && rogue.mode != GAME_MODE_EASY && rogue.mode != GAME_MODE_WIZARD) {
+    if (!rogue.playbackMode && rogue.mode == GAME_MODE_NORMAL) {
         saveRunHistory(victoryVerb, "-", (int) theEntry.score, gemCount);
     }
 


### PR DESCRIPTION
This should fix issue #833.

Previously, not-playback, not-easy, not-normal mode was saved, i.e. wizard mode.

It should now be not-playback, not-easy, not-wizard mode, i.e. normal mode that gets saved in BrogueRunHistory.txt.