### PR TITLE
#816 Explosion immunity should last a full five turns

### DIFF
--- a/changes/816-explosion-immunity-duration
+++ b/changes/816-explosion-immunity-duration
@@ -1,0 +1,1 @@
+Fixed explosive terrain being able to hit you again a turn too early: after an explosion you are now reliably immune for the full five turns.

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2447,6 +2447,7 @@ typedef struct playerCharacter {
     boolean automationActive;           // cut some corners during redraws to speed things up
     boolean justRested;                 // previous turn was a rest -- used in stealth
     boolean justSearched;               // previous turn was a search -- used in manual searches
+    boolean explosionImmunityFresh;     // #816: true only for the turn an explosion granted STATUS_EXPLOSION_IMMUNITY, so playerTurnEnded's per-turn decrement skips itself once and a grant applied before it (a bloat detonating in melee) keeps the full five turns
     boolean cautiousMode;               // used to prevent careless deaths caused by holding down a key
     boolean receivedLevitationWarning;  // only warn you once when you're hovering dangerously over liquid
     boolean updatedSafetyMapThisTurn;   // so it's updated no more than once per turn

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -302,7 +302,12 @@ void applyInstantTileEffectsToCreature(creature *monst) {
         && !(monst->bookkeepingFlags & MB_SUBMERGED)) {
         damage = rand_range(15, 20);
         damage = max(damage, monst->info.maxHP / 2);
-        monst->status[STATUS_EXPLOSION_IMMUNITY] = 5;
+        // #816: grant 6, not 5. The status is decremented once per turn and explosive damage only
+        // fires while it is 0, so a value of N yields N-1 immune turns; 5 protected only 4,
+        // contradicting the intended "not again for five turns". 6 gives the five clear turns.
+        // (Paired with the decrement relocation in playerTurnEnded, so the per-turn decrement runs
+        // ahead of both explosion checks rather than between them, where it would steal a turn back.)
+        monst->status[STATUS_EXPLOSION_IMMUNITY] = 6;
         if (monst == &player) {
             rogue.disturbed = true;
             for (layer = 0; layer < NUMBER_TERRAIN_LAYERS && !(tileCatalog[pmap[*x][*y].layers[layer]].flags & T_CAUSES_EXPLOSIVE_DAMAGE); layer++);
@@ -2045,9 +2050,9 @@ static void decrementPlayerStatus() {
         player.status[STATUS_STUCK] = 0;
     }
 
-    if (player.status[STATUS_EXPLOSION_IMMUNITY]) {
-        player.status[STATUS_EXPLOSION_IMMUNITY]--;
-    }
+    // #816: STATUS_EXPLOSION_IMMUNITY is decremented in playerTurnEnded before updateEnvironment(),
+    // not here (which runs after it), so the single per-turn decrement precedes both explosion
+    // checks instead of landing between them and zeroing a fresh grant one turn early.
 
     if (player.status[STATUS_DISCORDANT]) {
         player.status[STATUS_DISCORDANT]--;
@@ -2416,6 +2421,14 @@ void playerTurnEnded() {
                     }
                 }
 
+                // #816: decrement explosion immunity before updateEnvironment(), which is where a
+                // spreading explosion can hit the player (spawnDungeonFeature -> applyInstantTileEffects).
+                // Running the single per-turn decrement ahead of both explosion checks (here and the
+                // applyInstantTileEffectsToCreature below) keeps it from zeroing a fresh grant one turn
+                // early, and matches monsters (decrementMonsterStatus runs before updateEnvironment).
+                if (player.status[STATUS_EXPLOSION_IMMUNITY]) {
+                    player.status[STATUS_EXPLOSION_IMMUNITY]--;
+                }
                 updateEnvironment(); // Update fire and gas, items floating around in water, monsters falling into chasms, etc.
                 decrementPlayerStatus();
                 applyInstantTileEffectsToCreature(&player);

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -309,6 +309,13 @@ void applyInstantTileEffectsToCreature(creature *monst) {
         // ahead of both explosion checks rather than between them, where it would steal a turn back.)
         monst->status[STATUS_EXPLOSION_IMMUNITY] = 6;
         if (monst == &player) {
+            // #816: mark that immunity was granted this turn so the per-turn decrement in playerTurnEnded
+            // skips itself once. Without this, a grant applied earlier in the same turn than that decrement
+            // -- an explosive bloat detonating on you in melee, applied during your own action before
+            // playerTurnEnded runs -- is zeroed one turn early, giving only four clear turns instead of
+            // five. (Monsters need no such flag: they grant and decrement in one env tick, grant-then-
+            // decrement, so a value of 6 already yields five clear turns.) Cleared once per turn below.
+            rogue.explosionImmunityFresh = true;
             rogue.disturbed = true;
             for (layer = 0; layer < NUMBER_TERRAIN_LAYERS && !(tileCatalog[pmap[*x][*y].layers[layer]].flags & T_CAUSES_EXPLOSIVE_DAMAGE); layer++);
             message(tileCatalog[pmap[*x][*y].layers[layer]].flavorText, 0);
@@ -2426,7 +2433,11 @@ void playerTurnEnded() {
                 // Running the single per-turn decrement ahead of both explosion checks (here and the
                 // applyInstantTileEffectsToCreature below) keeps it from zeroing a fresh grant one turn
                 // early, and matches monsters (decrementMonsterStatus runs before updateEnvironment).
-                if (player.status[STATUS_EXPLOSION_IMMUNITY]) {
+                // The explosionImmunityFresh guard additionally skips this decrement on the turn immunity
+                // was granted, so a grant applied before this point in the turn -- a bloat detonating in
+                // melee, applied during the player's own action -- also keeps the full five turns. The flag
+                // is cleared once per turn below, after the turn-advance loop.
+                if (player.status[STATUS_EXPLOSION_IMMUNITY] && !rogue.explosionImmunityFresh) {
                     player.status[STATUS_EXPLOSION_IMMUNITY]--;
                 }
                 updateEnvironment(); // Update fire and gas, items floating around in water, monsters falling into chasms, etc.
@@ -2483,6 +2494,13 @@ void playerTurnEnded() {
                 return;
             }
         }
+
+        // #816: the grant turn is over; clear the marker so the next turn's decrement counts again.
+        // Cleared here (once per turn, after the turn-advance loop) rather than at the decrement: a grant
+        // that lands after the decrement (gas igniting in updateEnvironment) must not be re-protected next
+        // turn, while a grant before it (a bloat in melee) must be protected exactly once.
+        rogue.explosionImmunityFresh = false;
+
         // DEBUG displayLevel();
         //checkForDungeonErrors();
 


### PR DESCRIPTION
`STATUS_EXPLOSION_IMMUNITY` is granted on an explosive hit and decremented once per turn; explosive damage only fires while it is 0, so a grant of N yields N−1 immune turns. Two problems combined to cut the intended five turns short:

1. The grant was `5`, giving only four immune turns.
2. The player's per-turn decrement ran in `decrementPlayerStatus()`, which is called *after* `updateEnvironment()` — but a spreading explosion can hit the player inside `updateEnvironment` (`spawnDungeonFeature` → `applyInstantTileEffectsToCreature`). With the decrement landing between that check and the end-of-turn `applyInstantTileEffectsToCreature(&player)` check, the second check saw 0 one turn early and re-detonated, stealing a turn back.

## Fix

- Grant `6` instead of `5`.
- Move the player's explosion-immunity decrement to *before* `updateEnvironment()`, so the single per-turn decrement precedes both explosion checks. This restores the full five clear turns and matches monsters, which already decrement (`decrementMonsterStatus`) before `updateEnvironment`. The grant change applies to monsters too, keeping them consistent.

## Notes

- Not a dungeon-generation change: all three variant seed catalogs are byte-identical.
- Replay-breaking (explosion timing), so this targets `master`.

Fixes #816
