### PR TITLE
Fix curses title screen hanging for up to ~32s on startup

### DIFF
--- a/changes/curses-title-hang.md
+++ b/changes/curses-title-hang.md
@@ -1,0 +1,1 @@
+Fixed the title screen sometimes hanging for up to 32 seconds on startup in the terminal (curses) build.

--- a/src/platform/curses-platform.c
+++ b/src/platform/curses-platform.c
@@ -118,11 +118,14 @@ static long lastDelayTime = 0;
 // Like SDL_Delay, but reduces the delay if time has passed since the last delay
 static void _delayUpTo(short ms) {
     long curTime = getTime();
-    long timeDiff = curTime - lastDelayTime;
-    ms -= timeDiff;
+    // lastDelayTime == 0 means this is the first call, so treat it as
+    // "no time elapsed". Compute in long: subtracting the elapsed time
+    // into the short `ms` overflows on the first call.
+    long timeDiff = (lastDelayTime == 0) ? 0 : (curTime - lastDelayTime);
+    long remaining = (long)ms - timeDiff;
 
-    if (ms > 0) {
-        Term.wait(ms);
+    if (remaining > 0) {
+        Term.wait((int)remaining);
     } // else delaying further would go past the time we want to delay until
 
     lastDelayTime = getTime();


### PR DESCRIPTION
On the ncurses (`TERMINAL=YES`) build, the title screen can hang — unresponsive, no animation — for up to ~32s on startup before the menu appears. It is intermittent (roughly half of launches show no hang at all), which makes it hard to reproduce.

## Cause

`_delayUpTo()` in `src/platform/curses-platform.c` subtracts the elapsed time directly into its `short` parameter:

```c
long timeDiff = curTime - lastDelayTime;
ms -= timeDiff;            // ms is short
```

`lastDelayTime` is a `static` initialized to `0`, so on the **first** call `timeDiff` is the full `gettimeofday`-based millisecond clock (~1.78e12). Subtracting that into a `short` wraps the result to an arbitrary value in `[-32768, 32767]`, determined by the wall-clock time at launch. When it lands positive, `Term.wait()` performs a single `napms()` of up to **32767 ms** before the title loop ever animates or polls for input. Only the curses build is affected; the SDL build uses a different timer.

## Fix

Compute the remaining delay in `long` (no truncation) and treat the first call (`lastDelayTime == 0`) as "no time elapsed". Frame pacing is otherwise unchanged.

## How it was found

Attaching a debugger to a hung process showed it parked in `clock_nanosleep` ← `napms` ← `_delayUpTo` ← `curses_pauseForMilliseconds` ← `titleMenu`, with the requested sleep equal to the wrapped `short` value.