### PR TITLE
Store cell memory on discovery, so cells discovered unseen aren't a "chilly void"

### DIFF
--- a/changes/770-fix-wizard-mode-mutation
+++ b/changes/770-fix-wizard-mode-mutation
@@ -1,0 +1,1 @@
+Fixed a bug that applied the wrong mutation to some creatures created in wizard mode.

--- a/changes/783-fix-push-player-machine-room
+++ b/changes/783-fix-push-player-machine-room
@@ -1,0 +1,1 @@
+You can no longer be pushed into a machine room by monsters entering from the stairs.

--- a/changes/785-fix-conjure-crash
+++ b/changes/785-fix-conjure-crash
@@ -1,0 +1,1 @@
+Fixed a bug where filling the level with conjured blades would crash the game.

--- a/changes/787-fix-enchant-rune-identify
+++ b/changes/787-fix-enchant-rune-identify
@@ -1,1 +1,1 @@
-Fixed a bug in which enchanting runic armor or weapons sometimes identified them.
+Fixed a bug in which enchanting items sometimes identified them.

--- a/changes/787-fix-enchant-rune-identify
+++ b/changes/787-fix-enchant-rune-identify
@@ -1,0 +1,1 @@
+Fixed a bug in which enchanting runic armor or weapons sometimes identified them.

--- a/changes/792-easy-mode-logic-fixes
+++ b/changes/792-easy-mode-logic-fixes
@@ -1,1 +1,0 @@
-Fixed a bug that caused Brogue to switch to easy mode without confirmation.

--- a/changes/792-easy-mode-logic-fixes
+++ b/changes/792-easy-mode-logic-fixes
@@ -1,0 +1,1 @@
+Fixed a bug that caused Brogue to switch to easy mode without confirmation.

--- a/changes/793-wizard-mode-menu-selection-fix
+++ b/changes/793-wizard-mode-menu-selection-fix
@@ -1,0 +1,1 @@
+Fixed a bug that caused unexpected behavor when cancelling menu selections in wizard mode.

--- a/changes/803-ally-avoid-invulnerable
+++ b/changes/803-ally-avoid-invulnerable
@@ -1,0 +1,1 @@
+Adjusted ally behavor to better avoid invulnerable monsters.

--- a/changes/871-store-memories-on-discovery
+++ b/changes/871-store-memories-on-discovery
@@ -1,0 +1,1 @@
+Fixed a bug where tiles discovered without ever being seen, such as the stairs on arrival or a wall bumped into in the dark, were described as "a chilly void".

--- a/changes/Lumenstone-score-fix.md
+++ b/changes/Lumenstone-score-fix.md
@@ -1,0 +1,1 @@
+Fixed an issue in score calculation for losing where lumenstones were miscounted. Lumenstone stacks were counted instead of individual lumenstones.

--- a/changes/RunHistoryFix.md
+++ b/changes/RunHistoryFix.md
@@ -1,0 +1,1 @@
+Fixed an issue where wizard mode instead of normal mode victories were saved in the run history file.

