### PR TITLE
Monster stair approach

### DIFF
--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3515,7 +3515,11 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
         }
 
         pmap[*x][*y].flags &= ~HAS_MONSTER;
-        if (theMap) {
+        // Only simulate monster movement if its cell is reachable from the stairs.
+	// Otherwise, if the monster is standing on a blocker like a trap, its cell
+	// has the default value 30000, which blows up turnCount and walks the monster
+	// all the way to the stairs
+        if (theMap && theMap[monst->loc.x][monst->loc.y] < 30000) {
             // STATUS_ENTERS_LEVEL_IN accounts for monster speed; convert back to map distance and subtract from distance to stairs
             turnCount = (theMap[monst->loc.x][monst->loc.y] - (monst->status[STATUS_ENTERS_LEVEL_IN] * 100 / monst->movementSpeed));
             for (i=0; i < turnCount; i++) {

--- a/src/brogue/Architect.c
+++ b/src/brogue/Architect.c
@@ -3499,7 +3499,7 @@ boolean spawnDungeonFeature(short x, short y, dungeonFeature *feat, boolean refr
 }
 
 void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
-    short i, *x, *y, turnCount;
+    short *x, *y;
     boolean foundLeader = false;
     short **theMap;
     enum directions dir;
@@ -3515,20 +3515,15 @@ void restoreMonster(creature *monst, short **mapToStairs, short **mapToPit) {
         }
 
         pmap[*x][*y].flags &= ~HAS_MONSTER;
-        // Only simulate monster movement if its cell is reachable from the stairs.
-	// Otherwise, if the monster is standing on a blocker like a trap, its cell
-	// has the default value 30000, which blows up turnCount and walks the monster
-	// all the way to the stairs
-        if (theMap && theMap[monst->loc.x][monst->loc.y] < 30000) {
-            // STATUS_ENTERS_LEVEL_IN accounts for monster speed; convert back to map distance and subtract from distance to stairs
-            turnCount = (theMap[monst->loc.x][monst->loc.y] - (monst->status[STATUS_ENTERS_LEVEL_IN] * 100 / monst->movementSpeed));
-            for (i=0; i < turnCount; i++) {
-                if ((dir = nextStep(theMap, monst->loc, NULL, true)) != NO_DIRECTION) {
-                    monst->loc.x += nbDirs[dir][0];
-                    monst->loc.y += nbDirs[dir][1];
-                } else {
-                    break;
-                }
+        if (theMap) {
+            // STATUS_ENTERS_LEVEL_IN is a turn count factoring in monster speed.
+            // Convert it back into the tile distance the monster should still be from its destination
+            // then walk it towards the destination until it's closed the distance.
+            const short remainingDistance = monst->status[STATUS_ENTERS_LEVEL_IN] * 100 / monst->movementSpeed;
+            while (theMap[monst->loc.x][monst->loc.y] > remainingDistance
+                   && (dir = nextStep(theMap, monst->loc, NULL, true)) != NO_DIRECTION) {
+                monst->loc.x += nbDirs[dir][0];
+                monst->loc.y += nbDirs[dir][1];
             }
         }
         monst->bookkeepingFlags |= MB_PREPLACED;

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -889,19 +889,37 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     }
 
     if (levels[rogue.depthLevel - 1].visited) {
+        // Build both a normal and a "flying" distance map to each destination.
+        // The flying map treats blockers like traps and fires as passable
+        // so a monster on such a tile is simulated based on its real distance to the target.
+        // Without this, the distance becomes the unreachable value 30,000,
+        // which causes the monster to skip directly to the stairs.
+        short **mapToStairsFlying = allocGrid();
+        short **mapToPitFlying = allocGrid();
         mapToStairs = allocGrid();
         mapToPit = allocGrid();
-        fillGrid(mapToStairs, 0);
-        fillGrid(mapToPit, 0);
-        calculateDistances(mapToStairs, player.loc.x, player.loc.y, T_PATHING_BLOCKER, NULL, true, true);
-        calculateDistances(mapToPit, levels[rogue.depthLevel-1].playerExitedVia.x,
-                           levels[rogue.depthLevel-1].playerExitedVia.y, T_PATHING_BLOCKER, NULL, true, true);
+        for (flying = 0; flying <= 1; flying++) {
+            short **stairsMap = flying ? mapToStairsFlying : mapToStairs;
+            short **pitMap = flying ? mapToPitFlying : mapToPit;
+            const unsigned long blockingFlags = flying ? T_OBSTRUCTS_PASSABILITY : T_PATHING_BLOCKER;
+            fillGrid(stairsMap, 0);
+            fillGrid(pitMap, 0);
+            calculateDistances(stairsMap, player.loc.x, player.loc.y, blockingFlags, NULL, true, true);
+            calculateDistances(pitMap, levels[rogue.depthLevel-1].playerExitedVia.x,
+                               levels[rogue.depthLevel-1].playerExitedVia.y, blockingFlags, NULL, true, true);
+        }
         for (creatureIterator it = iterateCreatures(monsters); hasNextCreature(it);) {
             creature *monst = nextCreature(&it);
-            restoreMonster(monst, mapToStairs, mapToPit);
+            const boolean usesFlyingMap = monst->status[STATUS_LEVITATING]
+                                          || cellHasTerrainFlag(monst->loc, T_PATHING_BLOCKER);
+            restoreMonster(monst,
+                           usesFlyingMap ? mapToStairsFlying : mapToStairs,
+                           usesFlyingMap ? mapToPitFlying : mapToPit);
         }
         freeGrid(mapToStairs);
         freeGrid(mapToPit);
+        freeGrid(mapToStairsFlying);
+        freeGrid(mapToPitFlying);
     }
 
     updateMapToShore();


### PR DESCRIPTION
Fixes #784

Reports of 'teleporting' monsters, which seemingly jump to the stairs when the player ascends/descends consecutively (taking zero turns), are caused by monsters standing on unpathable tiles like traps or fire. The distance map is constructed with 30000 as a sentinel value for unreachable tiles, but because `restoreMonster` directly references that distance in order to calculate how many tiles to advance the monster, it moves the monster ~30000 steps, causing it to appear to reach the stairs instantly.

This PR adds a "flying" map that's passed to `restoreMonster`, modeled off of the block at RogueMain.c:590 where `STATUS_ENTERS_LEVEL_IN` is set. This makes it so that departure and arrival back on the level both use the same distance metric and the distance to the stairs never blows up to 30000. That on its own fixes the bug, but I also slightly simplified the loop in `restoreMonster` to more explicitly step the monster based on distance.

This change doesn't affect the snap-to-shore behavior, which is independent.

Reproduce/test by descending a staircase, spawning a zombie, aggroing it, igniting it with an incendiary dart, and then ascending and immediately re-descending the staircase.