### PR TITLE
#550 Fix charms of protection above +18 having unpredictable effects

### DIFF
--- a/changes/550-charm-protection-overflow
+++ b/changes/550-charm-protection-overflow
@@ -1,0 +1,1 @@
+Charms and staffs of protection above +18 no longer behave unpredictably (their shield value could previously overflow and turn negative).

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2296,8 +2296,8 @@ typedef struct creature {
     short turnsSpentStationary;         // how many (subjective) turns it's been since the creature moved between tiles
     short flashStrength;                // monster will flash soon; this indicates the percent strength of flash
     color flashColor;                   // the color that the monster will flash
-    short status[NUMBER_OF_STATUS_EFFECTS];
-    short maxStatus[NUMBER_OF_STATUS_EFFECTS]; // used to set the max point on the status bars
+    int status[NUMBER_OF_STATUS_EFFECTS];
+    int maxStatus[NUMBER_OF_STATUS_EFFECTS]; // used to set the max point on the status bars
     unsigned long bookkeepingFlags;
     short spawnDepth;                   // keep track of the depth of the machine to which they relate (for activation monsters)
     short machineHome;                  // monsters that spawn in a machine keep track of the machine number here (for activation monsters)


### PR DESCRIPTION
The power tables allow protection charms and staffs up to +50, but the creature `status[]` / `maxStatus[]` arrays were `short` (max 32767), while `charmProtection()` and `staffProtection()` both return `int`. A +18 charm correctly set `status[STATUS_SHIELDED]` to 24647, but a +19 charm computed 33273, overflowing the `short` and wrapping to a negative value — so high-level protection charms behaved unpredictably. The same overflow affected monsters shielded by a staff of protection.

## Fix

Widen `creature.status[]` and `creature.maxStatus[]` from `short` to `int`, matching the `int` return types of the power-table functions. This fixes both the player (charm) and monster (staff) shield paths at once, with no per-call caps.

- `printProgressBar()` already takes `long`, so the status-bar display is unaffected.
- Saves and recordings are input replays (no struct dump), so the widening does not change the save format.
- No `sizeof`/`memcpy`/format-string on the status arrays relies on the width.

## Notes

- A `short` shield of 32767 already absorbs ~3276 HP (the value stores HP×10), far beyond any reachable damage; widening to `int` raises the ceiling to hundreds of millions. `charmProtection` is clamped by its 51-entry power table, but `staffProtection` uses live `fp_pow` with no table clamp — so this raises the ceiling far beyond any reachable game state rather than being a mathematically hard bound. A pragmatic fix, not a true clamp.
- Not a dungeon-generation change: all three variant seed catalogs are byte-identical.
- Replay-breaking (a +19 charm now produces a large positive shield instead of a negative one), so this targets `master`; the version bump is left to the release process.

Fixes #550
Fixes #815
