### PR TITLE
#855 Krakens and eels should not seize or attack while beached

### DIFF
--- a/changes/855-beached-kraken-seize
+++ b/changes/855-beached-kraken-seize
@@ -1,0 +1,1 @@
+A kraken or eel knocked onto dry land now writhes helplessly as intended, instead of continuing to seize and attack.

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -3352,6 +3352,16 @@ void monstersTurn(creature *monst) {
         return;
     }
 
+    // #855: a kraken or eel beached on dry land writhes helplessly -- it cannot seize, attack, or
+    // move. The info box already describes this state; enforce it here. Any seize it was holding is
+    // released in applyInstantTileEffectsToCreature above.
+    if ((monst->info.flags & MONST_RESTRICTED_TO_LIQUID)
+        && !cellHasTMFlag(monst->loc, TM_ALLOWS_SUBMERGING)) {
+
+        monst->ticksUntilTurn = monst->movementSpeed;
+        return;
+    }
+
     monst->ticksUntilTurn = monst->movementSpeed / 3; // will be later overwritten by movement or attack
 
     x = monst->loc.x;

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -147,6 +147,16 @@ void applyInstantTileEffectsToCreature(creature *monst) {
         monst->bookkeepingFlags &= ~MB_SEIZING;
     }
 
+    // #855: a kraken or eel knocked onto dry land can no longer hold its prey. A liquid-restricted
+    // monster off submergible terrain writhes helplessly (enforced in monstersTurn), so it must
+    // also release any seize the instant it is beached; otherwise the seized creature stays pinned.
+    if ((monst->bookkeepingFlags & MB_SEIZING)
+        && (monst->info.flags & MONST_RESTRICTED_TO_LIQUID)
+        && !cellHasTMFlag((pos){ *x, *y }, TM_ALLOWS_SUBMERGING)) {
+
+        monst->bookkeepingFlags &= ~MB_SEIZING;
+    }
+
     // Creatures plunge into chasms and through trap doors.
     if (monsterShouldFall(monst)) {
         if (monst == &player) {


### PR DESCRIPTION
A kraken, eel, or bog monster knocked onto dry land could keep a seize active and keep attacking the player, even though the info box already describes a beached liquid-restricted monster as writhing "helplessly on dry land". Two enforcement gaps:

1. The seize (`MB_SEIZING`) was only released for a kraken obstructed by a wall, not for one beached on non-submergible terrain, so a knocked-ashore monster kept its prey pinned — and pinned prey is auto-hit.
2. `monstersTurn` still let a beached monster hunt/attack, because the eel hunt gate keys off the player's terrain (`player.loc`), not the monster's own tile.

## Fix

Enforce the "writhes helplessly" state that the info box already promises:

- `applyInstantTileEffectsToCreature` now also drops `MB_SEIZING` when a `MONST_RESTRICTED_TO_LIQUID` monster is off submergible terrain (a sibling to the existing obstructed-kraken release), so a seize ends the instant the monster is beached. The seized creature frees itself on its next move.
- `monstersTurn` forfeits the turn for a beached liquid-restricted monster (mirroring the existing paralyzed/entranced guard): no seize, attack, or movement.

Applies to all `MONST_RESTRICTED_TO_LIQUID` monsters — krakens, eels, and bog monsters. The guard only triggers in the rare force/knockback beaching case, so normal in-water behaviour is unchanged.

## Notes

- Not a dungeon-generation change: all three variant seed catalogs (`brogue`, `rapid_brogue`, `bullet_brogue`) are byte-identical.
- Replay-breaking (monster behaviour changes when a liquid-restricted monster is beached), so this targets `master`.
- Related: #102 ("Eels escaped from water somehow") concerns how a liquid-restricted monster ends up on land in the first place — a separate root cause — but with this change such a beached monster is at least correctly helpless rather than attacking.

Fixes #855
Fixes #752
