### PR TITLE
#832 Don't generate foliage on top of traps

### DIFF
--- a/changes/832-foliage-not-on-traps
+++ b/changes/832-foliage-not-on-traps
@@ -1,0 +1,1 @@
+Foliage no longer grows on top of a trap, where it would hide the trap from view and block thrown items from reaching the trigger.

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3228,6 +3228,11 @@ boolean fillSpawnMap(enum dungeonLayers layer,
                 && (superpriority || tileCatalog[pmap[i][j].layers[layer]].drawPriority >= tileCatalog[surfaceTileType].drawPriority)
                     // and we won't be painting into the surface layer when that cell forbids it,
                 && !(layer == SURFACE && cellHasTerrainFlag((pos){ i, j }, T_OBSTRUCTS_SURFACE_EFFECTS))
+                    // #832: and we won't bury a trap under vision-blocking terrain -- foliage on a trap
+                    // hides it from view and stops thrown items from settling on the trigger. Applies to
+                    // every foliage source (autogenerators, the jackal den, regrowth).
+                && !((tileCatalog[surfaceTileType].flags & T_OBSTRUCTS_VISION)
+                     && cellHasTerrainFlag((pos){ i, j }, T_IS_DF_TRAP))
                     // and, if requested, the fill won't violate the priority of the most important terrain in this cell:
                 && (!blockedByOtherLayers || tileCatalog[pmap[i][j].layers[highestPriorityLayer(i, j, true)]].drawPriority >= tileCatalog[surfaceTileType].drawPriority)
                 ) {


### PR DESCRIPTION
Foliage (and other vision-blocking surface terrain) could be painted onto a cell containing a trap, hiding the trap from view and preventing the player from throwing an item onto the trigger to spring it safely.

## Fix

In `fillSpawnMap`, skip painting a vision-obstructing surface tile onto a cell flagged `T_IS_DF_TRAP`. This covers every foliage source that routes through the spawn map (autogenerators, the jackal den's grass, regrowth).

## Notes

- The guard is a pure terrain check with no RNG cost, so dungeon generation is otherwise unchanged: all three variant seed catalogs are byte-identical (verified against the committed catalogs).
- The only vision-obstructing surface tiles are foliage/fungus and doors, so no dynamic effect (fire, gas, steam) is affected — none of those obstruct vision.

Fixes #832
