### PR TITLE
Fix unlimited cloning of allies via weapon of plenty and discord

### DIFF
--- a/changes/PlentyDiscordantAllyCloning.md
+++ b/changes/PlentyDiscordantAllyCloning.md
@@ -1,0 +1,1 @@
+Fixed an exploit which allowed players to clone allies using a weapon of plenty against discordant allies.

--- a/src/brogue/Combat.c
+++ b/src/brogue/Combat.c
@@ -770,6 +770,7 @@ void magicWeaponHit(creature *defender, item *theItem, boolean backstabbed) {
             case W_PLENTY:
                 newMonst = cloneMonster(defender, true, true);
                 if (newMonst) {
+                    unAlly(newMonst); // Cloned allies shall always be hostile, no army generation allowed here
                     flashMonster(newMonst, effectColors[enchantType], 100);
                     if (canSeeMonster(newMonst)) {
                         autoID = true;


### PR DESCRIPTION
Currently, players are able to clone allies using a weapon of plenty and a discord source. Auxiliary items (entrancement, wisdom, etc.) and the right terrain help.

See the attached image:

<img width="969" height="409" alt="CloningDiscordantAllyW_Plenty" src="https://github.com/user-attachments/assets/88bc4e72-eb2d-4c46-8d8b-5efe1b9072fe" />

In the above image, I'm wielding a spear of plenty. A staff of entrancement can be used to prevent my discordant allies from fighting each other. One can also walk an ally off the ledge to resume cloning.

The item information of the weapon of plenty reads "Glowing runes of plenty adorn the [weapon]. 15% of the time it hits an enemy, the enemy will be cloned." Nothing is said about hitting a discordant ally.

My opinion is that allies (apart from jellies) should not be infinitely cloned. Players have effectively created a renewable wand of plenty.

This fix makes it so that the clones are generated hostile, all while the parent remains allied.

This (exploit? design feature?) has only recently been discovered. This PR is just defensive game balance in case the problem gets out of hand.