### PR TITLE
fix: remove redundant 7z compression in Windows CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,11 +159,9 @@ jobs:
         mingw32-make SYSTEM=WINDOWS BrogueCE-windows
         cp SDL2\x86_64-w64-mingw32\bin\SDL2.dll BrogueCE-windows
         cp SDL2_image\x86_64-w64-mingw32\bin\SDL2_image.dll BrogueCE-windows
-        7z a BrogueCE-windows-x86_64.zip BrogueCE-windows
 
     - name: "Upload artifact"
       uses: actions/upload-artifact@v4
       with:
         name: windows-x86_64
-        path: BrogueCE-windows-x86_64.zip
-        compression-level: 0  # There's no point compressing something already compressed
+        path: BrogueCE-windows


### PR DESCRIPTION
## Summary

- Removes the `7z a` step from the Windows build workflow that was creating a zip archive before upload
- Changes the upload path from `BrogueCE-windows-x86_64.zip` to the `BrogueCE-windows` directory
- `upload-artifact@v4` already creates a zip archive from the path, so the 7z step was producing a zip-inside-a-zip

Closes #726

## Test plan

- [ ] Windows CI build produces a correctly structured artifact (single zip, not double-zipped)
- [ ] macOS builds are unaffected