### PR TITLE
#841 Confused monsters should not stumble onto sacred ground

### DIFF
--- a/changes/841-confused-monster-sacred-ward
+++ b/changes/841-confused-monster-sacred-ward
@@ -1,0 +1,1 @@
+A confused monster can no longer stumble onto a scroll of sanctuary's sacred glyph that it could never willingly step across.

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -469,6 +469,15 @@ short randValidDirectionFrom(creature *monst, short x, short y, boolean respectA
         if (coordinatesAreInMap(newX, newY)
             && !cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_PASSABILITY)
             && !diagonalBlocked(x, y, newX, newY, false)
+            // #841: sacred ground (scroll of sanctuary glyphs) is a hard ward, not just an avoidance
+            // preference. A confused monster stumbles with respectAvoidancePreferences == false, which
+            // would otherwise let it wander onto a glyph it could never willingly cross. Apply the
+            // avoidance/attack check to sacred tiles regardless, but still permit stepping onto the
+            // glyph to attack a player standing on it. (The player is sacred-immune, so monsterAvoids
+            // returns false for them here and the confused player is never restricted.)
+            && (!cellHasTerrainFlag((pos){ newX, newY }, T_SACRED)
+                || (!monsterAvoids(monst, (pos){newX, newY}))
+                || ((pmap[newX][newY].flags & HAS_PLAYER) && monst->creatureState != MONSTER_ALLY))
             && (!respectAvoidancePreferences
                 || (!monsterAvoids(monst, (pos){newX, newY}))
                 || ((pmap[newX][newY].flags & HAS_PLAYER) && monst->creatureState != MONSTER_ALLY))) {

--- a/src/brogue/Movement.c
+++ b/src/brogue/Movement.c
@@ -466,20 +466,18 @@ short randValidDirectionFrom(creature *monst, short x, short y, boolean respectA
     for (i=0; i<8; i++) {
         newX = x + nbDirs[i][0];
         newY = y + nbDirs[i][1];
+        const pos newPos = (pos){ newX, newY };
         if (coordinatesAreInMap(newX, newY)
-            && !cellHasTerrainFlag((pos){ newX, newY }, T_OBSTRUCTS_PASSABILITY)
+            && !cellHasTerrainFlag(newPos, T_OBSTRUCTS_PASSABILITY)
             && !diagonalBlocked(x, y, newX, newY, false)
             // #841: sacred ground (scroll of sanctuary glyphs) is a hard ward, not just an avoidance
             // preference. A confused monster stumbles with respectAvoidancePreferences == false, which
-            // would otherwise let it wander onto a glyph it could never willingly cross. Apply the
-            // avoidance/attack check to sacred tiles regardless, but still permit stepping onto the
-            // glyph to attack a player standing on it. (The player is sacred-immune, so monsterAvoids
-            // returns false for them here and the confused player is never restricted.)
-            && (!cellHasTerrainFlag((pos){ newX, newY }, T_SACRED)
-                || (!monsterAvoids(monst, (pos){newX, newY}))
-                || ((pmap[newX][newY].flags & HAS_PLAYER) && monst->creatureState != MONSTER_ALLY))
-            && (!respectAvoidancePreferences
-                || (!monsterAvoids(monst, (pos){newX, newY}))
+            // would otherwise let it wander onto a glyph it could never willingly cross; so sacred tiles
+            // get the avoidance/attack check regardless. A monster may still step onto the glyph to
+            // attack a player standing on it, and the player is sacred-immune so monsterAvoids never
+            // restricts the confused player.
+            && ((!cellHasTerrainFlag(newPos, T_SACRED) && !respectAvoidancePreferences)
+                || !monsterAvoids(monst, newPos)
                 || ((pmap[newX][newY].flags & HAS_PLAYER) && monst->creatureState != MONSTER_ALLY))) {
             validDirections[count++] = i;
         }


### PR DESCRIPTION
`randValidDirectionFrom` picks a confused monster's stumble direction with `respectAvoidancePreferences == false`, which skips the `monsterAvoids` check entirely. That treats sacred ground (scroll of sanctuary glyphs) as a mere avoidance preference, letting a confused monster wander onto a glyph it could never willingly cross.

## Fix

Add a clause that applies the avoidance/attack check to `T_SACRED` tiles regardless of `respectAvoidancePreferences`, so sacred ground stays a hard ward for confused monsters — while still permitting a monster to step onto the glyph to attack a player standing on it.

- The confused player is unaffected: `monsterAvoids` grants the player `T_SACRED` immunity, so the clause passes for them.
- `respectAvoidancePreferences == true` callers are unchanged, since they already route sacred through `monsterAvoids` in the existing clause.

## Notes

- Not a dungeon-generation change: all three variant seed catalogs are byte-identical.
- Replay-breaking only when a confused monster is adjacent to sacred ground, so this targets `master`.

Fixes #841