--- a/changes/force-eat-food-bug
+++ b/changes/force-eat-food-bug
@@ -1,0 +1,1 @@
+The player no longer gets a free turn after automatically eating food when starving.

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -4743,6 +4743,13 @@ static void detonateBolt(bolt *theBolt, creature *caster, short x, short y, bool
                 monst->loc = getQualifyingPathLocNear((pos){ x, y }, true,
                                          T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, HAS_PLAYER,
                                          avoidedFlagsForMonster(&(monst->info)) & ~T_SPONTANEOUSLY_IGNITES, (HAS_PLAYER | HAS_MONSTER | HAS_STAIRS), false);
+
+                // Invalid location (level is full)
+                if (posEq(monst->loc, INVALID_POS)) {
+                    killCreature(monst, true); // Administrative death
+                    break; // Don't conjure any more
+                }
+
                 monst->bookkeepingFlags |= (MB_FOLLOWER | MB_BOUND_TO_LEADER | MB_DOES_NOT_TRACK_LEADER);
                 monst->bookkeepingFlags &= ~MB_JUST_SUMMONED;
                 monst->leader = &player;

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -6960,6 +6960,7 @@ boolean readScroll(item *theItem) {
     creature *monst;
     boolean hadEffect = false;
     char buf[COLS * 3], buf2[COLS * 3];
+    item *theScroll = theItem;
 
     itemTable scrollKind = tableForItemCategory(theItem->category)[theItem->kind];
 
@@ -7212,12 +7213,7 @@ boolean readScroll(item *theItem) {
     }
 
     // all scrolls auto-identify on use
-    if (!scrollKind.identified
-        && (theItem->kind != SCROLL_ENCHANTING)
-        && (theItem->kind != SCROLL_IDENTIFY)) {
-
-        autoIdentify(theItem);
-    }
+    autoIdentify(theScroll);
 
     return true;
 }

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -6501,7 +6501,7 @@ static boolean playerCancelsBlinking(const pos originLoc, const pos targetLoc, c
             x = coordinates[i].x;
             y = coordinates[i].y;
             if (pmap[x][y].flags & DISCOVERED) {
-                getLocationFlags(x, y, &tFlags, NULL, NULL, true);
+                getLocationFlags(x, y, &tFlags, &tmFlags, NULL, true);
                 if ((tFlags & T_LAVA_INSTA_DEATH)
                     && !(tFlags & (T_ENTANGLES | T_AUTO_DESCENT))
                     && !(tmFlags & TM_EXTINGUISHES_FIRE)) {

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -2945,22 +2945,22 @@ void unAlly(creature *monst) {
 }
 
 boolean monsterFleesFrom(creature *monst, creature *defender) {
-    const short x = monst->loc.x;
-    const short y = monst->loc.y;
+    const short dist = distanceBetween(monst->loc, defender->loc);
 
     if (!monsterWillAttackTarget(defender, monst)) {
         return false;
     }
 
-    if (distanceBetween((pos){x, y}, defender->loc) >= 4) {
-        return false;
-    }
-
-    if ((defender->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))
+    if (dist <= 6 // Stay farther away from invulnerable monsters
+        && (defender->info.flags & (MONST_IMMUNE_TO_WEAPONS | MONST_INVULNERABLE))
         && !(defender->info.flags & MONST_IMMOBILE)) {
         // Don't charge if the monster is damage-immune and is NOT immobile;
         // i.e., keep distance from revenants and stone guardians but not mirror totems.
         return true;
+    }
+
+    if (dist >= 4) {
+        return false;
     }
 
     if (monst->creatureState == MONSTER_ALLY && !monst->status[STATUS_DISCORDANT]
@@ -3185,6 +3185,7 @@ static void moveAlly(creature *monst) {
                     && distanceBetween((pos){x, y}, target->loc) < shortestDistance
                     && traversiblePathBetween(monst, target->loc.x, target->loc.y)
                     && (!monsterAvoids(monst, target->loc) || (target->info.flags & MONST_ATTACKABLE_THRU_WALLS))
+                    && (!attackWouldBeFutile(monst, target)) // Check each target
                     && (!target->status[STATUS_INVISIBLE] || ((monst->info.flags & MONST_ALWAYS_USE_ABILITY) || rand_percent(33)))) {
 
                     enemyMap[target->loc.x][target->loc.y] = 0;

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1145,7 +1145,12 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     }
 
     // Count gems as 500 gold each
-    short numGems = numberOfMatchingPackItems(GEM, 0, 0, false);
+    short numGems = 0;
+    for (theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+        if (theItem->category & GEM) {
+            numGems += theItem->quantity;
+        }
+}
     rogue.gold += 500 * numGems;
     theEntry.score = rogue.gold;
 

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -1212,7 +1212,7 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
     }
 
-    if (!rogue.playbackMode && rogue.mode != GAME_MODE_EASY &&  rogue.mode != GAME_MODE_WIZARD) {
+    if (!rogue.playbackMode && rogue.mode == GAME_MODE_NORMAL) {
         saveRunHistory(rogue.quit ? "Quit" : "Died", rogue.quit ? "-" : killedBy, (int) theEntry.score, numGems);
     }
 
@@ -1378,7 +1378,7 @@ void victory(boolean superVictory) {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
     }
 
-    if (!rogue.playbackMode && rogue.mode != GAME_MODE_EASY && rogue.mode != GAME_MODE_NORMAL) {
+    if (!rogue.playbackMode && rogue.mode == GAME_MODE_NORMAL) {
         saveRunHistory(victoryVerb, "-", (int) theEntry.score, gemCount);
     }
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1901,7 +1901,7 @@ static void monsterEntersLevel(creature *monst, short n) {
         brogueAssert(prevMonst);
         prevMonst->loc = getQualifyingPathLocNear(monst->loc, true,
                                  T_DIVIDES_LEVEL & avoidedFlagsForMonster(&(prevMonst->info)), 0,
-                                 avoidedFlagsForMonster(&(prevMonst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS), false);
+                                 avoidedFlagsForMonster(&(prevMonst->info)), (HAS_MONSTER | HAS_PLAYER | HAS_STAIRS | IS_IN_MACHINE), false);
         pmapAt(monst->loc)->flags &= ~(HAS_PLAYER | HAS_MONSTER);
         pmapAt(prevMonst->loc)->flags |= (prevMonst == &player ? HAS_PLAYER : HAS_MONSTER);
         refreshDungeonCell(prevMonst->loc);

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -801,8 +801,8 @@ void updateVision(boolean refreshDisplay) {
     }
 }
 
-static void checkNutrition() {
-    item *theItem;
+// This should be called only after decrementing the player's nutrition.
+static void printNutritionMessages(void) {
     char buf[DCOLS*3], foodWarning[DCOLS*3];
 
     if (numberOfMatchingPackItems(FOOD, 0, 0, false) == 0) {
@@ -812,34 +812,34 @@ static void checkNutrition() {
     }
 
     if (player.status[STATUS_NUTRITION] == HUNGER_THRESHOLD) {
-        player.status[STATUS_NUTRITION]--;
         sprintf(buf, "you are hungry%s.", foodWarning);
         message(buf, foodWarning[0] ? REQUIRE_ACKNOWLEDGMENT : 0);
     } else if (player.status[STATUS_NUTRITION] == WEAK_THRESHOLD) {
-        player.status[STATUS_NUTRITION]--;
         sprintf(buf, "you feel weak with hunger%s.", foodWarning);
         message(buf, REQUIRE_ACKNOWLEDGMENT);
     } else if (player.status[STATUS_NUTRITION] == FAINT_THRESHOLD) {
-        player.status[STATUS_NUTRITION]--;
         sprintf(buf, "you feel faint with hunger%s.", foodWarning);
         message(buf, REQUIRE_ACKNOWLEDGMENT);
-    } else if (player.status[STATUS_NUTRITION] <= 1) {
-        // Force the player to eat something if he has it
-        for (theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
-            if (theItem->category == FOOD) {
-                sprintf(buf, "unable to control your hunger, you eat a %s.", (theItem->kind == FRUIT ? "mango" : "ration of food"));
-                messageWithColor(buf, &itemMessageColor, REQUIRE_ACKNOWLEDGMENT);
-                confirmMessages();
-                eat(theItem, false);
-                playerTurnEnded();
-                break;
-            }
-        }
-    }
-
-    if (player.status[STATUS_NUTRITION] == 1) { // Didn't manage to eat any food above.
-        player.status[STATUS_NUTRITION] = 0;    // So the status bar changes in time for the message:
+    } else if (player.status[STATUS_NUTRITION] == 0) {
         message("you are starving to death!", REQUIRE_ACKNOWLEDGMENT);
+    }
+}
+
+// This should only be called when the player is starving or very close to it.
+static void forceEatFood(void) {
+    brogueAssert(player.status[STATUS_NUTRITION] <= 1);
+    char buf[DCOLS*3];
+    // Force the player to eat something if he has it
+    for (item *theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+        if (theItem->category == FOOD) {
+            const char *foodName = theItem->kind == FRUIT ? "mango" : "ration of food";
+            sprintf(buf, "unable to control your hunger, you eat a %s.", foodName);
+            messageWithColor(buf, &itemMessageColor, REQUIRE_ACKNOWLEDGMENT);
+            confirmMessages();
+            eat(theItem, false);
+            playerTurnEnded();
+            break;
+        }
     }
 }
 
@@ -1973,9 +1973,9 @@ static void decrementPlayerStatus() {
         if (player.status[STATUS_NUTRITION] > 0) {
             if (!numberOfMatchingPackItems(AMULET, 0, 0, false) || rand_percent(20)) {
                 player.status[STATUS_NUTRITION]--;
+                printNutritionMessages();
             }
         }
-        checkNutrition();
     }
 
     if (player.status[STATUS_TELEPATHIC] > 0 && !--player.status[STATUS_TELEPATHIC]) {
@@ -2553,7 +2553,6 @@ void playerTurnEnded() {
             }
         }
 
-        //checkNutrition(); // Now handled within decrementPlayerStatus().
         if (!rogue.playbackFastForward) {
             shuffleTerrainColors(100, false);
         }
@@ -2618,6 +2617,10 @@ void playerTurnEnded() {
     if (rogue.flareCount > 0) {
         animateFlares(rogue.flares, rogue.flareCount);
         rogue.flareCount = 0;
+    }
+    
+    if (player.status[STATUS_NUTRITION] <= 1) {
+        forceEatFood();
     }
 }
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -736,6 +736,9 @@ void discoverCell(const short x, const short y) {
         if (!cellHasTerrainFlag((pos){ x, y }, T_PATHING_BLOCKER)) {
             rogue.xpxpThisTurn++;
         }
+        // Memory is otherwise only stored when a cell stops being visible, a
+        // transition a cell discovered unseen never makes.
+        storeMemories(x, y);
     }
 }
 

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -287,6 +287,7 @@ static void dialogCreateMonsterChooseMutation(creature *theMonster) {
             && !(theMonster->info.abilityFlags & mutationCatalog[i].forbiddenAbilityFlags)) {
             strncpy(buttonText, mutationCatalog[i].title, COLS);
             initializeCreateItemButton(&(buttons[j]), buttonText);
+            buttons[j].command = i; // Store the mutation index (as opposed to the button index)
             j++;
         }
     }
@@ -297,7 +298,7 @@ static void dialogCreateMonsterChooseMutation(creature *theMonster) {
     selectedMutation = dialogSelectEntryFromList(buttons, j+1, "Choose a mutation:");
 
     if (selectedMutation >= 0 && selectedMutation != noMutation) {
-        mutateMonster(theMonster, selectedMutation);
+        mutateMonster(theMonster, buttons[selectedMutation].command); // Retrieve the mutation index from the button
     }
 }
 

--- a/src/brogue/Wizard.c
+++ b/src/brogue/Wizard.c
@@ -296,7 +296,7 @@ static void dialogCreateMonsterChooseMutation(creature *theMonster) {
 
     selectedMutation = dialogSelectEntryFromList(buttons, j+1, "Choose a mutation:");
 
-    if (selectedMutation != noMutation) {
+    if (selectedMutation >= 0 && selectedMutation != noMutation) {
         mutateMonster(theMonster, selectedMutation);
     }
 }
@@ -456,10 +456,10 @@ static void dialogCreateItem() {
 
     selectedCategory = dialogSelectEntryFromList(buttons, i, "Create item:");
 
-    if (tableForItemCategory(Fl(selectedCategory))) {
-        selectedKind = dialogCreateItemChooseKind(Fl(selectedCategory));
-    } else if (selectedCategory == -1) {
+    if (selectedCategory == -1) {
         return;
+    } else if (tableForItemCategory(Fl(selectedCategory))) {
+        selectedKind = dialogCreateItemChooseKind(Fl(selectedCategory));
     } else {
         selectedKind = 0;
     }


### PR DESCRIPTION
Fixes the "a chilly void" case from #200 for cells that are discovered without ever being visible.

**Correction to the original description of this PR:** I first wrote that telepathy and clairvoyance were affected. That was wrong. `updateFieldOfViewDisplay()` already calls `storeMemories` when a cell ceases to be clairvoyantly or telepathically visible, so both systems work correctly on master. See the discussion below.

### The remaining case

`rememberedTerrain` starts as `NOTHING` (`Architect.c:2770`), and `NOTHING` renders and describes as `"a chilly void"` (`Globals.c:321`). The only routine that normally writes it is `storeMemories` (`Movement.c:2233`), which runs on the transitions where a cell stops being visible.

A cell that becomes `DISCOVERED` while never having been visible in any sense reaches none of those transitions, so it keeps `NOTHING`.

Three call sites do that:

| site | situation |
|---|---|
| `Movement.c:1237` | walking into an obstruction you cannot see; discovered on the bump |
| `RogueMain.c:881` | the 3x3 around the up-stairs when `connectingStairsDiscovered` is set on arrival |
| `Items.c:3397` | the alarm trap; the following line branches on `!playerCanSee(x, y)` |

### The change

One `storeMemories(x, y)` call inside the `!DISCOVERED` guard in `discoverCell()`, so a cell gets its memory written the moment it is discovered.

This adds to rather than replaces the existing calls. Those fire when a cell leaves view and capture the terrain as it stands at that moment, which is what keeps memory current for a cell that changed while you were watching it. For a normally seen cell this change means one extra write at discovery.

### Not verified in a live game

I found this by reading the code, not by playing. The mechanism above is traceable statically, but I have not sat down and bumped into a wall in the dark to confirm the message. Worth someone doing before this lands.
