### PR TITLE
#831 Submerged creatures only reveal each other within the same water body

### DIFF
--- a/changes/831-submerged-visibility-same-pool
+++ b/changes/831-submerged-visibility-same-pool
@@ -1,0 +1,1 @@
+While submerged, you now only see (and, with telepathy, identify) other submerged creatures sharing your own connected body of water, rather than every submerged creature on the level.

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -176,15 +176,62 @@ boolean monsterRevealed(creature *monst) {
     return false;
 }
 
+// #831: true if `to` is reachable from `from` through a contiguous, 8-connected region of deep
+// water. A submerged observer should only make out submerged monsters sharing its own body of
+// water; without this, an observer submerged in any pool revealed every submerged monster on the
+// level (and, with telepathy, learned each one's identity), even across disconnected pools.
+// Iterative flood fill (explicit queue, not recursion) so an arbitrarily large water body can't
+// blow the stack. Only ever called when the observer is already standing in deep water, so the
+// common (non-swimming) case never reaches it.
+static boolean inSameDeepWaterBody(pos from, pos to) {
+    if (!cellHasTerrainFlag(from, T_IS_DEEP_WATER) || !cellHasTerrainFlag(to, T_IS_DEEP_WATER)) {
+        return false;
+    }
+    if (from.x == to.x && from.y == to.y) {
+        return true;
+    }
+
+    char visited[DCOLS][DROWS];
+    pos queue[DCOLS * DROWS];
+    short head = 0, tail = 0;
+
+    memset(visited, 0, sizeof(visited));
+    queue[tail++] = from;
+    visited[from.x][from.y] = true;
+
+    while (head < tail) {
+        const pos cur = queue[head++];
+        for (short dir = 0; dir < DIRECTION_COUNT; dir++) {
+            const short nx = cur.x + nbDirs[dir][0];
+            const short ny = cur.y + nbDirs[dir][1];
+            if (!coordinatesAreInMap(nx, ny)
+                || visited[nx][ny]
+                || !cellHasTerrainFlag((pos){ nx, ny }, T_IS_DEEP_WATER)) {
+
+                continue;
+            }
+            if (nx == to.x && ny == to.y) {
+                return true;
+            }
+            visited[nx][ny] = true;
+            queue[tail++] = (pos){ nx, ny };
+        }
+    }
+    return false;
+}
+
 boolean monsterHiddenBySubmersion(const creature *monst, const creature *observer) {
     if (monst->bookkeepingFlags & MB_SUBMERGED) {
         if (observer
             && (terrainFlags(observer->loc) & T_IS_DEEP_WATER)
-            && !observer->status[STATUS_LEVITATING]) {
-            // observer is in deep water, so target is not hidden by water
+            && !observer->status[STATUS_LEVITATING]
+            // #831: and only if the observer shares the same connected body of deep water as the
+            // submerged target (see inSameDeepWaterBody).
+            && inSameDeepWaterBody(observer->loc, monst->loc)) {
+            // observer is in the same body of deep water, so target is not hidden by water
             return false;
         } else {
-            // submerged and the observer is not in deep water.
+            // submerged, and the observer is not in the same body of deep water.
             return true;
         }
     }


### PR DESCRIPTION
`monsterHiddenBySubmersion` revealed a submerged creature to any observer standing in deep water, regardless of whether the two shared the same pool. So an observer submerged in one body of water could see every submerged creature on the level — and, with telepathy, learn each one's identity — even across entirely disconnected pools of water, lava, or bog.

## Fix

Add `inSameDeepWaterBody(from, to)`: an iterative 8-connected flood fill (explicit queue, no recursion) that returns true only when the two cells belong to the same contiguous region of deep water. `monsterHiddenBySubmersion` now requires it before treating a submerged target as visible to a deep-water observer. A creature submerged in a separate water pool — or in any lava/bog body — is therefore no longer visible.

## Notes

- The flood fill is gated behind the pre-existing conditions — target submerged **and** observer standing in deep water and not levitating — so it is only reached in the rare swimming-observer case, never on the common visibility path. It early-outs when either endpoint isn't deep water or when `from == to`.
- No RNG is consumed: all three variant seed catalogs are byte-identical.
- Replay-breaking (what a submerged observer can see/target), so this targets `master`.

Fixes #831
