### PR TITLE
A fix for grinding that bypasses the food clock

### DIFF
--- a/changes/Anti-grind.md
+++ b/changes/Anti-grind.md
@@ -1,0 +1,1 @@
+Added measures to combat grinding via bypassing the food clock. Wear identification and item generation are significantly curtailed if you are starving or paralyzed.

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -137,17 +137,18 @@ void initializeMonster(creature *monst, boolean itemPossible) {
     } else {
         itemChance = 0;
     }
+    if ((rogue.monsterSpawnFuse <= 0) && ((player.status[STATUS_NUTRITION] <= 0) || (player.status[STATUS_PARALYZED]))) {
+        monst->carriedItem = NULL; // antigrind measures
+    } else if (ITEMS_ENABLED
+               && itemPossible
+               && (rogue.depthLevel <= gameConst->amuletLevel)
+               && monsterItemsHopper->nextItem
+               && rand_percent(itemChance)) {
 
-    if (ITEMS_ENABLED
-        && itemPossible
-        && (rogue.depthLevel <= gameConst->amuletLevel)
-        && monsterItemsHopper->nextItem
-        && rand_percent(itemChance)) {
-
-        monst->carriedItem = monsterItemsHopper->nextItem;
-        monsterItemsHopper->nextItem = monsterItemsHopper->nextItem->nextItem;
-        monst->carriedItem->nextItem = NULL;
-        monst->carriedItem->originDepth = rogue.depthLevel;
+               monst->carriedItem = monsterItemsHopper->nextItem;
+               monsterItemsHopper->nextItem = monsterItemsHopper->nextItem->nextItem;
+               monst->carriedItem->nextItem = NULL;
+               monst->carriedItem->originDepth = rogue.depthLevel;
     } else {
         monst->carriedItem = NULL;
     }

--- a/src/brogue/Monsters.c
+++ b/src/brogue/Monsters.c
@@ -137,8 +137,11 @@ void initializeMonster(creature *monst, boolean itemPossible) {
     } else {
         itemChance = 0;
     }
-    if ((rogue.monsterSpawnFuse <= 0) && ((player.status[STATUS_NUTRITION] <= 0) || (player.status[STATUS_PARALYZED]))) {
-        monst->carriedItem = NULL; // antigrind measures
+    if ((rogue.monsterSpawnFuse <= 0) // try to affect only periodic spawns
+        && ((rogue.starvedTurnsLeeway <= 0) // i.e. player is also starving
+            || (player.status[STATUS_PARALYZED] && rogue.paralyzedTurnsLeeway <= 0))) {
+                
+                monst->carriedItem = NULL; // antigrind measures
     } else if (ITEMS_ENABLED
                && itemPossible
                && (rogue.depthLevel <= gameConst->amuletLevel)

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -2405,6 +2405,9 @@ typedef struct gameConstants {
     const int armorDelayToAutoID;                   // number of turns until unknown armor is IDed
     const int ringDelayToAutoID;                    // number of turns until unknown ring is IDed
 
+    const int starvationLeeway;                     // turns a player may starve before antigrind measures kick in, per starvation event
+    const int paralysisLeeway;                      // turns a player may be paralyzed before antigrind measures kick in, per game
+
     const int numberAutogenerators;                 // size of autoGeneratorCatalog table
     const int numberBoltKinds;                      // size of boltKinds table
     const int numberBlueprints;                     // size of blueprintCatalog table
@@ -2469,6 +2472,8 @@ typedef struct playerCharacter {
     unsigned long goldGenerated;        // how much gold has been generated on the levels, not counting gold held by monsters
     short strength;
     unsigned short monsterSpawnFuse;    // how much longer till a random monster spawns
+    short starvedTurnsLeeway;           // how many turns more a player may starve before antigrind measures kick in, per starve event
+    short paralyzedTurnsLeeway;         // how many turns more a player may be paralyzed before antigrind measures kick in, per game
 
     item *weapon;
     item *armor;

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -405,6 +405,8 @@ void initializeRogue(uint64_t seed) {
     rogue.mapToShore = NULL;
     rogue.cursorLoc = INVALID_POS;
     rogue.xpxpThisTurn = 0;
+    rogue.starvedTurnsLeeway = gameConst->starvationLeeway;
+    rogue.paralyzedTurnsLeeway = gameConst->paralysisLeeway;
 
     rogue.yendorWarden = NULL;
 

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -837,6 +837,7 @@ static void forceEatFood(void) {
             messageWithColor(buf, &itemMessageColor, REQUIRE_ACKNOWLEDGMENT);
             confirmMessages();
             eat(theItem, false);
+            rogue.starvedTurnsLeeway = gameConst->starvationLeeway; // ensures a positive leeway when not starving
             playerTurnEnded();
             break;
         }
@@ -1775,9 +1776,11 @@ static void processIncrementalAutoID() {
     short i;
 
     // A safeguard placed against grindy foodclock bypasses, with a paralysis loophole closed
-    if ((player.status[STATUS_NUTRITION] <= 0) || (player.status[STATUS_PARALYZED])) {
-        return;
-    }
+    if ((rogue.starvedTurnsLeeway <= 0) // i.e. player is also starving
+        || (player.status[STATUS_PARALYZED] && rogue.paralyzedTurnsLeeway <= 0)) {
+            
+            return;
+	}
 
     for (i=0; i<3; i++) {
         theItem = autoIdentifyItems[i];
@@ -1983,6 +1986,11 @@ static void decrementPlayerStatus() {
         }
     }
 
+    // Handle starvation grinding
+    if (player.status[STATUS_NUTRITION] <= 0 && rogue.starvedTurnsLeeway > 0) {
+        rogue.starvedTurnsLeeway--;
+    }
+
     if (player.status[STATUS_TELEPATHIC] > 0 && !--player.status[STATUS_TELEPATHIC]) {
         updateVision(true);
         message("your preternatural mental sensitivity fades.", 0);
@@ -2013,8 +2021,13 @@ static void decrementPlayerStatus() {
         message("you feel less nauseous.", 0);
     }
 
-    if (player.status[STATUS_PARALYZED] > 0 && !--player.status[STATUS_PARALYZED]) {
-        message("you can move again.", 0);
+    if (player.status[STATUS_PARALYZED] > 0) {
+        if (rogue.paralyzedTurnsLeeway > 0) { // handle paralysis grinding
+            rogue.paralyzedTurnsLeeway--;
+        }
+        if (!--player.status[STATUS_PARALYZED]) {
+            message("you can move again.", 0);
+        }
     }
 
     if (player.status[STATUS_HASTED] > 0 && !--player.status[STATUS_HASTED]) {

--- a/src/brogue/Time.c
+++ b/src/brogue/Time.c
@@ -1774,6 +1774,11 @@ static void processIncrementalAutoID() {
     char buf[DCOLS*3], theItemName[DCOLS*3];
     short i;
 
+    // A safeguard placed against grindy foodclock bypasses, with a paralysis loophole closed
+    if ((player.status[STATUS_NUTRITION] <= 0) || (player.status[STATUS_PARALYZED])) {
+        return;
+    }
+
     for (i=0; i<3; i++) {
         theItem = autoIdentifyItems[i];
         if (theItem

--- a/src/variants/GlobalsBrogue.c
+++ b/src/variants/GlobalsBrogue.c
@@ -1041,6 +1041,9 @@ const gameConstants brogueGameConst = {
     .armorDelayToAutoID = 1000,
     .ringDelayToAutoID = 1500,
 
+    .starvationLeeway = 120, // less than monsterSpawnFuse
+    .paralysisLeeway = 400, // 80 base + 320 for difficulty
+    
     .fallDamageMin = 8,
     .fallDamageMax = 10,
 

--- a/src/variants/GlobalsBulletBrogue.c
+++ b/src/variants/GlobalsBulletBrogue.c
@@ -1055,6 +1055,9 @@ const gameConstants bulletBrogueGameConst = {
     .armorDelayToAutoID = 120,
     .ringDelayToAutoID = 120,
 
+    .starvationLeeway = 120, // less than monsterSpawnFuse
+    .paralysisLeeway = 120, // 80 base + 40 for difficulty
+
     .fallDamageMin = 8,
     .fallDamageMax = 10,
 

--- a/src/variants/GlobalsRapidBrogue.c
+++ b/src/variants/GlobalsRapidBrogue.c
@@ -1045,6 +1045,9 @@ const gameConstants rapidBrogueGameConst = {
     .armorDelayToAutoID = 250,
     .ringDelayToAutoID = 250,
 
+    .starvationLeeway = 120, // less than monsterSpawnFuse
+    .paralysisLeeway = 160, // 80 base + 80 for difficulty
+
     .fallDamageMin = 8,
     .fallDamageMax = 10,
 


### PR DESCRIPTION
This should fix issue #852.

Currently players can cheat the food clock and grind out wear-identificatioon or item generation (items from the item hopper carried by eligible periodic spawns).

See the attached screenshot:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ef0f0857-e83a-493e-8cb1-215977c42c51" />

Source: [discord](https://discord.com/channels/205277826788622337/205347357745872896/1341707251546718279)

The two means by which this happens is by starvation and self-paralysis. (The self-paralysis method is currently unnoticed by the player base, so the fix here is prophylactic).

The first commit is the simple fix. It's rather blunt and will impact players who are starving (or paralyzed) but not grinding. If the simple fix is adopted, it might be worthwhile changing some in-game messages. Let me know.

The second commit is an extension of the first granting the player a bit of leeway so as not to affect standard play too much. It should go relatively unnoticed by those playing in the standard way.

The starvation leeway is set to be less than the minimum of the monsterSpawnFuse timer and resets after the player eats food.

The paralysis leeway is set for an entire game to be a flat allowance of turns that the player may be paralyzed before antigrind measures kick in. I've found that a simple turn allowance is the least gameable sort of leeway.

I've ignored weapon identification (20 kills) as players are sticking their neck out, not just waiting.

The issue of waiting for wear-identification or item generation while holding the Amulet with its reduced nutrition consumption has not been addressed here.

I was concerned that the code would affect item generation for pre-placed monsters from an edge case where the monster spawn fuse was 0 or 1 as I descended a staircase. I don't exactly understand the code for extra turns from descending staircases, and how the monsterSpawnFuse is affected by it. I simply chose to test in wizard mode and the code passed all tests. I'm concerned that a future fix to issue #874 might introduce the edge case.