### PR TITLE
Prevent remembered tiles from being described as "chilly void"

### DIFF
--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -3395,6 +3395,7 @@ void aggravateMonsters(short distance, short x, short y, const color *flashColor
     if (grid[player.loc.x][player.loc.y] >= 0 && grid[player.loc.x][player.loc.y] <= distance) {
         discover(x, y);
         discoverCell(x, y);
+        storeMemories(x, y);
         colorFlash(flashColor, 0, (DISCOVERED | MAGIC_MAPPED), 10, distance, x, y);
         if (!playerCanSee(x, y)) {
             message("You hear a piercing shriek; something must have triggered a nearby alarm.", 0);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -879,6 +879,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
             for (j = rogue.upLoc.y-1; j <= rogue.upLoc.y + 1; j++) {
                 if (coordinatesAreInMap(i, j)) {
                     discoverCell(i, j);
+                    storeMemories(i, j);
                 }
             }
         }


### PR DESCRIPTION
The main bug reported in issue #200 was previously solved. However, two similar bugs are still in the code:
1. If the player sees the downstairs, then falls to the next level, the upstairs are revealed. The stair tile and its neighbors are described as "chilly void" in this case.
2. If an alarm trap on an undiscovered tile is triggered by an out of sight monster, that tile is revealed but still described as "chilly void"

In both cases the solution is to `storeMemories` after calling `discoverCell` on the tile.