### PR TITLE
Print data dir with version info

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -6501,7 +6501,7 @@ static boolean playerCancelsBlinking(const pos originLoc, const pos targetLoc, c
             x = coordinates[i].x;
             y = coordinates[i].y;
             if (pmap[x][y].flags & DISCOVERED) {
-                getLocationFlags(x, y, &tFlags, NULL, NULL, true);
+                getLocationFlags(x, y, &tFlags, &tmFlags, NULL, true);
                 if ((tFlags & T_LAVA_INSTA_DEATH)
                     && !(tFlags & (T_ENTANGLES | T_AUTO_DESCENT))
                     && !(tmFlags & TM_EXTINGUISHES_FIRE)) {

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2868,7 +2868,7 @@ extern "C" {
     void append(char *str, char *ending, int bufsize);
 
     int rogueMain(void);
-    void printBrogueVersion(void);
+    void printBrogueVersion(const char *dataDir);
     void executeEvent(rogueEvent *theEvent);
     boolean fileExists(const char *pathname);
     boolean chooseFile(char *path, char *prompt, char *defaultName, char *suffix);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -36,10 +36,11 @@ int rogueMain() {
     return rogue.gameExitStatusCode;
 }
 
-void printBrogueVersion() {
+void printBrogueVersion(const char *dataDir) {
     printf("Brogue version: %s\n", brogueVersion);
     printf("Supports variant (rapid_brogue): %s\n", rapidBrogueVersion);
     printf("Supports variant (bullet_brogue): %s\n", bulletBrogueVersion);
+    printf("Default data directory: %s\n", dataDir);
 }
 
 void executeEvent(rogueEvent *theEvent) {

--- a/src/platform/main.c
+++ b/src/platform/main.c
@@ -233,7 +233,7 @@ int main(int argc, char *argv[])
         }
 
         if (strcmp(argv[i], "-V") == 0 || strcmp(argv[i], "--version") == 0) {
-            printBrogueVersion();
+            printBrogueVersion(dataDirectory);
             return 0;
         }
 


### PR DESCRIPTION
Currently, it is difficult to determine brogue's data directory, which is baked in during the build.

Print with `-V`.