### PR TITLE
#837 Recompute stealth range before monsters take their turns

### DIFF
--- a/changes/837-stealth-range-before-monster-turns
+++ b/changes/837-stealth-range-before-monster-turns
@@ -1,0 +1,1 @@
+Fixed monsters occasionally starting to hunt you from just outside your stealth range when you step into darkness, because they judged awareness against your previous, brighter position's range.

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -2344,11 +2344,20 @@ void playerTurnEnded() {
         }
 
         updateScent();
-//      updateVision(true);
-//        rogue.stealthRange = currentStealthRange();
-//        if (rogue.displayStealthRangeMode) {
-//            displayLevel();
-//        }
+        // #837: recompute lighting and the player's stealth range *before* monsters evaluate
+        // awareness this turn. The player has already moved, so without this the monster wake check
+        // (which reads rogue.stealthRange) runs against last turn's stealth range -- computed for the
+        // previous tile's lighting -- while the monster's awareness distance already reflects the new
+        // position. That let a monster start hunting from within the stale (brighter) range even
+        // though the freshly-drawn stealth circle excluded it (e.g. stepping from lit into dark).
+        // updateVision(true) (not a bare updateLighting) keeps the light-diff bookkeeping correct for
+        // the end-of-turn pass below; FOV is recomputed redundantly here, but the player does not move
+        // during the monster loop.
+        updateVision(true);
+        rogue.stealthRange = currentStealthRange();
+        if (rogue.displayStealthRangeMode) {
+            displayLevel();
+        }
         rogue.updatedSafetyMapThisTurn          = false;
         rogue.updatedAllySafetyMapThisTurn      = false;
         rogue.updatedMapToSafeTerrainThisTurn   = false;


### PR DESCRIPTION
In `playerTurnEnded`, after the player moves, monsters take their turns and evaluate awareness against `rogue.stealthRange` — but that range was only recomputed *after* the monster loop. So when the player stepped into darkness (shrinking the stealth range), monsters acted on the previous tile's larger, brighter range: a monster just outside the freshly-drawn stealth circle could still begin hunting, contradicting the displayed range (e.g. the pit bloat in the report).

## Fix

Recompute vision and the stealth range before the monster loop — activating the block that was already present in the source but commented out. `updateVision(true)` (not a bare `updateLighting`) keeps the light-diff bookkeeping correct for the existing end-of-turn vision pass.

## Notes

- No RNG is consumed, so dungeon generation is unchanged: all three variant seed catalogs are byte-identical.
- Replay-breaking (monster awareness timing), so this targets `master`.

Fixes #837
